### PR TITLE
feat(#2): データベーススキーマ・基盤構築

### DIFF
--- a/drizzle/0000_soft_killer_shrike.sql
+++ b/drizzle/0000_soft_killer_shrike.sql
@@ -1,0 +1,32 @@
+CREATE TABLE `boards` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`template_id` text NOT NULL,
+	`config` text DEFAULT '{}' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `media_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`board_id` text NOT NULL,
+	`type` text NOT NULL,
+	`file_path` text NOT NULL,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`duration` integer DEFAULT 5 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`board_id`) REFERENCES `boards`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`board_id` text NOT NULL,
+	`content` text NOT NULL,
+	`priority` integer DEFAULT 0 NOT NULL,
+	`expires_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`board_id`) REFERENCES `boards`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,241 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "007848e7-ce35-4bd8-90ff-200fb7f9c31f",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "boards": {
+      "name": "boards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1775628837963,
+      "tag": "0000_soft_killer_shrike",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,2 +1,18 @@
-// Database connection
-// Will be implemented in Issue #2
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "./schema";
+import path from "path";
+import fs from "fs";
+
+const DB_PATH = path.resolve(process.cwd(), "data", "e-web-board.db");
+
+// Ensure data directory exists
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+
+const sqlite = new Database(DB_PATH);
+
+// Enable WAL mode for better concurrent read performance
+sqlite.pragma("journal_mode = WAL");
+sqlite.pragma("foreign_keys = ON");
+
+export const db = drizzle(sqlite, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,2 +1,59 @@
-// Drizzle ORM schema definitions
-// Will be implemented in Issue #2
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { randomUUID } from "crypto";
+
+export const boards = sqliteTable("boards", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  name: text("name").notNull(),
+  templateId: text("template_id").notNull(), // "simple" | "photo-clock" | "retro" | "message"
+  config: text("config", { mode: "json" }).notNull().default("{}"),
+  isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`)
+    .$onUpdate(() => new Date().toISOString()),
+});
+
+export const mediaItems = sqliteTable("media_items", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  boardId: text("board_id")
+    .notNull()
+    .references(() => boards.id, { onDelete: "cascade" }),
+  type: text("type").notNull(), // "image" | "video"
+  filePath: text("file_path").notNull(),
+  displayOrder: integer("display_order").notNull().default(0),
+  duration: integer("duration").notNull().default(5), // seconds
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`)
+    .$onUpdate(() => new Date().toISOString()),
+});
+
+export const messages = sqliteTable("messages", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  boardId: text("board_id")
+    .notNull()
+    .references(() => boards.id, { onDelete: "cascade" }),
+  content: text("content").notNull(),
+  priority: integer("priority").notNull().default(0),
+  expiresAt: text("expires_at"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`)
+    .$onUpdate(() => new Date().toISOString()),
+});

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,2 +1,57 @@
-// Zod validation schemas
-// Will be implemented in Issue #2
+import { z } from "zod";
+
+// --- Board ---
+
+export const templateIdSchema = z.enum([
+  "simple",
+  "photo-clock",
+  "retro",
+  "message",
+]);
+
+export const createBoardSchema = z.object({
+  name: z.string().min(1).max(100),
+  templateId: templateIdSchema,
+  config: z.record(z.unknown()).optional().default({}),
+});
+
+export const updateBoardSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  templateId: templateIdSchema.optional(),
+  config: z.record(z.unknown()).optional(),
+  isActive: z.boolean().optional(),
+});
+
+// --- MediaItem ---
+
+export const mediaTypeSchema = z.enum(["image", "video"]);
+
+export const createMediaItemSchema = z.object({
+  boardId: z.string().uuid(),
+  type: mediaTypeSchema,
+  filePath: z.string().min(1),
+  displayOrder: z.number().int().min(0).optional().default(0),
+  duration: z.number().int().min(1).optional().default(5),
+});
+
+export const updateMediaOrderSchema = z.array(
+  z.object({
+    id: z.string().uuid(),
+    displayOrder: z.number().int().min(0),
+  })
+);
+
+// --- Message ---
+
+export const createMessageSchema = z.object({
+  boardId: z.string().uuid(),
+  content: z.string().min(1).max(1000),
+  priority: z.number().int().min(0).optional().default(0),
+  expiresAt: z.string().datetime().nullable().optional(),
+});
+
+export const updateMessageSchema = z.object({
+  content: z.string().min(1).max(1000).optional(),
+  priority: z.number().int().min(0).optional(),
+  expiresAt: z.string().datetime().nullable().optional(),
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,29 @@
-// Common type definitions
-// Will be implemented in Issue #2
+import type { InferSelectModel, InferInsertModel } from "drizzle-orm";
+import type { boards, mediaItems, messages } from "@/db/schema";
+
+// Select types (read from DB)
+export type Board = InferSelectModel<typeof boards>;
+export type MediaItem = InferSelectModel<typeof mediaItems>;
+export type Message = InferSelectModel<typeof messages>;
+
+// Insert types (write to DB)
+export type NewBoard = InferInsertModel<typeof boards>;
+export type NewMediaItem = InferInsertModel<typeof mediaItems>;
+export type NewMessage = InferInsertModel<typeof messages>;
+
+// Template types
+export type TemplateId = "simple" | "photo-clock" | "retro" | "message";
+
+export interface BoardTemplate {
+  id: TemplateId;
+  name: string;
+  description: string;
+  defaultConfig: Record<string, unknown>;
+  component: React.ComponentType<BoardTemplateProps>;
+}
+
+export interface BoardTemplateProps {
+  board: Board;
+  mediaItems: MediaItem[];
+  messages: Message[];
+}


### PR DESCRIPTION
## 概要
Closes #2

Drizzle ORM で DESIGN.md に定義されたデータモデル (Board / MediaItem / Message) を実装し、マイグレーションの仕組みを整えました。

## 変更内容
- `src/db/schema.ts`: Board / MediaItem / Message テーブル定義 (Drizzle ORM)
- `src/db/index.ts`: DB 接続処理 (better-sqlite3, WAL mode, foreign keys)
- `src/types/index.ts`: Drizzle スキーマから推論した型の export
- `src/lib/validators.ts`: Zod スキーマ (Board / MediaItem / Message の作成・更新用)
- `drizzle/0000_soft_killer_shrike.sql`: 初回マイグレーション SQL
- `drizzle.config.ts`: 既に Issue #1 で作成済み

## 動作確認
- `pnpm db:generate` でマイグレーションファイルが生成される ✅
- `pnpm db:migrate` でテーブルが作成される ✅
- SQLite DB ファイル `data/e-web-board.db` に 3 テーブル (boards, media_items, messages) が作成されていることを確認 ✅