### PR TITLE
feat(#4): フォトクロック掲示板テンプレート

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -74,6 +74,42 @@ sampleMessages.forEach((content, i) => {
 });
 
 console.log(`✅ Seed complete — board ID: ${boardId}`);
-console.log(`   Open http://localhost:3000/board/${boardId}`);
+console.log(`   Open http://localhost:3000/${boardId}`);
+
+// --- Photo-Clock Board ---
+const photoClockId = randomUUID();
+
+db.insert(schema.boards)
+  .values({
+    id: photoClockId,
+    name: "フォトクロック サンプル",
+    templateId: "photo-clock",
+    config: JSON.stringify({
+      slideInterval: 8,
+      clockPosition: "bottom-right",
+      clockFontSize: "text-5xl",
+      clockColor: "#ffffff",
+      clockBgOpacity: 0.5,
+      is24Hour: true,
+    }),
+    isActive: true,
+  })
+  .run();
+
+sampleImages.forEach((url, i) => {
+  db.insert(schema.mediaItems)
+    .values({
+      id: randomUUID(),
+      boardId: photoClockId,
+      type: "image",
+      filePath: url,
+      displayOrder: i,
+      duration: 8,
+    })
+    .run();
+});
+
+console.log(`✅ Photo-Clock board ID: ${photoClockId}`);
+console.log(`   Open http://localhost:3000/${photoClockId}`);
 
 sqlite.close();

--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+interface DateTimeClockProps {
+  /** 24-hour format (default: true) */
+  is24Hour?: boolean;
+  /** Font size class or CSS value */
+  fontSize?: string;
+  /** Text color */
+  color?: string;
+  /** Background opacity 0-1 */
+  bgOpacity?: number;
+}
+
+export function DateTimeClock({
+  is24Hour = true,
+  fontSize = "text-4xl",
+  color = "#ffffff",
+  bgOpacity = 0.5,
+}: DateTimeClockProps) {
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setNow(new Date());
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!now) return null;
+
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const weekday = WEEKDAYS[now.getDay()];
+
+  let hours = now.getHours();
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const seconds = String(now.getSeconds()).padStart(2, "0");
+
+  let period = "";
+  if (!is24Hour) {
+    period = hours >= 12 ? " PM" : " AM";
+    hours = hours % 12 || 12;
+  }
+  const hoursStr = String(hours).padStart(2, "0");
+
+  return (
+    <div
+      className="inline-flex flex-col items-center rounded-lg px-6 py-3"
+      style={{
+        backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`,
+        color,
+      }}
+    >
+      <span className={`${fontSize} font-mono font-bold tabular-nums tracking-wider`}>
+        {hoursStr}:{minutes}:{seconds}{period}
+      </span>
+      <span className="mt-1 text-lg font-medium opacity-90">
+        {year}/{month}/{day} ({weekday})
+      </span>
+    </div>
+  );
+}

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { MediaSlider } from "@/components/board/MediaSlider";
+import { DateTimeClock } from "@/components/board/DateTimeClock";
+import type { BoardTemplateProps } from "@/types";
+
+/** Default config for the Photo-Clock Board template */
+export const photoClockDefaultConfig = {
+  slideInterval: 8,
+  clockPosition: "bottom-right" as ClockPosition,
+  clockFontSize: "text-5xl",
+  clockColor: "#ffffff",
+  clockBgOpacity: 0.5,
+  is24Hour: true,
+};
+
+type ClockPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+type PhotoClockConfig = typeof photoClockDefaultConfig;
+
+function parseConfig(raw: unknown): PhotoClockConfig {
+  const cfg = (raw && typeof raw === "object" ? raw : {}) as Partial<PhotoClockConfig>;
+  return { ...photoClockDefaultConfig, ...cfg };
+}
+
+const positionClasses: Record<ClockPosition, string> = {
+  "top-left": "top-6 left-6",
+  "top-right": "top-6 right-6",
+  "bottom-left": "bottom-6 left-6",
+  "bottom-right": "bottom-6 right-6",
+};
+
+export default function PhotoClockBoard({
+  board,
+  mediaItems,
+}: BoardTemplateProps) {
+  const config = parseConfig(board.config);
+
+  const sorted = [...mediaItems].sort(
+    (a, b) => a.displayOrder - b.displayOrder
+  );
+
+  return (
+    <div className="relative h-screen w-screen overflow-hidden bg-black">
+      {/* Full-screen slideshow */}
+      <MediaSlider mediaItems={sorted} interval={config.slideInterval} />
+
+      {/* Clock overlay */}
+      <div
+        className={`absolute z-10 ${positionClasses[config.clockPosition] ?? positionClasses["bottom-right"]}`}
+      >
+        <DateTimeClock
+          is24Hour={config.is24Hour}
+          fontSize={config.clockFontSize}
+          color={config.clockColor}
+          bgOpacity={config.clockBgOpacity}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -2,6 +2,9 @@ import type { TemplateId, BoardTemplate } from "@/types";
 import SimpleBoard, {
   simpleBoardDefaultConfig,
 } from "@/components/board/templates/SimpleBoard";
+import PhotoClockBoard, {
+  photoClockDefaultConfig,
+} from "@/components/board/templates/PhotoClockBoard";
 
 /** Registry of all available board templates */
 export const templates: Record<TemplateId, BoardTemplate> = {
@@ -17,8 +20,8 @@ export const templates: Record<TemplateId, BoardTemplate> = {
     id: "photo-clock",
     name: "フォトクロック",
     description: "写真スライドショーに日時オーバーレイを重ねた表示",
-    defaultConfig: {},
-    component: SimpleBoard, // placeholder — will be replaced in Issue #4
+    defaultConfig: photoClockDefaultConfig,
+    component: PhotoClockBoard,
   },
   retro: {
     id: "retro",


### PR DESCRIPTION
## 概要
Closes #4

全画面スライドショーに日時オーバーレイを重ねる「フォトクロック掲示板」テンプレートを実装しました。

## 変更内容

### コンポーネント
- `src/components/board/DateTimeClock.tsx`: リアルタイム日時表示 (毎秒更新、12/24時間制対応)
- `src/components/board/templates/PhotoClockBoard.tsx`: フォトクロックテンプレート本体

### テンプレート設定 (config)
| key | default | description |
|-----|---------|-------------|
| slideInterval | 8 | スライド切り替え間隔 (秒) |
| clockPosition | bottom-right | 時計の表示位置 (top-left/top-right/bottom-left/bottom-right) |
| clockFontSize | text-5xl | 時計のフォントサイズ |
| clockColor | #ffffff | 時計の文字色 |
| clockBgOpacity | 0.5 | 時計背景の透過度 |
| is24Hour | true | 24時間制/12時間制 |

### その他
- テンプレートレジストリに PhotoClockBoard を登録
- seed スクリプトにフォトクロック用サンプルボードを追加

## 動作確認
- `pnpm db:seed` → サンプルデータ挿入 ✅
- `pnpm dev` → ボードページで全画面スライドショー + 時計オーバーレイ表示 ✅
- 日時表示: `15:43:19` / `2026/04/08 (水)` 形式で正常表示 ✅
- TypeScript エラーなし ✅