### PR TITLE
feat(#5): レトロ掲示板テンプレートの実装

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -112,4 +112,46 @@ sampleImages.forEach((url, i) => {
 console.log(`✅ Photo-Clock board ID: ${photoClockId}`);
 console.log(`   Open http://localhost:3000/${photoClockId}`);
 
+// --- Retro Board ---
+const retroBoardId = randomUUID();
+
+db.insert(schema.boards)
+  .values({
+    id: retroBoardId,
+    name: "レトロ掲示板 サンプル",
+    templateId: "retro",
+    config: JSON.stringify({
+      displayColor: "green",
+      rows: 5,
+      flipSpeed: 0.08,
+      switchInterval: 5,
+    }),
+    isActive: true,
+  })
+  .run();
+
+const retroMessages = [
+  "1番線  東京行き  10:15 発  定刻",
+  "2番線  大阪行き  10:32 発  定刻",
+  "3番線  名古屋行き  10:45 発  約5分遅れ",
+  "4番線  博多行き  11:00 発  定刻",
+  "5番線  仙台行き  11:15 発  定刻",
+  "6番線  新潟行き  11:30 発  定刻",
+  "7番線  広島行き  11:45 発  運休",
+];
+
+retroMessages.forEach((content, i) => {
+  db.insert(schema.messages)
+    .values({
+      id: randomUUID(),
+      boardId: retroBoardId,
+      content,
+      priority: retroMessages.length - i,
+    })
+    .run();
+});
+
+console.log(`✅ Retro board ID: ${retroBoardId}`);
+console.log(`   Open http://localhost:3000/${retroBoardId}`);
+
 sqlite.close();

--- a/src/components/board/templates/RetroBoard.tsx
+++ b/src/components/board/templates/RetroBoard.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { BoardTemplateProps } from "@/types";
+
+/** Default config for the Retro Board template */
+export const retroBoardDefaultConfig = {
+  displayColor: "green" as "green" | "orange" | "white",
+  rows: 5,
+  flipSpeed: 0.08,
+  switchInterval: 5,
+};
+
+type RetroBoardConfig = typeof retroBoardDefaultConfig;
+
+function parseConfig(raw: unknown): RetroBoardConfig {
+  const cfg = (raw && typeof raw === "object" ? raw : {}) as Partial<RetroBoardConfig>;
+  return { ...retroBoardDefaultConfig, ...cfg };
+}
+
+const COLOR_MAP: Record<string, { text: string; glow: string }> = {
+  green: { text: "#39ff14", glow: "0 0 8px #39ff14, 0 0 20px #39ff1466" },
+  orange: { text: "#ff8c00", glow: "0 0 8px #ff8c00, 0 0 20px #ff8c0066" },
+  white: { text: "#f0f0f0", glow: "0 0 8px #f0f0f0, 0 0 20px #f0f0f066" },
+};
+
+/** Flip-style single character animation */
+function FlipChar({
+  char,
+  delay,
+  color,
+  glow,
+  flipSpeed,
+}: {
+  char: string;
+  delay: number;
+  color: string;
+  glow: string;
+  flipSpeed: number;
+}) {
+  return (
+    <motion.span
+      initial={{ rotateX: -90, opacity: 0 }}
+      animate={{ rotateX: 0, opacity: 1 }}
+      transition={{
+        duration: flipSpeed,
+        delay,
+        ease: "easeOut",
+      }}
+      className="inline-block"
+      style={{
+        color,
+        textShadow: glow,
+        perspective: "400px",
+        transformStyle: "preserve-3d",
+      }}
+    >
+      {char === " " ? "\u00A0" : char}
+    </motion.span>
+  );
+}
+
+/** A single row that flips in character-by-character */
+function RetroRow({
+  text,
+  color,
+  glow,
+  flipSpeed,
+}: {
+  text: string;
+  color: string;
+  glow: string;
+  flipSpeed: number;
+}) {
+  return (
+    <div className="flex items-center border-b border-white/5 px-6 py-3">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={text}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="flex overflow-hidden font-mono text-2xl font-bold tracking-widest md:text-3xl lg:text-4xl"
+        >
+          {text.split("").map((char, i) => (
+            <FlipChar
+              key={`${text}-${i}`}
+              char={char}
+              delay={i * flipSpeed}
+              color={color}
+              glow={glow}
+              flipSpeed={flipSpeed}
+            />
+          ))}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default function RetroBoard({
+  board,
+  messages,
+}: BoardTemplateProps) {
+  const config = parseConfig(board.config);
+  const { text: color, glow } = COLOR_MAP[config.displayColor] ?? COLOR_MAP.green;
+
+  const sorted = [...messages].sort((a, b) => b.priority - a.priority);
+  const totalMessages = sorted.length;
+
+  const [offset, setOffset] = useState(0);
+
+  const advance = useCallback(() => {
+    if (totalMessages <= config.rows) return;
+    setOffset((prev) => (prev + config.rows) % totalMessages);
+  }, [totalMessages, config.rows]);
+
+  useEffect(() => {
+    if (totalMessages <= config.rows) return;
+    const timer = setInterval(advance, config.switchInterval * 1000);
+    return () => clearInterval(timer);
+  }, [totalMessages, config.rows, config.switchInterval, advance]);
+
+  // Build visible rows (circular)
+  const visibleRows: string[] = [];
+  for (let i = 0; i < config.rows; i++) {
+    if (totalMessages === 0) {
+      visibleRows.push("");
+    } else {
+      visibleRows.push(sorted[(offset + i) % totalMessages].content);
+    }
+  }
+
+  return (
+    <div className="flex h-screen w-screen flex-col bg-[#0a0a0a]">
+      {/* Header bar */}
+      <div
+        className="flex items-center justify-between border-b-2 px-6 py-3"
+        style={{ borderColor: color }}
+      >
+        <span
+          className="font-mono text-sm font-bold uppercase tracking-[0.3em]"
+          style={{ color, textShadow: glow }}
+        >
+          {board.name}
+        </span>
+        <span
+          className="font-mono text-sm tracking-wider opacity-70"
+          style={{ color }}
+        >
+          ● LIVE
+        </span>
+      </div>
+
+      {/* Message rows */}
+      <div className="flex flex-1 flex-col justify-center">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={offset}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            {visibleRows.map((text, i) => (
+              <RetroRow
+                key={`${offset}-${i}`}
+                text={text || "—"}
+                color={color}
+                glow={glow}
+                flipSpeed={config.flipSpeed}
+              />
+            ))}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Bottom decorative line */}
+      <div className="h-1" style={{ backgroundColor: color, opacity: 0.3 }} />
+    </div>
+  );
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -5,6 +5,9 @@ import SimpleBoard, {
 import PhotoClockBoard, {
   photoClockDefaultConfig,
 } from "@/components/board/templates/PhotoClockBoard";
+import RetroBoard, {
+  retroBoardDefaultConfig,
+} from "@/components/board/templates/RetroBoard";
 
 /** Registry of all available board templates */
 export const templates: Record<TemplateId, BoardTemplate> = {
@@ -28,8 +31,8 @@ export const templates: Record<TemplateId, BoardTemplate> = {
     name: "レトロ掲示板",
     description:
       "駅の案内板風ドットマトリクスデザインのクラシックな掲示板",
-    defaultConfig: {},
-    component: SimpleBoard, // placeholder — will be replaced in Issue #5
+    defaultConfig: retroBoardDefaultConfig,
+    component: RetroBoard,
   },
   message: {
     id: "message",


### PR DESCRIPTION
## 概要
駅の案内板風ドットマトリクスデザインの「レトロ掲示板」テンプレートを実装しました。

## 変更内容

### 新規ファイル
- **`src/components/board/templates/RetroBoard.tsx`** — レトロ掲示板テンプレート
  - 黒背景 + カラー選択可能なグロー効果テキスト（green / orange / white）
  - Framer Motion によるフリップアニメーション（1文字ずつ回転して表示）
  - 行ベースのメッセージ表示（駅の発車案内板スタイル）
  - メッセージが行数を超える場合は自動ページ切替
  - ヘッダーバーにボード名と LIVE インジケーター

### 変更ファイル
- **`src/lib/templates.ts`** — RetroBoard をインポートし、プレースホルダーを置換
- **`scripts/seed.ts`** — レトロ掲示板のサンプルデータ追加（駅案内板風メッセージ7件）

## 設定パラメータ
| パラメータ | デフォルト | 説明 |
|---|---|---|
| `displayColor` | `green` | テキスト色 (green / orange / white) |
| `rows` | `5` | 同時表示行数 |
| `flipSpeed` | `0.08` | 1文字あたりのフリップ遅延（秒） |
| `switchInterval` | `5` | ページ切替間隔（秒） |

Closes #5