### PR TITLE
feat(#7): 管理画面（ダッシュボード）の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ pnpm-debug.log*
 
 # vercel
 .vercel/
+tsconfig.tsbuildinfo

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(dashboard)/boards/[boardId]/page.tsx
+++ b/src/app/(dashboard)/boards/[boardId]/page.tsx
@@ -1,0 +1,10 @@
+import BoardEditClient from "@/components/dashboard/BoardEditClient";
+
+export default async function BoardEditPage({
+  params,
+}: {
+  params: Promise<{ boardId: string }>;
+}) {
+  const { boardId } = await params;
+  return <BoardEditClient boardId={boardId} />;
+}

--- a/src/app/(dashboard)/boards/new/page.tsx
+++ b/src/app/(dashboard)/boards/new/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { templates } from "@/lib/templates";
+import type { TemplateId } from "@/types";
+
+const templateList = Object.values(templates);
+
+export default function NewBoardPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [templateId, setTemplateId] = useState<TemplateId>("simple");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const res = await fetch("/api/boards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, templateId }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error ?? "作成に失敗しました");
+      setSubmitting(false);
+      return;
+    }
+
+    const board = await res.json();
+    router.push(`/boards/${board.id}`);
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/boards"
+          className={buttonVariants({ variant: "ghost", size: "sm" })}
+        >
+          <ArrowLeft data-icon="inline-start" />
+          ボード一覧に戻る
+        </Link>
+      </div>
+
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle>新規ボード作成</CardTitle>
+          <CardDescription>
+            テンプレートを選んでボードを作成します
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Board name */}
+            <div className="space-y-2">
+              <Label htmlFor="name">ボード名</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例: 1F ロビー掲示板"
+                required
+                maxLength={100}
+              />
+            </div>
+
+            {/* Template selection */}
+            <div className="space-y-3">
+              <Label>テンプレート</Label>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {templateList.map((t) => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => setTemplateId(t.id)}
+                    className={`rounded-lg border p-4 text-left transition-colors ${
+                      templateId === t.id
+                        ? "border-primary bg-primary/5 ring-1 ring-primary"
+                        : "border-border hover:bg-accent"
+                    }`}
+                  >
+                    <div className="font-medium">{t.name}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {t.description}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <div className="flex gap-3">
+              <Button type="submit" disabled={submitting || !name.trim()}>
+                {submitting ? "作成中..." : "作成"}
+              </Button>
+              <Link
+                href="/boards"
+                className={buttonVariants({ variant: "outline" })}
+              >
+                キャンセル
+              </Link>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/boards/page.tsx
+++ b/src/app/(dashboard)/boards/page.tsx
@@ -1,3 +1,92 @@
-export default function BoardsPage() {
-  return <div>Boards</div>;
+import Link from "next/link";
+import { db } from "@/db";
+import { boards } from "@/db/schema";
+import { desc } from "drizzle-orm";
+import { Plus, ExternalLink } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { templates } from "@/lib/templates";
+
+export const dynamic = "force-dynamic";
+
+export default async function BoardsPage() {
+  const allBoards = await db
+    .select()
+    .from(boards)
+    .orderBy(desc(boards.createdAt));
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">ボード管理</h1>
+          <p className="text-sm text-muted-foreground">
+            ボードの作成・編集・削除を行います
+          </p>
+        </div>
+        <Link
+          href="/boards/new"
+          className={buttonVariants()}
+        >
+          <Plus data-icon="inline-start" />
+          新規作成
+        </Link>
+      </div>
+
+      {allBoards.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <p className="mb-4 text-muted-foreground">
+              ボードがまだありません
+            </p>
+            <Link
+              href="/boards/new"
+              className={buttonVariants()}
+            >
+              <Plus data-icon="inline-start" />
+              最初のボードを作成
+            </Link>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {allBoards.map((board) => {
+            const template = templates[board.templateId as keyof typeof templates];
+            return (
+              <Link key={board.id} href={`/boards/${board.id}`}>
+                <Card className="transition-shadow hover:shadow-md">
+                  <CardHeader className="pb-3">
+                    <div className="flex items-start justify-between">
+                      <CardTitle className="text-base">{board.name}</CardTitle>
+                      <Badge variant={board.isActive ? "default" : "secondary"}>
+                        {board.isActive ? "有効" : "無効"}
+                      </Badge>
+                    </div>
+                    <CardDescription>
+                      {template?.name ?? board.templateId}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>
+                        作成: {new Date(board.createdAt).toLocaleDateString("ja-JP")}
+                      </span>
+                      <ExternalLink className="size-3.5" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,54 @@
+import Link from "next/link";
+import { LayoutDashboard, MonitorPlay } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+
+function SidebarLink({
+  href,
+  icon: Icon,
+  children,
+}: {
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <Icon className="size-4" />
+      {children}
+    </Link>
+  );
+}
+
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="flex min-h-full">{children}</div>;
+  return (
+    <div className="flex min-h-full">
+      {/* Sidebar */}
+      <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
+        <div className="flex h-14 items-center px-4">
+          <Link href="/boards" className="flex items-center gap-2 font-bold">
+            <MonitorPlay className="size-5" />
+            <span>e-Web Board</span>
+          </Link>
+        </div>
+        <Separator />
+        <nav className="flex-1 space-y-1 px-2 py-3">
+          <SidebarLink href="/boards" icon={LayoutDashboard}>
+            ボード管理
+          </SidebarLink>
+        </nav>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-5xl px-6 py-8">{children}</div>
+      </main>
+    </div>
+  );
 }

--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { boards, mediaItems, messages } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { updateBoardSchema } from "@/lib/validators";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, id),
+  });
+  if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  const media = await db
+    .select()
+    .from(mediaItems)
+    .where(eq(mediaItems.boardId, id))
+    .orderBy(asc(mediaItems.displayOrder));
+
+  const boardMessages = await db
+    .select()
+    .from(messages)
+    .where(eq(messages.boardId, id));
+
+  return NextResponse.json({ ...board, mediaItems: media, messages: boardMessages });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const existing = await db.query.boards.findFirst({
+    where: eq(boards.id, id),
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = updateBoardSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (result.data.name !== undefined) updates.name = result.data.name;
+  if (result.data.templateId !== undefined) updates.templateId = result.data.templateId;
+  if (result.data.config !== undefined) updates.config = JSON.stringify(result.data.config);
+  if (result.data.isActive !== undefined) updates.isActive = result.data.isActive;
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json(existing);
+  }
+
+  const [updated] = await db
+    .update(boards)
+    .set(updates)
+    .where(eq(boards.id, id))
+    .returning();
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const existing = await db.query.boards.findFirst({
+    where: eq(boards.id, id),
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  await db.delete(boards).where(eq(boards.id, id));
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/boards/route.ts
+++ b/src/app/api/boards/route.ts
@@ -1,5 +1,45 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { boards } from "@/db/schema";
+import { desc } from "drizzle-orm";
+import { createBoardSchema } from "@/lib/validators";
+import { templates } from "@/lib/templates";
 
 export async function GET() {
-  return NextResponse.json([]);
+  const allBoards = await db.select().from(boards).orderBy(desc(boards.createdAt));
+  return NextResponse.json(allBoards);
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = createBoardSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { name, templateId, config } = result.data;
+
+  // Apply default config from template if no config provided
+  const template = templates[templateId as keyof typeof templates];
+  const mergedConfig = Object.keys(config).length > 0 ? config : (template?.defaultConfig ?? {});
+
+  const [inserted] = await db
+    .insert(boards)
+    .values({
+      name,
+      templateId,
+      config: JSON.stringify(mergedConfig),
+    })
+    .returning();
+
+  return NextResponse.json(inserted, { status: 201 });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,5 @@
+import { redirect } from "next/navigation";
+
 export default function Home() {
-  return (
-    <div className="flex flex-1 items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight">e-Web Board</h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          カスタマイズ可能なデジタルサイネージ Web アプリ
-        </p>
-      </div>
-    </div>
-  );
+  redirect("/boards");
 }

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  ExternalLink,
+  Trash2,
+  Plus,
+  Save,
+} from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { templates } from "@/lib/templates";
+import type { Board, MediaItem, Message } from "@/types";
+
+interface BoardDetail extends Board {
+  mediaItems: MediaItem[];
+  messages: Message[];
+}
+
+export default function BoardEditClient({ boardId }: { boardId: string }) {
+  const router = useRouter();
+  const [board, setBoard] = useState<BoardDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Edit state
+  const [name, setName] = useState("");
+  const [isActive, setIsActive] = useState(true);
+  const [configText, setConfigText] = useState("");
+
+  // New message state
+  const [newMsgContent, setNewMsgContent] = useState("");
+  const [newMsgPriority, setNewMsgPriority] = useState("0");
+
+  const fetchBoard = useCallback(async () => {
+    const res = await fetch(`/api/boards/${boardId}`);
+    if (!res.ok) {
+      setError("ボードが見つかりません");
+      setLoading(false);
+      return;
+    }
+    const data: BoardDetail = await res.json();
+    setBoard(data);
+    setName(data.name);
+    setIsActive(data.isActive);
+    setConfigText(
+      JSON.stringify(
+        typeof data.config === "string" ? JSON.parse(data.config) : data.config,
+        null,
+        2,
+      ),
+    );
+    setLoading(false);
+  }, [boardId]);
+
+  useEffect(() => {
+    fetchBoard();
+  }, [fetchBoard]);
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+
+    let config: Record<string, unknown>;
+    try {
+      config = JSON.parse(configText);
+    } catch {
+      setError("設定の JSON が不正です");
+      setSaving(false);
+      return;
+    }
+
+    const res = await fetch(`/api/boards/${boardId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, isActive, config }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error ?? "保存に失敗しました");
+    } else {
+      await fetchBoard();
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete() {
+    const res = await fetch(`/api/boards/${boardId}`, { method: "DELETE" });
+    if (res.ok) {
+      router.push("/boards");
+    }
+  }
+
+  async function handleAddMessage() {
+    if (!newMsgContent.trim()) return;
+
+    const res = await fetch("/api/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        boardId,
+        content: newMsgContent,
+        priority: parseInt(newMsgPriority, 10) || 0,
+      }),
+    });
+
+    if (res.ok) {
+      setNewMsgContent("");
+      setNewMsgPriority("0");
+      await fetchBoard();
+    }
+  }
+
+  async function handleDeleteMessage(msgId: string) {
+    const res = await fetch(`/api/messages/${msgId}`, { method: "DELETE" });
+    if (res.ok) {
+      await fetchBoard();
+    }
+  }
+
+  if (loading) {
+    return <div className="py-12 text-center text-muted-foreground">読み込み中...</div>;
+  }
+
+  if (!board) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-muted-foreground">{error ?? "ボードが見つかりません"}</p>
+        <Link
+          href="/boards"
+          className={`mt-4 ${buttonVariants({ variant: "outline" })}`}
+        >
+          ボード一覧に戻る
+        </Link>
+      </div>
+    );
+  }
+
+  const template = templates[board.templateId as keyof typeof templates];
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <Link
+            href="/boards"
+            className={buttonVariants({ variant: "ghost", size: "sm" })}
+          >
+            <ArrowLeft data-icon="inline-start" />
+            ボード一覧
+          </Link>
+        </div>
+        <div className="flex items-center gap-2">
+          <a
+            href={`/${boardId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            <ExternalLink data-icon="inline-start" />
+            プレビュー
+          </a>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Left: Board settings (2 cols) */}
+        <div className="space-y-6 lg:col-span-2">
+          {/* Basic info */}
+          <Card>
+            <CardHeader>
+              <CardTitle>基本設定</CardTitle>
+              <CardDescription>
+                テンプレート: {template?.name ?? board.templateId}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="board-name">ボード名</Label>
+                <Input
+                  id="board-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  maxLength={100}
+                />
+              </div>
+
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="board-active"
+                  checked={isActive}
+                  onCheckedChange={setIsActive}
+                />
+                <Label htmlFor="board-active">
+                  ボードを有効にする
+                </Label>
+                <Badge variant={isActive ? "default" : "secondary"}>
+                  {isActive ? "有効" : "無効"}
+                </Badge>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Config JSON */}
+          <Card>
+            <CardHeader>
+              <CardTitle>テンプレート設定</CardTitle>
+              <CardDescription>
+                JSON 形式でテンプレート固有の設定を編集できます
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Textarea
+                value={configText}
+                onChange={(e) => setConfigText(e.target.value)}
+                className="font-mono text-sm"
+                rows={10}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Messages */}
+          <Card>
+            <CardHeader>
+              <CardTitle>メッセージ</CardTitle>
+              <CardDescription>
+                {board.messages.length} 件のメッセージ
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Add new message */}
+              <div className="flex gap-2">
+                <Input
+                  value={newMsgContent}
+                  onChange={(e) => setNewMsgContent(e.target.value)}
+                  placeholder="メッセージを入力..."
+                  className="flex-1"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                      e.preventDefault();
+                      handleAddMessage();
+                    }
+                  }}
+                />
+                <Input
+                  value={newMsgPriority}
+                  onChange={(e) => setNewMsgPriority(e.target.value)}
+                  placeholder="優先度"
+                  type="number"
+                  min={0}
+                  className="w-20"
+                />
+                <Button type="button" size="sm" onClick={handleAddMessage}>
+                  <Plus data-icon="inline-start" />
+                  追加
+                </Button>
+              </div>
+
+              <Separator />
+
+              {/* Message list */}
+              {board.messages.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  メッセージはありません
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {[...board.messages]
+                    .sort((a, b) => b.priority - a.priority)
+                    .map((msg) => (
+                      <div
+                        key={msg.id}
+                        className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                      >
+                        <Badge variant="secondary" className="shrink-0">
+                          P{msg.priority}
+                        </Badge>
+                        <span className="flex-1 truncate">{msg.content}</span>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => handleDeleteMessage(msg.id)}
+                        >
+                          <Trash2 className="size-3.5 text-destructive" />
+                        </Button>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Media items (read-only list for now, full media upload in Issue #8) */}
+          <Card>
+            <CardHeader>
+              <CardTitle>メディア</CardTitle>
+              <CardDescription>
+                {board.mediaItems.length} 件のメディア（アップロード機能は Issue #8 で実装）
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {board.mediaItems.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  メディアはありません
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {board.mediaItems.map((m) => (
+                    <div
+                      key={m.id}
+                      className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm"
+                    >
+                      <Badge variant="outline">{m.type}</Badge>
+                      <span className="flex-1 truncate font-mono text-xs">
+                        {m.filePath}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        #{m.displayOrder}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right: Actions sidebar */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">アクション</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button className="w-full" onClick={handleSave} disabled={saving}>
+                <Save data-icon="inline-start" />
+                {saving ? "保存中..." : "保存"}
+              </Button>
+
+              <a
+                href={`/${boardId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={buttonVariants({ variant: "outline", className: "w-full" })}
+              >
+                <ExternalLink data-icon="inline-start" />
+                プレビュー
+              </a>
+
+              <Separator />
+
+              <Dialog>
+                <DialogTrigger
+                render={
+                  <Button variant="destructive" className="w-full">
+                    <Trash2 data-icon="inline-start" />
+                    ボードを削除
+                  </Button>
+                }
+              />
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>ボードを削除しますか？</DialogTitle>
+                    <DialogDescription>
+                      「{board.name}」を削除します。この操作は取り消せません。
+                      関連するメディアとメッセージもすべて削除されます。
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter>
+                    <DialogClose
+                      render={<Button variant="outline">キャンセル</Button>}
+                    />
+                    <Button variant="destructive" onClick={handleDelete}>
+                      削除する
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </CardContent>
+          </Card>
+
+          {error && (
+            <Card className="border-destructive">
+              <CardContent className="py-3">
+                <p className="text-sm text-destructive">{error}</p>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardContent className="py-4 text-xs text-muted-foreground">
+              <div>ID: <span className="font-mono">{board.id}</span></div>
+              <div>作成: {new Date(board.createdAt).toLocaleString("ja-JP")}</div>
+              <div>更新: {new Date(board.updatedAt).toLocaleString("ja-JP")}</div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }


### PR DESCRIPTION
## 概要
ボードの作成・編集・削除を行う管理画面（ダッシュボード）を実装しました。

## 変更内容

### ダッシュボードUI
- **`src/app/(dashboard)/layout.tsx`** — 共通レイアウト（サイドバー + メインコンテンツ）
- **`src/app/(dashboard)/boards/page.tsx`** — ボード一覧画面
  - カード形式のボード表示（名前、テンプレート名、有効/無効バッジ、作成日）
  - 新規作成ボタン
  - ボードがない場合の空状態表示
- **`src/app/(dashboard)/boards/new/page.tsx`** — ボード新規作成画面
  - テンプレート選択（4種類のカード表示）
  - ボード名入力
- **`src/app/(dashboard)/boards/[boardId]/page.tsx`** + **`src/components/dashboard/BoardEditClient.tsx`** — ボード編集画面
  - 基本設定（名前変更、有効/無効切替）
  - テンプレート固有設定の JSON 編集
  - メッセージの追加・削除（優先度付き）
  - メディア一覧表示（アップロード機能は Issue #8 で実装）
  - ボードプレビュー（別タブで表示）
  - ボード削除（確認ダイアログ付き）
  - アクションサイドバー（保存、プレビュー、削除）

### Board CRUD API
- **`GET /api/boards`** — ボード一覧取得（作成日降順）
- **`POST /api/boards`** — ボード作成（Zod バリデーション、テンプレートデフォルト config 自動適用）
- **`GET /api/boards/:id`** — ボード詳細取得（メディア + メッセージ含む）
- **`PATCH /api/boards/:id`** — ボード更新（名前、config、有効/無効）
- **`DELETE /api/boards/:id`** — ボード削除（カスケードでメディア・メッセージも削除）

### その他
- shadcn/ui コンポーネント追加: card, input, label, select, switch, badge, dialog, textarea, separator
- ルートページ (`/`) から `/boards` へ自動リダイレクト
- `.gitignore` に `tsconfig.tsbuildinfo` 追加

Closes #7