### PR TITLE
feat(#8): メディアアップロード機能の実装

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "50mb",
+    },
+  },
 };
 
 export default nextConfig;

--- a/public/uploads/.gitignore
+++ b/public/uploads/.gitignore
@@ -1,0 +1,4 @@
+# uploaded media files
+*
+!.gitignore
+!.gitkeep

--- a/src/app/api/media/[id]/route.ts
+++ b/src/app/api/media/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { mediaItems } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import path from "path";
+import fs from "fs";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const item = await db.query.mediaItems.findFirst({
+    where: eq(mediaItems.id, id),
+  });
+  if (!item) {
+    return NextResponse.json(
+      { error: "Media item not found" },
+      { status: 404 },
+    );
+  }
+
+  // Delete file from disk
+  const filePath = path.resolve(process.cwd(), "public", item.filePath);
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch {
+    // File may already be deleted; continue with DB cleanup
+  }
+
+  // Delete from DB
+  await db.delete(mediaItems).where(eq(mediaItems.id, id));
+
+  return NextResponse.json({ success: true });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const item = await db.query.mediaItems.findFirst({
+    where: eq(mediaItems.id, id),
+  });
+  if (!item) {
+    return NextResponse.json(
+      { error: "Media item not found" },
+      { status: 404 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "duration" in body &&
+    typeof (body as Record<string, unknown>).duration === "number"
+  ) {
+    updates.duration = (body as Record<string, unknown>).duration;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json(item);
+  }
+
+  const [updated] = await db
+    .update(mediaItems)
+    .set(updates)
+    .where(eq(mediaItems.id, id))
+    .returning();
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -1,5 +1,157 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { mediaItems, boards } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { updateMediaOrderSchema } from "@/lib/validators";
+import path from "path";
+import fs from "fs";
+import { randomUUID } from "crypto";
+
+const UPLOAD_DIR = path.resolve(process.cwd(), "public", "uploads");
+
+const ALLOWED_IMAGE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];
+const ALLOWED_VIDEO_TYPES = ["video/mp4", "video/webm"];
+const ALLOWED_TYPES = [...ALLOWED_IMAGE_TYPES, ...ALLOWED_VIDEO_TYPES];
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
 export async function GET() {
-  return NextResponse.json([]);
+  const items = await db
+    .select()
+    .from(mediaItems)
+    .orderBy(asc(mediaItems.displayOrder));
+  return NextResponse.json(items);
+}
+
+export async function POST(request: NextRequest) {
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid form data" },
+      { status: 400 },
+    );
+  }
+
+  const file = formData.get("file");
+  const boardId = formData.get("boardId");
+  const duration = formData.get("duration");
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "File is required" }, { status: 400 });
+  }
+  if (!boardId || typeof boardId !== "string") {
+    return NextResponse.json(
+      { error: "boardId is required" },
+      { status: 400 },
+    );
+  }
+
+  // Validate board exists
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, boardId),
+  });
+  if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  // Validate file type
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      {
+        error: `Unsupported file type: ${file.type}. Allowed: JPEG, PNG, WebP, GIF, MP4, WebM`,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Validate file size
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: `File too large. Max size: ${MAX_FILE_SIZE / 1024 / 1024}MB` },
+      { status: 400 },
+    );
+  }
+
+  // Determine media type
+  const mediaType = ALLOWED_IMAGE_TYPES.includes(file.type)
+    ? "image"
+    : "video";
+
+  // Generate unique filename
+  const ext = path.extname(file.name) || `.${file.type.split("/")[1]}`;
+  const sanitizedExt = ext.replace(/[^a-zA-Z0-9.]/g, "");
+  const filename = `${randomUUID()}${sanitizedExt}`;
+  const filePath = path.join(UPLOAD_DIR, filename);
+
+  // Ensure upload directory exists
+  fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+
+  // Write file to disk
+  const buffer = Buffer.from(await file.arrayBuffer());
+  fs.writeFileSync(filePath, buffer);
+
+  // Calculate display order (append at end)
+  const existing = await db
+    .select()
+    .from(mediaItems)
+    .where(eq(mediaItems.boardId, boardId));
+  const maxOrder = existing.reduce(
+    (max, item) => Math.max(max, item.displayOrder),
+    -1,
+  );
+
+  const durationValue =
+    duration && typeof duration === "string"
+      ? Math.max(1, parseInt(duration, 10) || 5)
+      : 5;
+
+  const [created] = await db
+    .insert(mediaItems)
+    .values({
+      boardId,
+      type: mediaType,
+      filePath: `/uploads/${filename}`,
+      displayOrder: maxOrder + 1,
+      duration: durationValue,
+    })
+    .returning();
+
+  return NextResponse.json(created, { status: 201 });
+}
+
+export async function PATCH(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = updateMediaOrderSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const updates = result.data;
+  const updated: unknown[] = [];
+
+  for (const item of updates) {
+    const [row] = await db
+      .update(mediaItems)
+      .set({ displayOrder: item.displayOrder })
+      .where(eq(mediaItems.id, item.id))
+      .returning();
+    if (row) updated.push(row);
+  }
+
+  return NextResponse.json(updated);
 }

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -35,6 +35,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { templates } from "@/lib/templates";
+import MediaUploadZone from "@/components/dashboard/MediaUploadZone";
 import type { Board, MediaItem, Message } from "@/types";
 
 interface BoardDetail extends Board {
@@ -318,37 +319,20 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
             </CardContent>
           </Card>
 
-          {/* Media items (read-only list for now, full media upload in Issue #8) */}
+          {/* Media items */}
           <Card>
             <CardHeader>
               <CardTitle>メディア</CardTitle>
               <CardDescription>
-                {board.mediaItems.length} 件のメディア（アップロード機能は Issue #8 で実装）
+                {board.mediaItems.length} 件のメディア
               </CardDescription>
             </CardHeader>
             <CardContent>
-              {board.mediaItems.length === 0 ? (
-                <p className="py-4 text-center text-sm text-muted-foreground">
-                  メディアはありません
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {board.mediaItems.map((m) => (
-                    <div
-                      key={m.id}
-                      className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm"
-                    >
-                      <Badge variant="outline">{m.type}</Badge>
-                      <span className="flex-1 truncate font-mono text-xs">
-                        {m.filePath}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        #{m.displayOrder}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
+              <MediaUploadZone
+                boardId={boardId}
+                mediaItems={board.mediaItems}
+                onUpdate={fetchBoard}
+              />
             </CardContent>
           </Card>
         </div>

--- a/src/components/dashboard/MediaUploadZone.tsx
+++ b/src/components/dashboard/MediaUploadZone.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { Upload, X, GripVertical, Trash2, Image, Film } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { MediaItem } from "@/types";
+
+interface MediaUploadZoneProps {
+  boardId: string;
+  mediaItems: MediaItem[];
+  onUpdate: () => Promise<void>;
+}
+
+interface UploadProgress {
+  name: string;
+  progress: number;
+}
+
+export default function MediaUploadZone({
+  boardId,
+  mediaItems,
+  onUpdate,
+}: MediaUploadZoneProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [uploading, setUploading] = useState<UploadProgress[]>([]);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const ACCEPTED_TYPES =
+    "image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm";
+
+  const handleFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      if (fileArray.length === 0) return;
+
+      setUploading(fileArray.map((f) => ({ name: f.name, progress: 0 })));
+
+      for (let i = 0; i < fileArray.length; i++) {
+        const file = fileArray[i];
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("boardId", boardId);
+
+        try {
+          const res = await fetch("/api/media", {
+            method: "POST",
+            body: formData,
+          });
+
+          if (!res.ok) {
+            const err = await res.json();
+            console.error(`Upload failed for ${file.name}:`, err.error);
+          }
+
+          setUploading((prev) =>
+            prev.map((p, idx) =>
+              idx === i ? { ...p, progress: 100 } : p,
+            ),
+          );
+        } catch (err) {
+          console.error(`Upload error for ${file.name}:`, err);
+        }
+      }
+
+      await onUpdate();
+      setUploading([]);
+    },
+    [boardId, onUpdate],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      if (e.dataTransfer.files.length > 0) {
+        handleFiles(e.dataTransfer.files);
+      }
+    },
+    [handleFiles],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        handleFiles(e.target.files);
+        e.target.value = "";
+      }
+    },
+    [handleFiles],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const res = await fetch(`/api/media/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        await onUpdate();
+      }
+    },
+    [onUpdate],
+  );
+
+  const handleDurationChange = useCallback(
+    async (id: string, duration: number) => {
+      await fetch(`/api/media/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ duration }),
+      });
+      await onUpdate();
+    },
+    [onUpdate],
+  );
+
+  // Drag & drop reorder handlers
+  const handleReorderDragStart = useCallback(
+    (e: React.DragEvent, index: number) => {
+      setDraggedIndex(index);
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(index));
+    },
+    [],
+  );
+
+  const handleReorderDragOver = useCallback(
+    (e: React.DragEvent, index: number) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDragOverIndex(index);
+    },
+    [],
+  );
+
+  const handleReorderDrop = useCallback(
+    async (e: React.DragEvent, dropIndex: number) => {
+      e.preventDefault();
+      setDragOverIndex(null);
+
+      if (draggedIndex === null || draggedIndex === dropIndex) {
+        setDraggedIndex(null);
+        return;
+      }
+
+      const sorted = [...mediaItems].sort(
+        (a, b) => a.displayOrder - b.displayOrder,
+      );
+      const [moved] = sorted.splice(draggedIndex, 1);
+      sorted.splice(dropIndex, 0, moved);
+
+      const orderUpdates = sorted.map((item, idx) => ({
+        id: item.id,
+        displayOrder: idx,
+      }));
+
+      setDraggedIndex(null);
+
+      await fetch("/api/media", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(orderUpdates),
+      });
+      await onUpdate();
+    },
+    [draggedIndex, mediaItems, onUpdate],
+  );
+
+  const handleReorderDragEnd = useCallback(() => {
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  }, []);
+
+  const sortedMedia = [...mediaItems].sort(
+    (a, b) => a.displayOrder - b.displayOrder,
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Drop zone */}
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => fileInputRef.current?.click()}
+        className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
+          isDragOver
+            ? "border-primary bg-primary/5"
+            : "border-muted-foreground/25 hover:border-primary/50"
+        }`}
+      >
+        <Upload className="mb-2 size-8 text-muted-foreground" />
+        <p className="text-sm font-medium">
+          ファイルをドラッグ＆ドロップ、またはクリックして選択
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          JPEG, PNG, WebP, GIF, MP4, WebM（最大 50MB）
+        </p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES}
+          multiple
+          className="hidden"
+          onChange={handleFileSelect}
+        />
+      </div>
+
+      {/* Upload progress */}
+      {uploading.length > 0 && (
+        <div className="space-y-2">
+          {uploading.map((item, idx) => (
+            <div
+              key={idx}
+              className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm"
+            >
+              <span className="flex-1 truncate">{item.name}</span>
+              <div className="h-2 w-24 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-all"
+                  style={{ width: `${item.progress}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Media list with thumbnails & reorder */}
+      {sortedMedia.length === 0 ? (
+        <p className="py-4 text-center text-sm text-muted-foreground">
+          メディアはありません
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {sortedMedia.map((item, index) => (
+            <div
+              key={item.id}
+              draggable
+              onDragStart={(e) => handleReorderDragStart(e, index)}
+              onDragOver={(e) => handleReorderDragOver(e, index)}
+              onDrop={(e) => handleReorderDrop(e, index)}
+              onDragEnd={handleReorderDragEnd}
+              className={`flex items-center gap-3 rounded-md border px-3 py-2 text-sm transition-colors ${
+                draggedIndex === index ? "opacity-50" : ""
+              } ${dragOverIndex === index ? "border-primary bg-primary/5" : ""}`}
+            >
+              <GripVertical className="size-4 shrink-0 cursor-grab text-muted-foreground" />
+
+              {/* Thumbnail */}
+              <div className="relative size-12 shrink-0 overflow-hidden rounded border bg-muted">
+                {item.type === "image" ? (
+                  <img
+                    src={item.filePath}
+                    alt=""
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <div className="flex size-full items-center justify-center">
+                    <Film className="size-5 text-muted-foreground" />
+                  </div>
+                )}
+              </div>
+
+              {/* Info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline" className="shrink-0">
+                    {item.type === "image" ? (
+                      <Image className="mr-1 size-3" />
+                    ) : (
+                      <Film className="mr-1 size-3" />
+                    )}
+                    {item.type}
+                  </Badge>
+                  <span className="truncate font-mono text-xs text-muted-foreground">
+                    {item.filePath.split("/").pop()}
+                  </span>
+                </div>
+              </div>
+
+              {/* Duration */}
+              <div className="flex shrink-0 items-center gap-1">
+                <Label className="text-xs text-muted-foreground">秒:</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={item.duration}
+                  onChange={(e) => {
+                    const v = parseInt(e.target.value, 10);
+                    if (v >= 1) handleDurationChange(item.id, v);
+                  }}
+                  className="h-7 w-16 text-xs"
+                />
+              </div>
+
+              {/* Delete */}
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => handleDelete(item.id)}
+              >
+                <Trash2 className="size-3.5 text-destructive" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

メディアアップロード機能を実装しました。

Closes #8

## 変更内容

### API

- **POST `/api/media`**: multipart/form-data によるファイルアップロード
  - 対応形式: JPEG, PNG, WebP, GIF, MP4, WebM
  - 最大ファイルサイズ: 50MB
  - UUID ベースのファイル名で `public/uploads/` に保存
  - ファイル種別（image/video）の自動判定
  - displayOrder の自動採番（末尾追加）
- **DELETE `/api/media/[id]`**: メディア削除（ディスク上のファイル + DB レコード）
- **PATCH `/api/media`**: 表示順の一括更新（ドラッグ＆ドロップ並び替え用）
- **PATCH `/api/media/[id]`**: 個別メディアの表示時間（duration）更新

### UI コンポーネント

- **MediaUploadZone**: ドラッグ＆ドロップアップロードゾーン
  - ファイルドラッグ＆ドロップ / クリック選択
  - 複数ファイル同時アップロード対応
  - アップロード進捗表示
  - サムネイルプレビュー（画像: img タグ、動画: アイコン表示）
  - ドラッグ＆ドロップによる表示順の並び替え
  - 表示時間（秒）の編集
  - 個別削除ボタン

### 設定

- `next.config.ts`: `serverActions.bodySizeLimit` を 50MB に設定
- `public/uploads/.gitignore`: アップロードファイルを Git 管理外に

## テスト

- `tsc --noEmit`: エラーなし
- `pnpm build`: 正常完了