### PR TITLE
feat(#9): リアルタイム更新 (Server-Sent Events) の実装

### DIFF
--- a/src/app/(board)/[boardId]/page.tsx
+++ b/src/app/(board)/[boardId]/page.tsx
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { eq, asc, and, or, isNull, gt } from "drizzle-orm";
 import { getTemplate } from "@/lib/templates";
+import LiveBoard from "@/components/board/LiveBoard";
 
 export const dynamic = "force-dynamic";
 
@@ -43,9 +44,12 @@ export default async function BoardPage({
       )
     );
 
-  const TemplateComponent = template.component;
-
   return (
-    <TemplateComponent board={board} mediaItems={media} messages={activeMessages} />
+    <LiveBoard
+      board={board}
+      mediaItems={media}
+      messages={activeMessages}
+      TemplateComponent={template.component}
+    />
   );
 }

--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { updateBoardSchema } from "@/lib/validators";
+import { emitSSE } from "@/lib/sse";
 
 export async function GET(
   _request: NextRequest,
@@ -75,6 +76,8 @@ export async function PATCH(
     .where(eq(boards.id, id))
     .returning();
 
+  emitSSE(id, "board-updated");
+
   return NextResponse.json(updated);
 }
 
@@ -92,6 +95,8 @@ export async function DELETE(
   }
 
   await db.delete(boards).where(eq(boards.id, id));
+
+  emitSSE(id, "board-updated");
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/media/[id]/route.ts
+++ b/src/app/api/media/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { mediaItems } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { emitSSE } from "@/lib/sse";
 import path from "path";
 import fs from "fs";
 
@@ -33,6 +34,8 @@ export async function DELETE(
 
   // Delete from DB
   await db.delete(mediaItems).where(eq(mediaItems.id, id));
+
+  emitSSE(item.boardId, "media-updated");
 
   return NextResponse.json({ success: true });
 }
@@ -79,6 +82,8 @@ export async function PATCH(
     .set(updates)
     .where(eq(mediaItems.id, id))
     .returning();
+
+  emitSSE(item.boardId, "media-updated");
 
   return NextResponse.json(updated);
 }

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { mediaItems, boards } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { updateMediaOrderSchema } from "@/lib/validators";
+import { emitSSE } from "@/lib/sse";
 import path from "path";
 import fs from "fs";
 import { randomUUID } from "crypto";
@@ -122,6 +123,8 @@ export async function POST(request: NextRequest) {
     })
     .returning();
 
+  emitSSE(boardId, "media-updated");
+
   return NextResponse.json(created, { status: 201 });
 }
 
@@ -144,13 +147,21 @@ export async function PATCH(request: NextRequest) {
   const updates = result.data;
   const updated: unknown[] = [];
 
+  const boardIds = new Set<string>();
   for (const item of updates) {
     const [row] = await db
       .update(mediaItems)
       .set({ displayOrder: item.displayOrder })
       .where(eq(mediaItems.id, item.id))
       .returning();
-    if (row) updated.push(row);
+    if (row) {
+      updated.push(row);
+      boardIds.add((row as { boardId: string }).boardId);
+    }
+  }
+
+  for (const boardId of boardIds) {
+    emitSSE(boardId, "media-updated");
   }
 
   return NextResponse.json(updated);

--- a/src/app/api/messages/[id]/route.ts
+++ b/src/app/api/messages/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { messages } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { emitSSE } from "@/lib/sse";
 
 export async function DELETE(
   _request: NextRequest,
@@ -17,6 +18,8 @@ export async function DELETE(
   }
 
   await db.delete(messages).where(eq(messages.id, id));
+
+  emitSSE(existing.boardId, "message-updated");
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { boards, messages } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { createMessageSchema } from "@/lib/validators";
+import { emitSSE } from "@/lib/sse";
 
 export async function POST(request: NextRequest) {
   let body: unknown;
@@ -39,6 +40,8 @@ export async function POST(request: NextRequest) {
       expiresAt: expiresAt ?? null,
     })
     .returning();
+
+  emitSSE(boardId, "message-updated");
 
   return NextResponse.json(inserted, { status: 201 });
 }

--- a/src/app/api/sse/[boardId]/route.ts
+++ b/src/app/api/sse/[boardId]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { addClient, removeClient } from "@/lib/sse";
+
+export const dynamic = "force-dynamic";
+
+const HEARTBEAT_INTERVAL = 30_000; // 30 seconds
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> },
+) {
+  const { boardId } = await params;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+
+      // Send initial connection event
+      controller.enqueue(
+        encoder.encode(`event: connected\ndata: {"boardId":"${boardId}"}\n\n`),
+      );
+
+      // Register client
+      const client = addClient(boardId, controller);
+
+      // Heartbeat to keep connection alive
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": heartbeat\n\n"));
+        } catch {
+          clearInterval(heartbeat);
+        }
+      }, HEARTBEAT_INTERVAL);
+
+      // Cleanup on close
+      _request.signal.addEventListener("abort", () => {
+        clearInterval(heartbeat);
+        removeClient(boardId, client);
+        try {
+          controller.close();
+        } catch {
+          // Already closed
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,15 +1,5 @@
+// SSE routes moved to /api/sse/[boardId]/route.ts
+// This file kept to avoid 404 on the base path
 export async function GET() {
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue("data: connected\n\n");
-    },
-  });
-
-  return new Response(stream, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    },
-  });
+  return new Response("Use /api/sse/:boardId", { status: 400 });
 }

--- a/src/components/board/LiveBoard.tsx
+++ b/src/components/board/LiveBoard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useSSE } from "@/hooks/useSSE";
+import type { Board, MediaItem, Message, BoardTemplateProps } from "@/types";
+
+interface LiveBoardProps {
+  board: Board;
+  mediaItems: MediaItem[];
+  messages: Message[];
+  TemplateComponent: React.ComponentType<BoardTemplateProps>;
+}
+
+/**
+ * Wraps a board template with SSE-based live updates.
+ * Initial data comes from server-side rendering (props).
+ * Subsequent updates are fetched when SSE events arrive.
+ */
+export default function LiveBoard({
+  board: initialBoard,
+  mediaItems: initialMedia,
+  messages: initialMessages,
+  TemplateComponent,
+}: LiveBoardProps) {
+  const [board, setBoard] = useState(initialBoard);
+  const [mediaItems, setMediaItems] = useState(initialMedia);
+  const [messages, setMessages] = useState(initialMessages);
+
+  const refetchData = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/boards/${initialBoard.id}`);
+      if (!res.ok) return;
+      const data = await res.json();
+
+      setBoard({
+        id: data.id,
+        name: data.name,
+        templateId: data.templateId,
+        config: data.config,
+        isActive: data.isActive,
+        createdAt: data.createdAt,
+        updatedAt: data.updatedAt,
+      });
+      setMediaItems(data.mediaItems ?? []);
+      setMessages(data.messages ?? []);
+    } catch {
+      // Network error; will retry on next SSE event
+    }
+  }, [initialBoard.id]);
+
+  const handleSSEEvent = useCallback(
+    (_event: string, _data: Record<string, unknown>) => {
+      // On any event, refetch the full board data
+      refetchData();
+    },
+    [refetchData],
+  );
+
+  useSSE({
+    boardId: initialBoard.id,
+    onEvent: handleSSEEvent,
+  });
+
+  return (
+    <TemplateComponent board={board} mediaItems={mediaItems} messages={messages} />
+  );
+}

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+interface UseSSEOptions {
+  boardId: string;
+  onEvent: (event: string, data: Record<string, unknown>) => void;
+}
+
+/**
+ * React hook that connects to the SSE endpoint for a board
+ * and calls onEvent whenever a server event is received.
+ * Handles automatic reconnection on disconnect.
+ */
+export function useSSE({ boardId, onEvent }: UseSSEOptions) {
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  const connect = useCallback(() => {
+    const es = new EventSource(`/api/sse/${boardId}`);
+
+    // Listen for all named events via the generic message handler
+    // Named events (board-updated, media-updated, message-updated)
+    const eventTypes = [
+      "board-updated",
+      "media-updated",
+      "message-updated",
+    ];
+
+    for (const type of eventTypes) {
+      es.addEventListener(type, (e) => {
+        try {
+          const data = JSON.parse(e.data);
+          onEventRef.current(type, data);
+        } catch {
+          onEventRef.current(type, {});
+        }
+      });
+    }
+
+    es.addEventListener("connected", () => {
+      // Connection established
+    });
+
+    es.onerror = () => {
+      // EventSource automatically reconnects on error
+      // No manual reconnection needed
+    };
+
+    return es;
+  }, [boardId]);
+
+  useEffect(() => {
+    const es = connect();
+    return () => {
+      es.close();
+    };
+  }, [connect]);
+}

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -1,2 +1,69 @@
-// SSE utilities
-// Will be implemented in Issue #9
+/**
+ * SSE (Server-Sent Events) manager
+ *
+ * Manages per-board SSE channels. API routes call `emitSSE(boardId, event)`
+ * after mutations, which pushes events to all connected clients for that board.
+ */
+
+type SSEClient = {
+  controller: ReadableStreamDefaultController;
+};
+
+const channels = new Map<string, Set<SSEClient>>();
+
+/** Register a client connection for a board */
+export function addClient(
+  boardId: string,
+  controller: ReadableStreamDefaultController,
+): SSEClient {
+  const client: SSEClient = { controller };
+  if (!channels.has(boardId)) {
+    channels.set(boardId, new Set());
+  }
+  channels.get(boardId)!.add(client);
+  return client;
+}
+
+/** Remove a client connection */
+export function removeClient(boardId: string, client: SSEClient): void {
+  const clients = channels.get(boardId);
+  if (clients) {
+    clients.delete(client);
+    if (clients.size === 0) {
+      channels.delete(boardId);
+    }
+  }
+}
+
+/** Emit an SSE event to all clients connected to a board */
+export function emitSSE(
+  boardId: string,
+  event: string,
+  data?: Record<string, unknown>,
+): void {
+  const clients = channels.get(boardId);
+  if (!clients || clients.size === 0) return;
+
+  const payload =
+    `event: ${event}\ndata: ${JSON.stringify(data ?? {})}\n\n`;
+  const encoded = new TextEncoder().encode(payload);
+
+  for (const client of clients) {
+    try {
+      client.controller.enqueue(encoded);
+    } catch {
+      // Client disconnected; remove it
+      clients.delete(client);
+    }
+  }
+
+  // Clean up empty channel
+  if (clients.size === 0) {
+    channels.delete(boardId);
+  }
+}
+
+/** Get number of connected clients for a board (for debugging) */
+export function getClientCount(boardId: string): number {
+  return channels.get(boardId)?.size ?? 0;
+}


### PR DESCRIPTION
## 概要

Server-Sent Events (SSE) によるリアルタイム更新機能を実装しました。

Closes #9

## 変更内容

### SSE 基盤

- **`src/lib/sse.ts`**: SSE チャネル管理ユーティリティ
  - ボード ID ごとのクライアント接続管理 (`addClient` / `removeClient`)
  - イベント発行関数 (`emitSSE`) — 接続中の全クライアントにイベントを配信
  - 切断済みクライアントの自動クリーンアップ

- **`GET /api/sse/[boardId]`**: SSE エンドポイント
  - `ReadableStream` ベースの SSE 実装
  - 30秒間隔のハートビートで接続維持
  - `AbortSignal` による切断検知とクリーンアップ
  - `X-Accel-Buffering: no` ヘッダーでプロキシバッファリング無効化

### クライアント

- **`src/hooks/useSSE.ts`**: `useSSE` フック
  - `EventSource` による SSE 接続
  - `board-updated`, `media-updated`, `message-updated` イベントの購読
  - ブラウザ標準の自動再接続

- **`src/components/board/LiveBoard.tsx`**: ライブ更新ラッパー
  - サーバーサイドレンダリングの初期データを props で受け取り
  - SSE イベント受信時に `/api/boards/:id` からデータを再取得
  - テンプレートコンポーネントに最新データを渡してリレンダー

- **`src/app/(board)/[boardId]/page.tsx`**: `LiveBoard` を統合
  - テンプレート直接レンダリング → `LiveBoard` ラッパー経由に変更

### SSE イベント発行

以下の API 操作後に SSE イベントを自動発行:

| 操作 | イベント |
|------|---------|
| ボード設定更新 (PATCH `/api/boards/:id`) | `board-updated` |
| ボード削除 (DELETE `/api/boards/:id`) | `board-updated` |
| メディアアップロード (POST `/api/media`) | `media-updated` |
| メディア削除 (DELETE `/api/media/:id`) | `media-updated` |
| メディア表示時間変更 (PATCH `/api/media/:id`) | `media-updated` |
| メディア並べ替え (PATCH `/api/media`) | `media-updated` |
| メッセージ送信 (POST `/api/messages`) | `message-updated` |
| メッセージ削除 (DELETE `/api/messages/:id`) | `message-updated` |

## テスト

- `tsc --noEmit`: エラーなし
- `pnpm build`: 正常完了（`/api/sse/[boardId]` ルート追加確認済み）