### PR TITLE
feat(#10): Docker イメージ・デプロイ構成の整備

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# dependencies
+node_modules/
+
+# next.js build output
+.next/
+out/
+
+# database & uploads (runtime data)
+data/
+*.db
+*.db-journal
+public/uploads/*
+!public/uploads/.gitignore
+!public/uploads/.gitkeep
+
+# git
+.git/
+.gitignore
+
+# env
+.env
+.env.local
+.env.*.local
+
+# editor / OS
+.vscode/
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+
+# debug
+npm-debug.log*
+pnpm-debug.log*
+
+# misc
+.turbo/
+.vercel/
+tsconfig.tsbuildinfo
+README.md
+DESIGN.md

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ docker compose up -d
 
 ブラウザで http://localhost:3000 にアクセスしてください。
 
+```bash
+# 停止
+docker compose down
+
+# 停止 + データ削除
+docker compose down -v
+```
+
+> **Note:** データ (SQLite DB、アップロードファイル) は Docker ボリュームに永続化されます。`docker compose down` ではデータは保持され、`-v` オプションを付けるとボリュームごと削除されます。
+
 ### ローカル開発
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,19 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./data:/app/data
-      - ./public/uploads:/app/public/uploads
+      - db-data:/app/data
+      - upload-data:/app/public/uploads
     environment:
       - NODE_ENV=production
+      - HOSTNAME=0.0.0.0
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  db-data:
+  upload-data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,55 @@
-FROM node:20-alpine AS base
+FROM node:20-slim AS base
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 
-# Install dependencies
+# ---- deps: install production + dev dependencies ----
 FROM base AS deps
+
+# Install build tools for native modules (better-sqlite3)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Build
+# ---- build: compile Next.js app ----
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
 RUN pnpm build
 
-# Production
+# ---- runner: minimal production image ----
 FROM base AS runner
 ENV NODE_ENV=production
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone server
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
+# Copy drizzle migrations + migration runner
+COPY --from=builder /app/drizzle ./drizzle
+COPY --from=builder /app/docker/migrate.cjs ./migrate.cjs
+COPY --from=builder /app/docker/entrypoint.sh ./entrypoint.sh
+
+# Create writable directories for runtime data
+RUN mkdir -p data public/uploads && \
+    chown -R nextjs:nodejs data public/uploads
+
+USER nextjs
+
 EXPOSE 3000
-CMD ["node", "server.js"]
+
+ENV HOSTNAME="0.0.0.0"
+ENV PORT=3000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "[entrypoint] Running database migrations..."
+node migrate.cjs
+
+echo "[entrypoint] Starting server..."
+exec node server.js

--- a/docker/migrate.cjs
+++ b/docker/migrate.cjs
@@ -1,0 +1,83 @@
+/**
+ * Lightweight migration runner for Docker container startup.
+ * Reads drizzle migration SQL files and applies them using better-sqlite3.
+ * This avoids needing drizzle-kit in the production image.
+ */
+const Database = require("better-sqlite3");
+const fs = require("fs");
+const path = require("path");
+
+const DB_DIR = path.resolve(process.cwd(), "data");
+const DB_PATH = path.join(DB_DIR, "e-web-board.db");
+const MIGRATIONS_DIR = path.resolve(process.cwd(), "drizzle");
+const JOURNAL_PATH = path.join(MIGRATIONS_DIR, "meta", "_journal.json");
+
+// Ensure data directory exists
+fs.mkdirSync(DB_DIR, { recursive: true });
+
+const db = new Database(DB_PATH);
+db.pragma("journal_mode = WAL");
+db.pragma("foreign_keys = ON");
+
+// Create migration tracking table
+db.exec(`
+  CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    hash TEXT NOT NULL,
+    created_at NUMERIC
+  )
+`);
+
+// Read journal
+if (!fs.existsSync(JOURNAL_PATH)) {
+  console.log("[migrate] No migration journal found, skipping.");
+  db.close();
+  process.exit(0);
+}
+
+const journal = JSON.parse(fs.readFileSync(JOURNAL_PATH, "utf-8"));
+const applied = new Set(
+  db
+    .prepare("SELECT hash FROM __drizzle_migrations")
+    .all()
+    .map((row) => row.hash),
+);
+
+let count = 0;
+for (const entry of journal.entries) {
+  if (applied.has(entry.tag)) continue;
+
+  const sqlPath = path.join(MIGRATIONS_DIR, `${entry.tag}.sql`);
+  if (!fs.existsSync(sqlPath)) {
+    console.error(`[migrate] Migration file not found: ${sqlPath}`);
+    process.exit(1);
+  }
+
+  const sql = fs.readFileSync(sqlPath, "utf-8");
+  // Split by drizzle statement breakpoint
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const migrate = db.transaction(() => {
+    for (const stmt of statements) {
+      db.exec(stmt);
+    }
+    db.prepare(
+      "INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)",
+    ).run(entry.tag, Date.now());
+  });
+
+  migrate();
+  count++;
+  console.log(`[migrate] Applied: ${entry.tag}`);
+}
+
+if (count === 0) {
+  console.log("[migrate] Database is up to date.");
+} else {
+  console.log(`[migrate] Applied ${count} migration(s).`);
+}
+
+db.close();

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   experimental: {
     serverActions: {
       bodySizeLimit: "50mb",


### PR DESCRIPTION
## 概要

Docker Compose で 1 コマンド起動できるデプロイ構成を整備しました。

Closes #10

## 変更内容

### Dockerfile (`docker/Dockerfile`)

マルチステージビルド (3ステージ):

| ステージ | 役割 |
|---------|------|
| `deps` | `pnpm install` + ネイティブモジュールビルド (better-sqlite3) |
| `builder` | Next.js アプリのビルド (`pnpm build`) |
| `runner` | standalone 出力 + マイグレーションファイルのみの最小イメージ |

- **ベースイメージ**: `node:20-slim`
- **ネイティブモジュール対応**: `python3`, `make`, `g++` を `deps` ステージでインストール
- **セキュリティ**: 非 root ユーザー (`nextjs:nodejs`) で実行
- **エントリポイント**: `entrypoint.sh` で起動時にマイグレーション → サーバー起動

### docker-compose.yml

- **名前付きボリューム**: `db-data` (SQLite DB), `upload-data` (アップロードファイル) で永続化
- **ヘルスチェック**: Node.js `fetch()` ベース (30秒間隔、10秒タイムアウト、3回リトライ)
- **ポート**: 3000
- **自動再起動**: `unless-stopped`

### マイグレーション

- **`docker/migrate.cjs`**: `better-sqlite3` を直接使い、`drizzle/` の SQL ファイルを適用する軽量マイグレーションスクリプト (drizzle-kit 不要)
- **`docker/entrypoint.sh`**: 起動時にマイグレーション実行後にサーバーを起動

### その他

- **`.dockerignore`**: `node_modules`, `.next`, `data/`, `.git` 等を除外
- **`next.config.ts`**: `output: "standalone"` を追加
- **`README.md`**: Docker の停止コマンドとデータ永続化の説明を追加

## 使い方

```bash
# 起動
docker compose up -d

# 停止
docker compose down

# 停止 + データ削除
docker compose down -v
```

## テスト

- `tsc --noEmit`: エラーなし
- `pnpm build`: standalone 出力が正常に生成されることを確認
- Docker デーモン未起動のため Docker ビルドは手元では未検証（CI or 手動テスト推奨）