### PR TITLE
[KAIZEN] シンプル掲示板下部の流れる文字の表示改善 & 設定UI刷新

### DIFF
--- a/src/app/api/messages/[id]/route.ts
+++ b/src/app/api/messages/[id]/route.ts
@@ -3,6 +3,46 @@ import { db } from "@/db";
 import { messages } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { emitSSE } from "@/lib/sse";
+import { updateMessageSchema } from "@/lib/validators";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = updateMessageSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const existing = await db.query.messages.findFirst({
+    where: eq(messages.id, id),
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Message not found" }, { status: 404 });
+  }
+
+  const [updated] = await db
+    .update(messages)
+    .set(result.data)
+    .where(eq(messages.id, id))
+    .returning();
+
+  emitSSE(existing.boardId, "message-updated");
+
+  return NextResponse.json(updated);
+}
 
 export async function DELETE(
   _request: NextRequest,

--- a/src/components/board/GoogleFontLoader.tsx
+++ b/src/components/board/GoogleFontLoader.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { buildGoogleFontsUrl } from "@/lib/fonts";
+
+/**
+ * Dynamically loads Google Fonts by injecting a <link> tag.
+ * Only loads fonts that aren't already loaded.
+ */
+export function GoogleFontLoader({ fonts }: { fonts: string[] }) {
+  useEffect(() => {
+    const url = buildGoogleFontsUrl(fonts);
+    if (!url) return;
+
+    const linkId = "google-fonts-dynamic";
+    const existing = document.getElementById(linkId) as HTMLLinkElement | null;
+
+    if (existing && existing.href === url) return;
+
+    if (existing) existing.remove();
+
+    const link = document.createElement("link");
+    link.id = linkId;
+    link.rel = "stylesheet";
+    link.href = url;
+    document.head.appendChild(link);
+
+    return () => {
+      // Don't remove on cleanup — fonts may still be needed
+    };
+  }, [fonts]);
+
+  return null;
+}

--- a/src/components/board/TickerText.tsx
+++ b/src/components/board/TickerText.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState, useCallback } from "react";
 import { motion } from "framer-motion";
 
 interface TickerTextProps {
@@ -8,29 +8,53 @@ interface TickerTextProps {
   /** Scroll speed in pixels per second */
   speed?: number;
   className?: string;
+  /** Font family for ticker text */
+  fontFamily?: string;
 }
 
 export function TickerText({
   messages,
   speed = 60,
   className = "",
+  fontFamily,
 }: TickerTextProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLSpanElement>(null);
   const [contentWidth, setContentWidth] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [ready, setReady] = useState(false);
 
   const text = messages.length > 0 ? messages.join("　　　") : "";
 
-  useEffect(() => {
-    if (!containerRef.current) return;
-    const container = containerRef.current;
-    setContainerWidth(container.offsetWidth);
-
-    const span = container.querySelector("span");
-    if (span) {
-      setContentWidth(span.offsetWidth);
+  const measure = useCallback(() => {
+    if (!containerRef.current || !contentRef.current) return;
+    const cw = containerRef.current.offsetWidth;
+    const tw = contentRef.current.offsetWidth;
+    if (cw > 0 && tw > 0) {
+      setContainerWidth(cw);
+      setContentWidth(tw);
+      setReady(true);
     }
-  }, [text]);
+  }, []);
+
+  useEffect(() => {
+    setReady(false);
+    // Use requestAnimationFrame to ensure DOM is laid out before measuring
+    const raf = requestAnimationFrame(() => {
+      measure();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [text, fontFamily, measure]);
+
+  // Re-measure on window resize
+  useEffect(() => {
+    const handleResize = () => {
+      setReady(false);
+      requestAnimationFrame(measure);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [measure]);
 
   if (!text) {
     return null;
@@ -45,17 +69,27 @@ export function TickerText({
       className={`relative overflow-hidden whitespace-nowrap ${className}`}
     >
       <motion.div
-        initial={{ x: containerWidth }}
-        animate={{ x: -contentWidth }}
-        transition={{
-          duration,
-          ease: "linear",
-          repeat: Infinity,
-          repeatType: "loop",
-        }}
-        key={text}
+        initial={{ x: containerWidth || "100%" }}
+        animate={ready ? { x: -contentWidth } : { x: "100%" }}
+        transition={
+          ready
+            ? {
+                duration,
+                ease: "linear",
+                repeat: Infinity,
+                repeatType: "loop",
+              }
+            : { duration: 0 }
+        }
+        key={`${text}-${ready}`}
       >
-        <span className="inline-block">{text}</span>
+        <span
+          ref={contentRef}
+          className="inline-block"
+          style={fontFamily ? { fontFamily } : undefined}
+        >
+          {text}
+        </span>
       </motion.div>
     </div>
   );

--- a/src/components/board/TickerText.tsx
+++ b/src/components/board/TickerText.tsx
@@ -67,7 +67,7 @@ export function TickerText({
   return (
     <div
       ref={containerRef}
-      className={`relative overflow-hidden whitespace-nowrap ${className}`}
+      className={`relative w-full overflow-hidden whitespace-nowrap ${className}`}
     >
       {/* Hidden span for measurement — always in DOM */}
       <span

--- a/src/components/board/TickerText.tsx
+++ b/src/components/board/TickerText.tsx
@@ -19,7 +19,7 @@ export function TickerText({
   fontFamily,
 }: TickerTextProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLSpanElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
   const [contentWidth, setContentWidth] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
   const [ready, setReady] = useState(false);
@@ -27,9 +27,9 @@ export function TickerText({
   const text = messages.length > 0 ? messages.join("　　　") : "";
 
   const measure = useCallback(() => {
-    if (!containerRef.current || !contentRef.current) return;
+    if (!containerRef.current || !measureRef.current) return;
     const cw = containerRef.current.offsetWidth;
-    const tw = contentRef.current.offsetWidth;
+    const tw = measureRef.current.offsetWidth;
     if (cw > 0 && tw > 0) {
       setContainerWidth(cw);
       setContentWidth(tw);
@@ -62,35 +62,41 @@ export function TickerText({
 
   const totalDistance = contentWidth + containerWidth;
   const duration = totalDistance / speed;
+  const fontStyle = fontFamily ? { fontFamily } : undefined;
 
   return (
     <div
       ref={containerRef}
       className={`relative overflow-hidden whitespace-nowrap ${className}`}
     >
-      <motion.div
-        initial={{ x: containerWidth || "100%" }}
-        animate={ready ? { x: -contentWidth } : { x: "100%" }}
-        transition={
-          ready
-            ? {
-                duration,
-                ease: "linear",
-                repeat: Infinity,
-                repeatType: "loop",
-              }
-            : { duration: 0 }
-        }
-        key={`${text}-${ready}`}
+      {/* Hidden span for measurement — always in DOM */}
+      <span
+        ref={measureRef}
+        className="pointer-events-none invisible absolute whitespace-nowrap"
+        style={fontStyle}
+        aria-hidden
       >
-        <span
-          ref={contentRef}
-          className="inline-block"
-          style={fontFamily ? { fontFamily } : undefined}
+        {text}
+      </span>
+
+      {/* Animated ticker — only rendered after measurement */}
+      {ready && (
+        <motion.div
+          initial={{ x: containerWidth }}
+          animate={{ x: -contentWidth }}
+          transition={{
+            duration,
+            ease: "linear",
+            repeat: Infinity,
+            repeatType: "loop",
+          }}
+          key={text}
         >
-          {text}
-        </span>
-      </motion.div>
+          <span className="inline-block" style={fontStyle}>
+            {text}
+          </span>
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/src/components/board/templates/SimpleBoard.tsx
+++ b/src/components/board/templates/SimpleBoard.tsx
@@ -2,6 +2,7 @@
 
 import { MediaSlider } from "@/components/board/MediaSlider";
 import { TickerText } from "@/components/board/TickerText";
+import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
 import type { BoardTemplateProps } from "@/types";
 
 /** Default config for the Simple Board template */
@@ -10,6 +11,8 @@ export const simpleBoardDefaultConfig = {
   tickerSpeed: 60,
   backgroundColor: "#000000",
   textColor: "#ffffff",
+  tickerBgColor: "#1a1a2e",
+  tickerFontFamily: "",
 };
 
 type SimpleBoardConfig = typeof simpleBoardDefaultConfig;
@@ -37,6 +40,9 @@ export default function SimpleBoard({
       className="flex h-screen w-screen flex-col"
       style={{ backgroundColor: config.backgroundColor }}
     >
+      {config.tickerFontFamily && (
+        <GoogleFontLoader fonts={[config.tickerFontFamily]} />
+      )}
       {/* Main area — slideshow */}
       <div className="flex-1 min-h-0">
         <MediaSlider mediaItems={sorted} interval={config.slideInterval} />
@@ -46,9 +52,13 @@ export default function SimpleBoard({
       {tickerMessages.length > 0 && (
         <div
           className="h-14 flex items-center border-t border-white/10 px-4 text-lg font-medium"
-          style={{ color: config.textColor, backgroundColor: config.backgroundColor }}
+          style={{ color: config.textColor, backgroundColor: config.tickerBgColor }}
         >
-          <TickerText messages={tickerMessages} speed={config.tickerSpeed} />
+          <TickerText
+            messages={tickerMessages}
+            speed={config.tickerSpeed}
+            fontFamily={config.tickerFontFamily || undefined}
+          />
         </div>
       )}
     </div>

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -9,6 +9,9 @@ import {
   Trash2,
   Plus,
   Save,
+  Pencil,
+  Check,
+  X,
 } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
@@ -20,7 +23,6 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
@@ -35,6 +37,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { templates } from "@/lib/templates";
+import { TemplateConfigEditor } from "@/components/dashboard/config-editors";
 import MediaUploadZone from "@/components/dashboard/MediaUploadZone";
 import type { Board, MediaItem, Message } from "@/types";
 
@@ -53,11 +56,16 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
   // Edit state
   const [name, setName] = useState("");
   const [isActive, setIsActive] = useState(true);
-  const [configText, setConfigText] = useState("");
+  const [config, setConfig] = useState<Record<string, unknown>>({});
 
   // New message state
   const [newMsgContent, setNewMsgContent] = useState("");
   const [newMsgPriority, setNewMsgPriority] = useState("0");
+
+  // Message editing state
+  const [editingMsgId, setEditingMsgId] = useState<string | null>(null);
+  const [editMsgContent, setEditMsgContent] = useState("");
+  const [editMsgPriority, setEditMsgPriority] = useState("");
 
   const fetchBoard = useCallback(async () => {
     const res = await fetch(`/api/boards/${boardId}`);
@@ -70,13 +78,9 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
     setBoard(data);
     setName(data.name);
     setIsActive(data.isActive);
-    setConfigText(
-      JSON.stringify(
-        typeof data.config === "string" ? JSON.parse(data.config) : data.config,
-        null,
-        2,
-      ),
-    );
+    const parsed =
+      typeof data.config === "string" ? JSON.parse(data.config) : data.config;
+    setConfig(parsed && typeof parsed === "object" ? parsed : {});
     setLoading(false);
   }, [boardId]);
 
@@ -87,15 +91,6 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
   async function handleSave() {
     setSaving(true);
     setError(null);
-
-    let config: Record<string, unknown>;
-    try {
-      config = JSON.parse(configText);
-    } catch {
-      setError("設定の JSON が不正です");
-      setSaving(false);
-      return;
-    }
 
     const res = await fetch(`/api/boards/${boardId}`, {
       method: "PATCH",
@@ -142,6 +137,33 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
   async function handleDeleteMessage(msgId: string) {
     const res = await fetch(`/api/messages/${msgId}`, { method: "DELETE" });
     if (res.ok) {
+      await fetchBoard();
+    }
+  }
+
+  function startEditMessage(msg: Message) {
+    setEditingMsgId(msg.id);
+    setEditMsgContent(msg.content);
+    setEditMsgPriority(String(msg.priority));
+  }
+
+  function cancelEditMessage() {
+    setEditingMsgId(null);
+    setEditMsgContent("");
+    setEditMsgPriority("");
+  }
+
+  async function handleSaveMessage(msgId: string) {
+    const res = await fetch(`/api/messages/${msgId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: editMsgContent,
+        priority: parseInt(editMsgPriority, 10) || 0,
+      }),
+    });
+    if (res.ok) {
+      setEditingMsgId(null);
       await fetchBoard();
     }
   }
@@ -230,20 +252,19 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
             </CardContent>
           </Card>
 
-          {/* Config JSON */}
+          {/* Config Editor */}
           <Card>
             <CardHeader>
               <CardTitle>テンプレート設定</CardTitle>
               <CardDescription>
-                JSON 形式でテンプレート固有の設定を編集できます
+                テンプレート固有の設定を編集できます
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <Textarea
-                value={configText}
-                onChange={(e) => setConfigText(e.target.value)}
-                className="font-mono text-sm"
-                rows={10}
+              <TemplateConfigEditor
+                templateId={board.templateId}
+                config={config}
+                onChange={setConfig}
               />
             </CardContent>
           </Card>
@@ -296,24 +317,75 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                 <div className="space-y-2">
                   {[...board.messages]
                     .sort((a, b) => b.priority - a.priority)
-                    .map((msg) => (
-                      <div
-                        key={msg.id}
-                        className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
-                      >
-                        <Badge variant="secondary" className="shrink-0">
-                          P{msg.priority}
-                        </Badge>
-                        <span className="flex-1 truncate">{msg.content}</span>
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          onClick={() => handleDeleteMessage(msg.id)}
+                    .map((msg) =>
+                      editingMsgId === msg.id ? (
+                        <div
+                          key={msg.id}
+                          className="flex items-center gap-2 rounded-md border border-primary/30 bg-accent/30 px-3 py-2 text-sm"
                         >
-                          <Trash2 className="size-3.5 text-destructive" />
-                        </Button>
-                      </div>
-                    ))}
+                          <Input
+                            value={editMsgPriority}
+                            onChange={(e) => setEditMsgPriority(e.target.value)}
+                            type="number"
+                            min={0}
+                            className="w-16 shrink-0"
+                          />
+                          <Input
+                            value={editMsgContent}
+                            onChange={(e) => setEditMsgContent(e.target.value)}
+                            className="flex-1"
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                                e.preventDefault();
+                                handleSaveMessage(msg.id);
+                              }
+                              if (e.key === "Escape") {
+                                cancelEditMessage();
+                              }
+                            }}
+                            autoFocus
+                          />
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => handleSaveMessage(msg.id)}
+                          >
+                            <Check className="size-3.5 text-green-600" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={cancelEditMessage}
+                          >
+                            <X className="size-3.5 text-muted-foreground" />
+                          </Button>
+                        </div>
+                      ) : (
+                        <div
+                          key={msg.id}
+                          className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                        >
+                          <Badge variant="secondary" className="shrink-0">
+                            P{msg.priority}
+                          </Badge>
+                          <span className="flex-1 truncate">{msg.content}</span>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => startEditMessage(msg)}
+                          >
+                            <Pencil className="size-3.5 text-muted-foreground" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => handleDeleteMessage(msg.id)}
+                          >
+                            <Trash2 className="size-3.5 text-destructive" />
+                          </Button>
+                        </div>
+                      ),
+                    )}
                 </div>
               )}
             </CardContent>

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface MessageBoardConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function MessageBoardConfigEditor({
+  config,
+  onChange,
+}: MessageBoardConfigEditorProps) {
+  const maxDisplayCount = (config.maxDisplayCount as number) ?? 10;
+  const fontSize = (config.fontSize as string) ?? "text-xl";
+  const backgroundColor = (config.backgroundColor as string) ?? "#1e293b";
+  const textColor = (config.textColor as string) ?? "#f8fafc";
+  const accentColor = (config.accentColor as string) ?? "#3b82f6";
+
+  function update(key: string, value: unknown) {
+    onChange({ ...config, [key]: value });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-maxDisplay">最大表示件数</Label>
+        <Input
+          id="cfg-maxDisplay"
+          type="number"
+          min={1}
+          max={100}
+          value={maxDisplayCount}
+          onChange={(e) =>
+            update("maxDisplayCount", Math.max(1, parseInt(e.target.value, 10) || 10))
+          }
+          className="w-24"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-fontSize">文字サイズ</Label>
+        <Select value={fontSize} onValueChange={(v) => update("fontSize", v)}>
+          <SelectTrigger id="cfg-fontSize" className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="text-base">小</SelectItem>
+            <SelectItem value="text-lg">やや小</SelectItem>
+            <SelectItem value="text-xl">中</SelectItem>
+            <SelectItem value="text-2xl">大</SelectItem>
+            <SelectItem value="text-3xl">特大</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-bgColor">背景色</Label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            id="cfg-bgColor"
+            value={backgroundColor}
+            onChange={(e) => update("backgroundColor", e.target.value)}
+            className="h-9 w-12 cursor-pointer rounded border"
+          />
+          <Input
+            value={backgroundColor}
+            onChange={(e) => update("backgroundColor", e.target.value)}
+            className="w-28 font-mono text-sm"
+            maxLength={7}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-textColor">文字色</Label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            id="cfg-textColor"
+            value={textColor}
+            onChange={(e) => update("textColor", e.target.value)}
+            className="h-9 w-12 cursor-pointer rounded border"
+          />
+          <Input
+            value={textColor}
+            onChange={(e) => update("textColor", e.target.value)}
+            className="w-28 font-mono text-sm"
+            maxLength={7}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-accentColor">アクセントカラー</Label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            id="cfg-accentColor"
+            value={accentColor}
+            onChange={(e) => update("accentColor", e.target.value)}
+            className="h-9 w-12 cursor-pointer rounded border"
+          />
+          <Input
+            value={accentColor}
+            onChange={(e) => update("accentColor", e.target.value)}
+            className="w-28 font-mono text-sm"
+            maxLength={7}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+
+interface PhotoClockConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function PhotoClockConfigEditor({
+  config,
+  onChange,
+}: PhotoClockConfigEditorProps) {
+  const slideInterval = (config.slideInterval as number) ?? 8;
+  const clockPosition = (config.clockPosition as string) ?? "bottom-right";
+  const clockFontSize = (config.clockFontSize as string) ?? "text-5xl";
+  const clockColor = (config.clockColor as string) ?? "#ffffff";
+  const clockBgOpacity = (config.clockBgOpacity as number) ?? 0.5;
+  const is24Hour = (config.is24Hour as boolean) ?? true;
+
+  function update(key: string, value: unknown) {
+    onChange({ ...config, [key]: value });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-slideInterval">スライド間隔（秒）</Label>
+        <Input
+          id="cfg-slideInterval"
+          type="number"
+          min={1}
+          max={300}
+          value={slideInterval}
+          onChange={(e) =>
+            update("slideInterval", Math.max(1, parseInt(e.target.value, 10) || 1))
+          }
+          className="w-24"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-clockPos">時計の位置</Label>
+        <Select value={clockPosition} onValueChange={(v) => update("clockPosition", v)}>
+          <SelectTrigger id="cfg-clockPos" className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="top-left">左上</SelectItem>
+            <SelectItem value="top-right">右上</SelectItem>
+            <SelectItem value="bottom-left">左下</SelectItem>
+            <SelectItem value="bottom-right">右下</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-clockSize">時計のサイズ</Label>
+        <Select value={clockFontSize} onValueChange={(v) => update("clockFontSize", v)}>
+          <SelectTrigger id="cfg-clockSize" className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="text-3xl">小</SelectItem>
+            <SelectItem value="text-5xl">中</SelectItem>
+            <SelectItem value="text-7xl">大</SelectItem>
+            <SelectItem value="text-9xl">特大</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-clockColor">時計の文字色</Label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            id="cfg-clockColor"
+            value={clockColor}
+            onChange={(e) => update("clockColor", e.target.value)}
+            className="h-9 w-12 cursor-pointer rounded border"
+          />
+          <Input
+            value={clockColor}
+            onChange={(e) => update("clockColor", e.target.value)}
+            className="w-28 font-mono text-sm"
+            maxLength={7}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-clockOpacity">
+          背景の不透明度: {Math.round(clockBgOpacity * 100)}%
+        </Label>
+        <input
+          id="cfg-clockOpacity"
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          value={clockBgOpacity}
+          onChange={(e) => update("clockBgOpacity", parseFloat(e.target.value))}
+          className="w-48"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Switch
+          id="cfg-24h"
+          checked={is24Hour}
+          onCheckedChange={(v) => update("is24Hour", v)}
+        />
+        <Label htmlFor="cfg-24h">24時間表示</Label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface RetroBoardConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function RetroBoardConfigEditor({
+  config,
+  onChange,
+}: RetroBoardConfigEditorProps) {
+  const displayColor = (config.displayColor as string) ?? "green";
+  const rows = (config.rows as number) ?? 5;
+  const flipSpeed = (config.flipSpeed as number) ?? 0.08;
+  const switchInterval = (config.switchInterval as number) ?? 5;
+
+  function update(key: string, value: unknown) {
+    onChange({ ...config, [key]: value });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-displayColor">表示カラー</Label>
+        <Select value={displayColor} onValueChange={(v) => update("displayColor", v)}>
+          <SelectTrigger id="cfg-displayColor" className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="green">
+              <span className="flex items-center gap-2">
+                <span className="inline-block size-3 rounded-full" style={{ backgroundColor: "#39ff14" }} />
+                グリーン
+              </span>
+            </SelectItem>
+            <SelectItem value="orange">
+              <span className="flex items-center gap-2">
+                <span className="inline-block size-3 rounded-full" style={{ backgroundColor: "#ff8c00" }} />
+                オレンジ
+              </span>
+            </SelectItem>
+            <SelectItem value="white">
+              <span className="flex items-center gap-2">
+                <span className="inline-block size-3 rounded-full border" style={{ backgroundColor: "#f0f0f0" }} />
+                ホワイト
+              </span>
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-rows">表示行数</Label>
+        <Input
+          id="cfg-rows"
+          type="number"
+          min={1}
+          max={20}
+          value={rows}
+          onChange={(e) =>
+            update("rows", Math.max(1, parseInt(e.target.value, 10) || 5))
+          }
+          className="w-24"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-flipSpeed">フリップ速度（秒/文字）</Label>
+        <Input
+          id="cfg-flipSpeed"
+          type="number"
+          min={0.01}
+          max={1}
+          step={0.01}
+          value={flipSpeed}
+          onChange={(e) =>
+            update("flipSpeed", Math.max(0.01, parseFloat(e.target.value) || 0.08))
+          }
+          className="w-24"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-switchInterval">切替間隔（秒）</Label>
+        <Input
+          id="cfg-switchInterval"
+          type="number"
+          min={1}
+          max={300}
+          value={switchInterval}
+          onChange={(e) =>
+            update("switchInterval", Math.max(1, parseInt(e.target.value, 10) || 5))
+          }
+          className="w-24"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -9,7 +9,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { GOOGLE_FONTS } from "@/lib/fonts";
+import { GOOGLE_FONTS, buildGoogleFontsUrl } from "@/lib/fonts";
+import { useEffect } from "react";
+
+/** Load ALL Google Fonts so the dropdown and preview can display them */
+function useLoadAllGoogleFonts() {
+  useEffect(() => {
+    const families = GOOGLE_FONTS.map((f) => f.value).filter(Boolean);
+    const url = buildGoogleFontsUrl(families);
+    if (!url) return;
+
+    const linkId = "google-fonts-all";
+    if (document.getElementById(linkId)) return;
+
+    const link = document.createElement("link");
+    link.id = linkId;
+    link.rel = "stylesheet";
+    link.href = url;
+    document.head.appendChild(link);
+  }, []);
+}
 
 /** Ticker color/style presets */
 const TICKER_PRESETS = [
@@ -32,6 +51,8 @@ export function SimpleBoardConfigEditor({
   config,
   onChange,
 }: SimpleBoardConfigEditorProps) {
+  useLoadAllGoogleFonts();
+
   const slideInterval = (config.slideInterval as number) ?? 5;
   const tickerSpeed = (config.tickerSpeed as number) ?? 60;
   const backgroundColor = (config.backgroundColor as string) ?? "#000000";
@@ -201,7 +222,11 @@ export function SimpleBoardConfigEditor({
               </SelectTrigger>
               <SelectContent>
                 {GOOGLE_FONTS.map((f) => (
-                  <SelectItem key={f.value || "__default__"} value={f.value || "__default__"}>
+                  <SelectItem
+                    key={f.value || "__default__"}
+                    value={f.value || "__default__"}
+                    style={f.value ? { fontFamily: f.value } : undefined}
+                  >
                     {f.label}
                   </SelectItem>
                 ))}

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { GOOGLE_FONTS } from "@/lib/fonts";
+
+/** Ticker color/style presets */
+const TICKER_PRESETS = [
+  { label: "ダーク（デフォルト）", textColor: "#ffffff", tickerBgColor: "#1a1a2e" },
+  { label: "白背景", textColor: "#1a1a2e", tickerBgColor: "#ffffff" },
+  { label: "ネオンブルー", textColor: "#00e5ff", tickerBgColor: "#0d1117" },
+  { label: "ネオングリーン", textColor: "#39ff14", tickerBgColor: "#0a0a0a" },
+  { label: "サンセット", textColor: "#ffffff", tickerBgColor: "#e65100" },
+  { label: "ロイヤルブルー", textColor: "#ffd700", tickerBgColor: "#1a237e" },
+  { label: "チェリー", textColor: "#ffffff", tickerBgColor: "#c2185b" },
+  { label: "フォレスト", textColor: "#e8f5e9", tickerBgColor: "#1b5e20" },
+];
+
+interface SimpleBoardConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function SimpleBoardConfigEditor({
+  config,
+  onChange,
+}: SimpleBoardConfigEditorProps) {
+  const slideInterval = (config.slideInterval as number) ?? 5;
+  const tickerSpeed = (config.tickerSpeed as number) ?? 60;
+  const backgroundColor = (config.backgroundColor as string) ?? "#000000";
+  const textColor = (config.textColor as string) ?? "#ffffff";
+  const tickerBgColor = (config.tickerBgColor as string) ?? "#1a1a2e";
+  const tickerFontFamily = (config.tickerFontFamily as string) ?? "";
+
+  function update(key: string, value: unknown) {
+    onChange({ ...config, [key]: value });
+  }
+
+  function applyPreset(preset: (typeof TICKER_PRESETS)[number]) {
+    onChange({
+      ...config,
+      textColor: preset.textColor,
+      tickerBgColor: preset.tickerBgColor,
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Slideshow settings */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">スライドショー</h4>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-slideInterval">スライド間隔（秒）</Label>
+            <Input
+              id="cfg-slideInterval"
+              type="number"
+              min={1}
+              max={300}
+              value={slideInterval}
+              onChange={(e) =>
+                update("slideInterval", Math.max(1, parseInt(e.target.value, 10) || 1))
+              }
+              className="w-24"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-bgColor">背景色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-bgColor"
+                value={backgroundColor}
+                onChange={(e) => update("backgroundColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={backgroundColor}
+                onChange={(e) => update("backgroundColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Ticker settings */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">ティッカー（流れる文字）</h4>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-tickerSpeed">スクロール速度（px/秒）</Label>
+            <Input
+              id="cfg-tickerSpeed"
+              type="number"
+              min={10}
+              max={500}
+              value={tickerSpeed}
+              onChange={(e) =>
+                update("tickerSpeed", Math.max(10, parseInt(e.target.value, 10) || 60))
+              }
+              className="w-24"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-textColor">文字色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-textColor"
+                value={textColor}
+                onChange={(e) => update("textColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={textColor}
+                onChange={(e) => update("textColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-tickerBg">背景色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-tickerBg"
+                value={tickerBgColor}
+                onChange={(e) => update("tickerBgColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={tickerBgColor}
+                onChange={(e) => update("tickerBgColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+
+          {/* Preview */}
+          <div className="space-y-1.5">
+            <Label>プレビュー</Label>
+            <div
+              className="flex h-10 items-center overflow-hidden rounded-md border px-3 text-sm font-medium"
+              style={{
+                color: textColor,
+                backgroundColor: tickerBgColor,
+                fontFamily: tickerFontFamily || undefined,
+              }}
+            >
+              サンプルテキストが流れます　　　お知らせ情報
+            </div>
+          </div>
+
+          {/* Color presets */}
+          <div className="space-y-1.5">
+            <Label>カラープリセット</Label>
+            <div className="flex flex-wrap gap-2">
+              {TICKER_PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => applyPreset(preset)}
+                  className="flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors hover:bg-accent"
+                >
+                  <span
+                    className="inline-block size-3 rounded-full border"
+                    style={{ backgroundColor: preset.tickerBgColor }}
+                  />
+                  <span
+                    className="inline-block size-3 rounded-full border"
+                    style={{ backgroundColor: preset.textColor }}
+                  />
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Font family */}
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-font">フォント</Label>
+            <Select
+              value={tickerFontFamily}
+              onValueChange={(v) => update("tickerFontFamily", v === "__default__" ? "" : v)}
+            >
+              <SelectTrigger id="cfg-font" className="w-64">
+                <SelectValue placeholder="フォントを選択" />
+              </SelectTrigger>
+              <SelectContent>
+                {GOOGLE_FONTS.map((f) => (
+                  <SelectItem key={f.value || "__default__"} value={f.value || "__default__"}>
+                    {f.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/config-editors/index.tsx
+++ b/src/components/dashboard/config-editors/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { SimpleBoardConfigEditor } from "./SimpleBoardConfigEditor";
+import { PhotoClockConfigEditor } from "./PhotoClockConfigEditor";
+import { RetroBoardConfigEditor } from "./RetroBoardConfigEditor";
+import { MessageBoardConfigEditor } from "./MessageBoardConfigEditor";
+
+interface ConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+const editors: Record<string, React.ComponentType<ConfigEditorProps>> = {
+  simple: SimpleBoardConfigEditor,
+  "photo-clock": PhotoClockConfigEditor,
+  retro: RetroBoardConfigEditor,
+  message: MessageBoardConfigEditor,
+};
+
+export function TemplateConfigEditor({
+  templateId,
+  config,
+  onChange,
+}: {
+  templateId: string;
+} & ConfigEditorProps) {
+  const Editor = editors[templateId];
+  if (!Editor) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        このテンプレートにはビジュアルエディタがありません
+      </p>
+    );
+  }
+  return <Editor config={config} onChange={onChange} />;
+}

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,0 +1,33 @@
+/** Available Google Fonts for board text */
+export const GOOGLE_FONTS = [
+  { value: "", label: "デフォルト（システムフォント）" },
+  { value: "Noto Sans JP", label: "Noto Sans JP" },
+  { value: "Noto Serif JP", label: "Noto Serif JP" },
+  { value: "M PLUS Rounded 1c", label: "M PLUS Rounded 1c" },
+  { value: "M PLUS 1p", label: "M PLUS 1p" },
+  { value: "Kosugi Maru", label: "Kosugi Maru" },
+  { value: "Sawarabi Gothic", label: "Sawarabi Gothic" },
+  { value: "Sawarabi Mincho", label: "Sawarabi Mincho" },
+  { value: "Zen Maru Gothic", label: "Zen Maru Gothic" },
+  { value: "Zen Kaku Gothic New", label: "Zen Kaku Gothic New" },
+  { value: "Kiwi Maru", label: "Kiwi Maru" },
+  { value: "Hachi Maru Pop", label: "Hachi Maru Pop" },
+  { value: "Dela Gothic One", label: "Dela Gothic One" },
+  { value: "Reggae One", label: "Reggae One" },
+  { value: "RocknRoll One", label: "RocknRoll One" },
+  { value: "Train One", label: "Train One" },
+] as const;
+
+/**
+ * Build the Google Fonts CSS link URL for given font families.
+ * Returns null if no fonts are specified.
+ */
+export function buildGoogleFontsUrl(families: string[]): string | null {
+  const filtered = families.filter(Boolean);
+  if (filtered.length === 0) return null;
+
+  const params = filtered
+    .map((f) => `family=${encodeURIComponent(f)}:wght@400;700`)
+    .join("&");
+  return `https://fonts.googleapis.com/css2?${params}&display=swap`;
+}


### PR DESCRIPTION
# 概要
Issue #21 の対応として、ティッカーテキストの表示改善、テンプレート設定のビジュアルUI化、メッセージ編集機能、Google Fonts対応を実装しました。

## 変更内容

### 1. ティッカーテキストアニメーションの修正
- **修正前**: テキストが画面中央から左に流れていた（初期状態で containerWidth=0 のため）
- **修正後**: テキストが右端から左端に正しく流れるようになった
- `ready` ステートの導入で測定完了後のみアニメーション開始
- ウィンドウリサイズ時の再計測にも対応

### 2. ティッカーの文字色・背景色カスタマイズ
- `tickerBgColor`（ティッカー背景色）と `tickerFontFamily` を SimpleBoard config に追加
- 8種類のカラープリセットテンプレートを用意:
  - ダーク（デフォルト）、白背景、ネオンブルー、ネオングリーン、サンセット、ロイヤルブルー、チェリー、フォレスト
- リアルタイムプレビュー表示

### 3. JSON設定エディタ → ビジュアルUIへの刷新
全テンプレートに対してフォーム形式の設定エディタを実装:
- **シンプル掲示板**: スライド間隔、背景色、ティッカー速度/文字色/背景色、カラープリセット、フォント選択
- **フォトクロック**: スライド間隔、時計位置、時計サイズ、文字色、背景不透明度、24時間表示
- **レトロ掲示板**: 表示カラー、表示行数、フリップ速度、切替間隔
- **メッセージ掲示板**: 最大表示件数、文字サイズ、背景色、文字色、アクセントカラー

### 4. Google Fonts 対応
- 16種類の日本語対応 Google Fonts から選択可能
- `GoogleFontLoader` コンポーネントによる動的フォント読み込み
- フォント一覧: Noto Sans JP, Noto Serif JP, M PLUS Rounded 1c, Zen Maru Gothic, Dela Gothic One 他

### 5. メッセージ編集機能
- `PATCH /api/messages/:id` エンドポイントを追加
- ダッシュボードでの インライン編集UI（鉛筆アイコンクリック → テキスト入力 → Enter/チェックで保存, Esc/×でキャンセル）
- 優先度の編集にも対応
- SSEイベント発火による リアルタイム反映

## 新規ファイル
- `src/lib/fonts.ts` — Google Fonts 定義とURL構築
- `src/components/board/GoogleFontLoader.tsx` — 動的フォントローダー
- `src/components/dashboard/config-editors/` — テンプレート別ビジュアル設定エディタ (5ファイル)

## 変更ファイル
- `src/components/board/TickerText.tsx` — アニメーション修正 + fontFamily対応
- `src/components/board/templates/SimpleBoard.tsx` — tickerBgColor/tickerFontFamily追加
- `src/components/dashboard/BoardEditClient.tsx` — JSON→フォームUI + メッセージ編集
- `src/app/api/messages/[id]/route.ts` — PATCH ハンドラ追加

Closes #21