### PR TITLE
fix: PhotoClock config bugs + improvements, fix all template configs (#23)

### DIFF
--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -63,7 +63,7 @@ export async function PATCH(
   const updates: Record<string, unknown> = {};
   if (result.data.name !== undefined) updates.name = result.data.name;
   if (result.data.templateId !== undefined) updates.templateId = result.data.templateId;
-  if (result.data.config !== undefined) updates.config = JSON.stringify(result.data.config);
+  if (result.data.config !== undefined) updates.config = result.data.config;
   if (result.data.isActive !== undefined) updates.isActive = result.data.isActive;
 
   if (Object.keys(updates).length === 0) {

--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -4,22 +4,27 @@ import { useState, useEffect } from "react";
 
 const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
 
+export type ClockLayout = "standard" | "compact" | "large-time" | "date-top";
+
 interface DateTimeClockProps {
   /** 24-hour format (default: true) */
   is24Hour?: boolean;
-  /** Font size class or CSS value */
-  fontSize?: string;
+  /** Font size in px for the time display */
+  timeFontSize?: number;
   /** Text color */
   color?: string;
   /** Background opacity 0-1 */
   bgOpacity?: number;
+  /** Clock layout variant */
+  layout?: ClockLayout;
 }
 
 export function DateTimeClock({
   is24Hour = true,
-  fontSize = "text-4xl",
+  timeFontSize = 48,
   color = "#ffffff",
   bgOpacity = 0.5,
+  layout = "standard",
 }: DateTimeClockProps) {
   const [now, setNow] = useState<Date | null>(null);
 
@@ -47,19 +52,100 @@ export function DateTimeClock({
   }
   const hoursStr = String(hours).padStart(2, "0");
 
+  const timeStr = `${hoursStr}:${minutes}:${seconds}${period}`;
+  const dateStr = `${year}/${month}/${day} (${weekday})`;
+
+  const dateFontSize = Math.max(14, Math.round(timeFontSize * 0.35));
+
+  if (layout === "compact") {
+    return (
+      <div
+        className="inline-flex items-center gap-4 rounded-lg px-5 py-2"
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+      >
+        <span
+          className="font-mono font-bold tabular-nums tracking-wider"
+          style={{ fontSize: timeFontSize }}
+        >
+          {timeStr}
+        </span>
+        <span
+          className="font-medium opacity-90"
+          style={{ fontSize: dateFontSize }}
+        >
+          {dateStr}
+        </span>
+      </div>
+    );
+  }
+
+  if (layout === "large-time") {
+    return (
+      <div
+        className="inline-flex flex-col items-center rounded-lg px-8 py-4"
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+      >
+        <span
+          className="font-mono font-bold tabular-nums tracking-wider"
+          style={{ fontSize: timeFontSize * 1.3 }}
+        >
+          {hoursStr}:{minutes}
+        </span>
+        <span
+          className="font-mono tabular-nums opacity-70"
+          style={{ fontSize: Math.round(timeFontSize * 0.5) }}
+        >
+          :{seconds}{period}
+        </span>
+        <span
+          className="mt-1 font-medium opacity-80"
+          style={{ fontSize: dateFontSize }}
+        >
+          {dateStr}
+        </span>
+      </div>
+    );
+  }
+
+  if (layout === "date-top") {
+    return (
+      <div
+        className="inline-flex flex-col items-center rounded-lg px-6 py-3"
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+      >
+        <span
+          className="font-medium opacity-90"
+          style={{ fontSize: dateFontSize }}
+        >
+          {dateStr}
+        </span>
+        <span
+          className="mt-1 font-mono font-bold tabular-nums tracking-wider"
+          style={{ fontSize: timeFontSize }}
+        >
+          {timeStr}
+        </span>
+      </div>
+    );
+  }
+
+  // "standard" layout (default)
   return (
     <div
       className="inline-flex flex-col items-center rounded-lg px-6 py-3"
-      style={{
-        backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`,
-        color,
-      }}
+      style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
     >
-      <span className={`${fontSize} font-mono font-bold tabular-nums tracking-wider`}>
-        {hoursStr}:{minutes}:{seconds}{period}
+      <span
+        className="font-mono font-bold tabular-nums tracking-wider"
+        style={{ fontSize: timeFontSize }}
+      >
+        {timeStr}
       </span>
-      <span className="mt-1 text-lg font-medium opacity-90">
-        {year}/{month}/{day} ({weekday})
+      <span
+        className="mt-1 font-medium opacity-90"
+        style={{ fontSize: dateFontSize }}
+      >
+        {dateStr}
       </span>
     </div>
   );

--- a/src/components/board/templates/MessageBoard.tsx
+++ b/src/components/board/templates/MessageBoard.tsx
@@ -7,7 +7,7 @@ import type { BoardTemplateProps, Message } from "@/types";
 /** Default config for the Message Board template */
 export const messageBoardDefaultConfig = {
   maxDisplayCount: 10,
-  fontSize: "text-xl" as string,
+  fontSize: 20 as number,
   backgroundColor: "#1e293b",
   textColor: "#f8fafc",
   accentColor: "#3b82f6",
@@ -15,9 +15,25 @@ export const messageBoardDefaultConfig = {
 
 type MessageBoardConfig = typeof messageBoardDefaultConfig;
 
+/** Migration map: old Tailwind class → pixel size */
+const tailwindToPx: Record<string, number> = {
+  "text-base": 16,
+  "text-lg": 18,
+  "text-xl": 20,
+  "text-2xl": 24,
+  "text-3xl": 30,
+};
+
 function parseConfig(raw: unknown): MessageBoardConfig {
   const cfg = (raw && typeof raw === "object" ? raw : {}) as Partial<MessageBoardConfig>;
-  return { ...messageBoardDefaultConfig, ...cfg };
+  // Migrate old Tailwind class values to pixel numbers
+  let fontSize = messageBoardDefaultConfig.fontSize;
+  if (typeof cfg.fontSize === "string" && cfg.fontSize in tailwindToPx) {
+    fontSize = tailwindToPx[cfg.fontSize];
+  } else if (typeof cfg.fontSize === "number" && cfg.fontSize > 0) {
+    fontSize = cfg.fontSize;
+  }
+  return { ...messageBoardDefaultConfig, ...cfg, fontSize };
 }
 
 /** Priority badge color */
@@ -120,7 +136,7 @@ export default function MessageBoard({
       <div className="flex-1 overflow-y-auto px-6 py-4">
         {currentMessages.length === 0 ? (
           <div className="flex h-full items-center justify-center opacity-40">
-            <p className={config.fontSize}>メッセージはありません</p>
+            <p style={{ fontSize: `${config.fontSize}px` }}>メッセージはありません</p>
           </div>
         ) : (
           <AnimatePresence mode="popLayout">
@@ -173,7 +189,7 @@ export default function MessageBoard({
                       </span>
                     )}
                   </div>
-                  <p className={`${config.fontSize} leading-relaxed`}>{msg.content}</p>
+                  <p className="leading-relaxed" style={{ fontSize: `${config.fontSize}px` }}>{msg.content}</p>
                 </motion.div>
               );
             })}

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -2,25 +2,45 @@
 
 import { MediaSlider } from "@/components/board/MediaSlider";
 import { DateTimeClock } from "@/components/board/DateTimeClock";
+import type { ClockLayout } from "@/components/board/DateTimeClock";
 import type { BoardTemplateProps } from "@/types";
+
+type ClockPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "center";
 
 /** Default config for the Photo-Clock Board template */
 export const photoClockDefaultConfig = {
   slideInterval: 8,
   clockPosition: "bottom-right" as ClockPosition,
-  clockFontSize: "text-5xl",
+  clockFontSize: 48,
   clockColor: "#ffffff",
   clockBgOpacity: 0.5,
+  clockLayout: "standard" as ClockLayout,
   is24Hour: true,
 };
-
-type ClockPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
 type PhotoClockConfig = typeof photoClockDefaultConfig;
 
 function parseConfig(raw: unknown): PhotoClockConfig {
   const cfg = (raw && typeof raw === "object" ? raw : {}) as Partial<PhotoClockConfig>;
-  return { ...photoClockDefaultConfig, ...cfg };
+
+  // Migrate old Tailwind class fontSize to pixel value
+  const merged = { ...photoClockDefaultConfig, ...cfg };
+  if (typeof merged.clockFontSize === "string") {
+    const sizeMap: Record<string, number> = {
+      "text-3xl": 30,
+      "text-5xl": 48,
+      "text-7xl": 72,
+      "text-9xl": 128,
+    };
+    merged.clockFontSize =
+      sizeMap[merged.clockFontSize as string] ?? 48;
+  }
+  return merged;
 }
 
 const positionClasses: Record<ClockPosition, string> = {
@@ -28,6 +48,7 @@ const positionClasses: Record<ClockPosition, string> = {
   "top-right": "top-6 right-6",
   "bottom-left": "bottom-6 left-6",
   "bottom-right": "bottom-6 right-6",
+  center: "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
 };
 
 export default function PhotoClockBoard({
@@ -51,9 +72,10 @@ export default function PhotoClockBoard({
       >
         <DateTimeClock
           is24Hour={config.is24Hour}
-          fontSize={config.clockFontSize}
+          timeFontSize={config.clockFontSize}
           color={config.clockColor}
           bgOpacity={config.clockBgOpacity}
+          layout={config.clockLayout}
         />
       </div>
     </div>

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -2,13 +2,6 @@
 
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 
 interface MessageBoardConfigEditorProps {
   config: Record<string, unknown>;
@@ -20,7 +13,7 @@ export function MessageBoardConfigEditor({
   onChange,
 }: MessageBoardConfigEditorProps) {
   const maxDisplayCount = (config.maxDisplayCount as number) ?? 10;
-  const fontSize = (config.fontSize as string) ?? "text-xl";
+  const fontSize = (config.fontSize as number) ?? 20;
   const backgroundColor = (config.backgroundColor as string) ?? "#1e293b";
   const textColor = (config.textColor as string) ?? "#f8fafc";
   const accentColor = (config.accentColor as string) ?? "#3b82f6";
@@ -47,19 +40,17 @@ export function MessageBoardConfigEditor({
       </div>
 
       <div className="space-y-1.5">
-        <Label htmlFor="cfg-fontSize">文字サイズ</Label>
-        <Select value={fontSize} onValueChange={(v) => update("fontSize", v)}>
-          <SelectTrigger id="cfg-fontSize" className="w-48">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="text-base">小</SelectItem>
-            <SelectItem value="text-lg">やや小</SelectItem>
-            <SelectItem value="text-xl">中</SelectItem>
-            <SelectItem value="text-2xl">大</SelectItem>
-            <SelectItem value="text-3xl">特大</SelectItem>
-          </SelectContent>
-        </Select>
+        <Label htmlFor="cfg-fontSize">文字サイズ ({fontSize}px)</Label>
+        <input
+          id="cfg-fontSize"
+          type="range"
+          min={12}
+          max={48}
+          step={1}
+          value={fontSize}
+          onChange={(e) => update("fontSize", Number(e.target.value))}
+          className="w-48"
+        />
       </div>
 
       <div className="space-y-1.5">

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -28,6 +28,21 @@ export function PhotoClockConfigEditor({
   const clockLayout = (config.clockLayout as string) ?? "standard";
   const is24Hour = (config.is24Hour as boolean) ?? true;
 
+  const positionLabels: Record<string, string> = {
+    "top-left": "左上",
+    "top-right": "右上",
+    center: "中央",
+    "bottom-left": "左下",
+    "bottom-right": "右下",
+  };
+
+  const layoutLabels: Record<string, string> = {
+    standard: "スタンダード（時刻 → 日付）",
+    compact: "コンパクト（横並び）",
+    "large-time": "大時刻（時分を大きく表示）",
+    "date-top": "日付上（日付 → 時刻）",
+  };
+
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
   }
@@ -53,7 +68,7 @@ export function PhotoClockConfigEditor({
         <Label htmlFor="cfg-clockPos">時計の位置</Label>
         <Select value={clockPosition} onValueChange={(v) => update("clockPosition", v)}>
           <SelectTrigger id="cfg-clockPos" className="w-48">
-            <SelectValue />
+            <SelectValue placeholder="位置を選択">{positionLabels[clockPosition] ?? clockPosition}</SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="top-left">左上</SelectItem>
@@ -69,7 +84,7 @@ export function PhotoClockConfigEditor({
         <Label htmlFor="cfg-clockLayout">時計レイアウト</Label>
         <Select value={clockLayout} onValueChange={(v) => update("clockLayout", v)}>
           <SelectTrigger id="cfg-clockLayout" className="w-64">
-            <SelectValue />
+            <SelectValue placeholder="レイアウトを選択">{layoutLabels[clockLayout] ?? clockLayout}</SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="standard">スタンダード（時刻 → 日付）</SelectItem>

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -22,9 +22,10 @@ export function PhotoClockConfigEditor({
 }: PhotoClockConfigEditorProps) {
   const slideInterval = (config.slideInterval as number) ?? 8;
   const clockPosition = (config.clockPosition as string) ?? "bottom-right";
-  const clockFontSize = (config.clockFontSize as string) ?? "text-5xl";
+  const clockFontSize = (config.clockFontSize as number) ?? 48;
   const clockColor = (config.clockColor as string) ?? "#ffffff";
   const clockBgOpacity = (config.clockBgOpacity as number) ?? 0.5;
+  const clockLayout = (config.clockLayout as string) ?? "standard";
   const is24Hour = (config.is24Hour as boolean) ?? true;
 
   function update(key: string, value: unknown) {
@@ -57,6 +58,7 @@ export function PhotoClockConfigEditor({
           <SelectContent>
             <SelectItem value="top-left">左上</SelectItem>
             <SelectItem value="top-right">右上</SelectItem>
+            <SelectItem value="center">中央</SelectItem>
             <SelectItem value="bottom-left">左下</SelectItem>
             <SelectItem value="bottom-right">右下</SelectItem>
           </SelectContent>
@@ -64,18 +66,36 @@ export function PhotoClockConfigEditor({
       </div>
 
       <div className="space-y-1.5">
-        <Label htmlFor="cfg-clockSize">時計のサイズ</Label>
-        <Select value={clockFontSize} onValueChange={(v) => update("clockFontSize", v)}>
-          <SelectTrigger id="cfg-clockSize" className="w-48">
+        <Label htmlFor="cfg-clockLayout">時計レイアウト</Label>
+        <Select value={clockLayout} onValueChange={(v) => update("clockLayout", v)}>
+          <SelectTrigger id="cfg-clockLayout" className="w-64">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="text-3xl">小</SelectItem>
-            <SelectItem value="text-5xl">中</SelectItem>
-            <SelectItem value="text-7xl">大</SelectItem>
-            <SelectItem value="text-9xl">特大</SelectItem>
+            <SelectItem value="standard">スタンダード（時刻 → 日付）</SelectItem>
+            <SelectItem value="compact">コンパクト（横並び）</SelectItem>
+            <SelectItem value="large-time">大時刻（時分を大きく表示）</SelectItem>
+            <SelectItem value="date-top">日付上（日付 → 時刻）</SelectItem>
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-clockSize">時計の文字サイズ: {clockFontSize}px</Label>
+        <input
+          id="cfg-clockSize"
+          type="range"
+          min={24}
+          max={160}
+          step={4}
+          value={clockFontSize}
+          onChange={(e) => update("clockFontSize", parseInt(e.target.value, 10))}
+          className="w-64"
+        />
+        <div className="flex justify-between text-xs text-muted-foreground w-64">
+          <span>24px</span>
+          <span>160px</span>
+        </div>
       </div>
 
       <div className="space-y-1.5">
@@ -119,7 +139,7 @@ export function PhotoClockConfigEditor({
           checked={is24Hour}
           onCheckedChange={(v) => update("is24Hour", v)}
         />
-        <Label htmlFor="cfg-24h">24時間表示</Label>
+        <Label htmlFor="cfg-24h">24時間表示（OFFで12時間+AM/PM表記）</Label>
       </div>
     </div>
   );

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -24,6 +24,12 @@ export function RetroBoardConfigEditor({
   const flipSpeed = (config.flipSpeed as number) ?? 0.08;
   const switchInterval = (config.switchInterval as number) ?? 5;
 
+  const colorLabels: Record<string, string> = {
+    green: "グリーン",
+    orange: "オレンジ",
+    white: "ホワイト",
+  };
+
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
   }
@@ -34,7 +40,7 @@ export function RetroBoardConfigEditor({
         <Label htmlFor="cfg-displayColor">表示カラー</Label>
         <Select value={displayColor} onValueChange={(v) => update("displayColor", v)}>
           <SelectTrigger id="cfg-displayColor" className="w-48">
-            <SelectValue />
+            <SelectValue placeholder="カラーを選択">{colorLabels[displayColor] ?? displayColor}</SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="green">

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -218,7 +218,9 @@ export function SimpleBoardConfigEditor({
               onValueChange={(v) => update("tickerFontFamily", v === "__default__" ? "" : v)}
             >
               <SelectTrigger id="cfg-font" className="w-64">
-                <SelectValue placeholder="フォントを選択" />
+                <SelectValue placeholder="フォントを選択">
+                  {GOOGLE_FONTS.find((f) => f.value === tickerFontFamily)?.label ?? "デフォルト"}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {GOOGLE_FONTS.map((f) => (


### PR DESCRIPTION
## 概要

Issue #23 で報告されたフォトクロックテンプレートの設定バグを修正し、改善を実施しました。

## 根本原因

**全テンプレートの設定が反映されない問題の根本原因を特定・修正:**

`PATCH /api/boards/[id]` ハンドラーで `config` を `JSON.stringify()` してからDBに保存していましたが、Drizzleの `text('config', { mode: 'json' })` が自動的にJSONシリアライズするため、**二重シリアライズ** が発生していました。

読み取り時にDrizzleがJSON解析すると文字列（オブジェクトではない）が返され、`parseConfig` が `typeof raw === 'object'` チェックで失敗 → 全デフォルト値にフォールバック → **全ての設定変更が無視される** 状態でした。

## 修正内容

### バグ修正
- **[根本原因] API ハンドラーの二重シリアライズ修正** — `JSON.stringify()` を削除、Drizzleのauto-serializationに任せる
- **PhotoClock: 時計の位置** が反映されるようになった
- **PhotoClock: 背景の透明度** が反映されるようになった
- **PhotoClock: フォントサイズ** が反映されるようになった（Tailwindクラス → px値に変更）
- **PhotoClock: 文字色** が反映されるようになった
- **MessageBoard: フォントサイズ** も同様にpx値に変更

### 改善
- **時計位置に「中央」を追加** — `center` オプション
- **時計レイアウトテンプレート追加** — 4種類（スタンダード / コンパクト / 大時刻 / 日付上）
- **12時間表示でAM/PM表記** （既存機能の確認）
- **フォントサイズをスライダーに変更** — PhotoClock (24-160px), MessageBoard (12-48px)
- **旧設定値の自動マイグレーション** — 旧Tailwindクラス値 → px値への自動変換

### 他テンプレートの確認
- **RetroBoard** — インラインスタイル使用のため根本原因修正で解決 ✅
- **SimpleBoard** — 設定値はTickerTextに渡すのみ、問題なし ✅

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/api/boards/[id]/route.ts` | `JSON.stringify()` 削除 |
| `src/components/board/DateTimeClock.tsx` | px-basedフォントサイズ, 4レイアウト対応 |
| `src/components/board/templates/PhotoClockBoard.tsx` | center位置, レイアウト, px fontSize + マイグレーション |
| `src/components/board/templates/MessageBoard.tsx` | px fontSize + マイグレーション |
| `src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx` | スライダー, レイアウト選択, center位置 |
| `src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx` | スライダーに変更 |

Closes #23