### PR TITLE
feat: フォトクロックテンプレートに天気予報表示機能を追加 (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ Issue や Pull Request は歓迎します。
 
 ---
 
+## 謝辞
+
+- 天気予報データは [天気予報 API（livedoor 天気互換）](https://weather.tsukumijima.net/) を利用させていただいています。
+
+---
+
 ## ライセンス
 
 <!-- TODO: ライセンスを決定する -->

--- a/drizzle/0001_spicy_obadiah_stane.sql
+++ b/drizzle/0001_spicy_obadiah_stane.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,273 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "edd48a94-3a52-489e-a95c-76ca15147c02",
+  "prevId": "007848e7-ce35-4bd8-90ff-200fb7f9c31f",
+  "tables": {
+    "boards": {
+      "name": "boards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775628837963,
       "tag": "0000_soft_killer_shrike",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1775960347684,
+      "tag": "0001_spicy_obadiah_stane",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,15 @@ const nextConfig: NextConfig = {
       bodySizeLimit: "50mb",
     },
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "www.jma.go.jp",
+        pathname: "/bosai/forecast/img/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { LayoutDashboard, MonitorPlay } from "lucide-react";
+import { LayoutDashboard, MonitorPlay, Settings } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 
 function SidebarLink({
@@ -41,6 +41,9 @@ export default function DashboardLayout({
         <nav className="flex-1 space-y-1 px-2 py-3">
           <SidebarLink href="/boards" icon={LayoutDashboard}>
             ボード管理
+          </SidebarLink>
+          <SidebarLink href="/settings" icon={Settings}>
+            設定
           </SidebarLink>
         </nav>
       </aside>

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,3 +1,10 @@
+import { SettingsClient } from "@/components/dashboard/SettingsClient";
+
 export default function SettingsPage() {
-  return <div>Settings</div>;
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">設定</h1>
+      <SettingsClient />
+    </div>
+  );
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { settings } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+/** GET /api/settings — get all settings as key-value object */
+export async function GET() {
+  const rows = await db.select().from(settings);
+  const result: Record<string, string> = {};
+  for (const row of rows) {
+    result[row.key] = row.value;
+  }
+  return NextResponse.json(result);
+}
+
+/** PATCH /api/settings — upsert settings { key: value, ... } */
+export async function PATCH(request: Request) {
+  const body = await request.json();
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const entries = Object.entries(body as Record<string, string>);
+  for (const [key, value] of entries) {
+    if (typeof key !== "string" || typeof value !== "string") continue;
+
+    const existing = await db
+      .select()
+      .from(settings)
+      .where(eq(settings.key, key))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .update(settings)
+        .set({ value })
+        .where(eq(settings.key, key));
+    } else {
+      await db.insert(settings).values({ key, value });
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { settings } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { DEFAULT_CITY_ID } from "@/lib/weather-areas";
+
+const WEATHER_API_BASE = "https://weather.tsukumijima.net/api/forecast/city";
+
+/** Allowed city ID pattern: 6-digit number */
+const CITY_ID_RE = /^\d{6}$/;
+
+/** In-memory cache for weather data */
+let weatherCache: { cityId: string; data: unknown; fetchedAt: number } | null =
+  null;
+const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+
+/** GET /api/weather — fetch today's weather for the configured city */
+export async function GET() {
+  // Get configured city from settings
+  const row = await db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, "weatherCityId"))
+    .limit(1);
+  const cityId = row[0]?.value ?? DEFAULT_CITY_ID;
+
+  if (!CITY_ID_RE.test(cityId)) {
+    return NextResponse.json(
+      { error: "Invalid city ID" },
+      { status: 400 },
+    );
+  }
+
+  // Return cache if valid
+  if (
+    weatherCache &&
+    weatherCache.cityId === cityId &&
+    Date.now() - weatherCache.fetchedAt < CACHE_TTL
+  ) {
+    return NextResponse.json(weatherCache.data);
+  }
+
+  try {
+    const res = await fetch(`${WEATHER_API_BASE}/${cityId}`, {
+      next: { revalidate: 1800 },
+    });
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Weather API error" },
+        { status: 502 },
+      );
+    }
+
+    const full = await res.json();
+
+    // Extract today's forecast only
+    const today = full.forecasts?.[0];
+    if (!today) {
+      return NextResponse.json(
+        { error: "No forecast data" },
+        { status: 502 },
+      );
+    }
+
+    const data = {
+      location: full.location,
+      telop: today.telop,
+      image: today.image,
+      chanceOfRain: today.chanceOfRain,
+      temperature: today.temperature,
+      date: today.date,
+    };
+
+    weatherCache = { cityId, data, fetchedAt: Date.now() };
+
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch weather" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 
 interface WeatherData {
+  location: { city: string; prefecture: string };
   telop: string;
   image: { url: string; title: string; width: number; height: number };
   chanceOfRain: {
@@ -21,18 +22,6 @@ interface WeatherData {
 interface WeatherDisplayProps {
   color?: string;
   bgOpacity?: number;
-}
-
-/** Get the current time slot label */
-function currentRainSlot(rain: WeatherData["chanceOfRain"]): {
-  label: string;
-  value: string;
-} {
-  const hour = new Date().getHours();
-  if (hour < 6) return { label: "0-6時", value: rain.T00_06 };
-  if (hour < 12) return { label: "6-12時", value: rain.T06_12 };
-  if (hour < 18) return { label: "12-18時", value: rain.T12_18 };
-  return { label: "18-24時", value: rain.T18_24 };
 }
 
 export function WeatherDisplay({
@@ -61,7 +50,7 @@ export function WeatherDisplay({
 
   if (!weather) return null;
 
-  const rain = currentRainSlot(weather.chanceOfRain);
+  const rain = weather.chanceOfRain;
 
   return (
     <div
@@ -84,12 +73,9 @@ export function WeatherDisplay({
       )}
 
       <div className="flex flex-col gap-0.5 text-sm leading-tight">
-        {/* Telop (e.g. 晴れ) */}
-        <span className="font-bold text-base">{weather.telop}</span>
-
-        {/* Chance of rain */}
-        <span className="opacity-80">
-          降水 {rain.label}: {rain.value}
+        {/* Location header */}
+        <span className="font-bold text-base">
+          {weather.location?.city ?? ""}の天気: {weather.telop}
         </span>
 
         {/* Temperature */}
@@ -105,6 +91,15 @@ export function WeatherDisplay({
               `最低 ${weather.temperature.min.celsius}°C`}
           </span>
         )}
+
+        {/* Chance of rain — all time slots */}
+        <div className="flex gap-2 opacity-80 text-xs">
+          <span>降水確率:</span>
+          <span>0-6時 {rain.T00_06}</span>
+          <span>6-12時 {rain.T06_12}</span>
+          <span>12-18時 {rain.T12_18}</span>
+          <span>18-24時 {rain.T18_24}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Image from "next/image";
+
+interface WeatherData {
+  telop: string;
+  image: { url: string; title: string; width: number; height: number };
+  chanceOfRain: {
+    T00_06: string;
+    T06_12: string;
+    T12_18: string;
+    T18_24: string;
+  };
+  temperature: {
+    min: { celsius: string | null };
+    max: { celsius: string | null };
+  };
+}
+
+interface WeatherDisplayProps {
+  color?: string;
+  bgOpacity?: number;
+}
+
+/** Get the current time slot label */
+function currentRainSlot(rain: WeatherData["chanceOfRain"]): {
+  label: string;
+  value: string;
+} {
+  const hour = new Date().getHours();
+  if (hour < 6) return { label: "0-6時", value: rain.T00_06 };
+  if (hour < 12) return { label: "6-12時", value: rain.T06_12 };
+  if (hour < 18) return { label: "12-18時", value: rain.T12_18 };
+  return { label: "18-24時", value: rain.T18_24 };
+}
+
+export function WeatherDisplay({
+  color = "#ffffff",
+  bgOpacity = 0.5,
+}: WeatherDisplayProps) {
+  const [weather, setWeather] = useState<WeatherData | null>(null);
+
+  const fetchWeather = useCallback(async () => {
+    try {
+      const res = await fetch("/api/weather");
+      if (!res.ok) return;
+      const data = await res.json();
+      setWeather(data);
+    } catch {
+      // silently ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchWeather();
+    // Refresh every 30 minutes
+    const interval = setInterval(fetchWeather, 30 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [fetchWeather]);
+
+  if (!weather) return null;
+
+  const rain = currentRainSlot(weather.chanceOfRain);
+
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl px-4 py-2"
+      style={{
+        backgroundColor: `rgba(0,0,0,${bgOpacity})`,
+        color,
+      }}
+    >
+      {/* Weather icon */}
+      {weather.image?.url && (
+        <Image
+          src={weather.image.url}
+          alt={weather.image.title || weather.telop}
+          width={50}
+          height={40}
+          className="shrink-0"
+          unoptimized
+        />
+      )}
+
+      <div className="flex flex-col gap-0.5 text-sm leading-tight">
+        {/* Telop (e.g. 晴れ) */}
+        <span className="font-bold text-base">{weather.telop}</span>
+
+        {/* Chance of rain */}
+        <span className="opacity-80">
+          降水 {rain.label}: {rain.value}
+        </span>
+
+        {/* Temperature */}
+        {(weather.temperature.max.celsius ||
+          weather.temperature.min.celsius) && (
+          <span className="opacity-80">
+            {weather.temperature.max.celsius &&
+              `最高 ${weather.temperature.max.celsius}°C`}
+            {weather.temperature.max.celsius &&
+              weather.temperature.min.celsius &&
+              " / "}
+            {weather.temperature.min.celsius &&
+              `最低 ${weather.temperature.min.celsius}°C`}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -51,6 +51,8 @@ export function WeatherDisplay({
   if (!weather) return null;
 
   const rain = weather.chanceOfRain;
+  /** "--%" → "0%" */
+  const r = (v: string) => (v === "--%" ? "0%" : v);
 
   return (
     <div
@@ -65,16 +67,16 @@ export function WeatherDisplay({
         <Image
           src={weather.image.url}
           alt={weather.image.title || weather.telop}
-          width={50}
-          height={40}
+          width={70}
+          height={56}
           className="shrink-0"
           unoptimized
         />
       )}
 
-      <div className="flex flex-col gap-0.5 text-sm leading-tight">
+      <div className="flex flex-col gap-1 text-base leading-snug">
         {/* Location header */}
-        <span className="font-bold text-base">
+        <span className="font-bold text-lg">
           {weather.location?.city ?? ""}の天気: {weather.telop}
         </span>
 
@@ -93,12 +95,12 @@ export function WeatherDisplay({
         )}
 
         {/* Chance of rain — all time slots */}
-        <div className="flex gap-2 opacity-80 text-xs">
+        <div className="flex gap-2 opacity-80 text-sm">
           <span>降水確率:</span>
-          <span>0-6時 {rain.T00_06}</span>
-          <span>6-12時 {rain.T06_12}</span>
-          <span>12-18時 {rain.T12_18}</span>
-          <span>18-24時 {rain.T18_24}</span>
+          <span>0-6時 {r(rain.T00_06)}</span>
+          <span>6-12時 {r(rain.T06_12)}</span>
+          <span>12-18時 {r(rain.T12_18)}</span>
+          <span>18-24時 {r(rain.T18_24)}</span>
         </div>
       </div>
     </div>

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -56,7 +56,7 @@ export function WeatherDisplay({
 
   return (
     <div
-      className="flex items-center gap-3 rounded-xl px-4 py-2"
+      className="flex items-center gap-4 rounded-xl px-5 py-3"
       style={{
         backgroundColor: `rgba(0,0,0,${bgOpacity})`,
         color,
@@ -67,16 +67,16 @@ export function WeatherDisplay({
         <Image
           src={weather.image.url}
           alt={weather.image.title || weather.telop}
-          width={70}
-          height={56}
+          width={90}
+          height={72}
           className="shrink-0"
           unoptimized
         />
       )}
 
-      <div className="flex flex-col gap-1 text-base leading-snug">
+      <div className="flex flex-col gap-1 text-lg leading-snug">
         {/* Location header */}
-        <span className="font-bold text-lg">
+        <span className="font-bold text-xl">
           {weather.location?.city ?? ""}の天気: {weather.telop}
         </span>
 
@@ -95,11 +95,14 @@ export function WeatherDisplay({
         )}
 
         {/* Chance of rain — all time slots */}
-        <div className="flex gap-2 opacity-80 text-sm">
+        <div className="flex items-center gap-1 opacity-80 text-base">
           <span>降水確率:</span>
           <span>0-6時 {r(rain.T00_06)}</span>
+          <span className="opacity-40">|</span>
           <span>6-12時 {r(rain.T06_12)}</span>
+          <span className="opacity-40">|</span>
           <span>12-18時 {r(rain.T12_18)}</span>
+          <span className="opacity-40">|</span>
           <span>18-24時 {r(rain.T18_24)}</span>
         </div>
       </div>

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -53,15 +53,6 @@ const positionClasses: Record<ClockPosition, string> = {
   center: "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
 };
 
-/** Weather widget position — placed opposite the clock to avoid overlap */
-const weatherPositionClasses: Record<ClockPosition, string> = {
-  "top-left": "top-6 right-6",
-  "top-right": "top-6 left-6",
-  "bottom-left": "top-6 left-6",
-  "bottom-right": "top-6 left-6",
-  center: "top-6 left-6",
-};
-
 export default function PhotoClockBoard({
   board,
   mediaItems,
@@ -77,9 +68,9 @@ export default function PhotoClockBoard({
       {/* Full-screen slideshow */}
       <MediaSlider mediaItems={sorted} interval={config.slideInterval} />
 
-      {/* Clock overlay */}
+      {/* Clock + Weather overlay */}
       <div
-        className={`absolute z-10 ${positionClasses[config.clockPosition] ?? positionClasses["bottom-right"]}`}
+        className={`absolute z-10 flex flex-col gap-2 ${positionClasses[config.clockPosition] ?? positionClasses["bottom-right"]}`}
       >
         <DateTimeClock
           is24Hour={config.is24Hour}
@@ -88,19 +79,13 @@ export default function PhotoClockBoard({
           bgOpacity={config.clockBgOpacity}
           layout={config.clockLayout}
         />
-      </div>
-
-      {/* Weather overlay */}
-      {config.showWeather && (
-        <div
-          className={`absolute z-10 ${weatherPositionClasses[config.clockPosition] ?? weatherPositionClasses["bottom-right"]}`}
-        >
+        {config.showWeather && (
           <WeatherDisplay
             color={config.clockColor}
             bgOpacity={config.clockBgOpacity}
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -2,6 +2,7 @@
 
 import { MediaSlider } from "@/components/board/MediaSlider";
 import { DateTimeClock } from "@/components/board/DateTimeClock";
+import { WeatherDisplay } from "@/components/board/WeatherDisplay";
 import type { ClockLayout } from "@/components/board/DateTimeClock";
 import type { BoardTemplateProps } from "@/types";
 
@@ -21,6 +22,7 @@ export const photoClockDefaultConfig = {
   clockBgOpacity: 0.5,
   clockLayout: "standard" as ClockLayout,
   is24Hour: true,
+  showWeather: false,
 };
 
 type PhotoClockConfig = typeof photoClockDefaultConfig;
@@ -51,6 +53,15 @@ const positionClasses: Record<ClockPosition, string> = {
   center: "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
 };
 
+/** Weather widget position — placed opposite the clock to avoid overlap */
+const weatherPositionClasses: Record<ClockPosition, string> = {
+  "top-left": "top-6 right-6",
+  "top-right": "top-6 left-6",
+  "bottom-left": "top-6 left-6",
+  "bottom-right": "top-6 left-6",
+  center: "top-6 left-6",
+};
+
 export default function PhotoClockBoard({
   board,
   mediaItems,
@@ -78,6 +89,18 @@ export default function PhotoClockBoard({
           layout={config.clockLayout}
         />
       </div>
+
+      {/* Weather overlay */}
+      {config.showWeather && (
+        <div
+          className={`absolute z-10 ${weatherPositionClasses[config.clockPosition] ?? weatherPositionClasses["bottom-right"]}`}
+        >
+          <WeatherDisplay
+            color={config.clockColor}
+            bgOpacity={config.clockBgOpacity}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -269,7 +269,8 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
             </CardContent>
           </Card>
 
-          {/* Messages */}
+          {/* Messages (not used by photo-clock template) */}
+          {board.templateId !== "photo-clock" && (
           <Card>
             <CardHeader>
               <CardTitle>メッセージ</CardTitle>
@@ -390,6 +391,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
               )}
             </CardContent>
           </Card>
+          )}
 
           {/* Media items */}
           <Card>

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
+import type { WeatherPrefecture } from "@/lib/weather-areas";
+
+export function SettingsClient() {
+  const [cityId, setCityId] = useState(DEFAULT_CITY_ID);
+  const [selectedPref, setSelectedPref] = useState<WeatherPrefecture | null>(
+    null,
+  );
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // Load current settings
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/settings");
+        if (!res.ok) return;
+        const data = await res.json();
+        const saved = data.weatherCityId ?? DEFAULT_CITY_ID;
+        setCityId(saved);
+        // Find the prefecture for the saved city
+        const pref = WEATHER_AREAS.find((p) =>
+          p.cities.some((c) => c.id === saved),
+        );
+        if (pref) setSelectedPref(pref);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  function handlePrefChange(prefName: string | null) {
+    if (!prefName) return;
+    const pref = WEATHER_AREAS.find((p) => p.name === prefName) ?? null;
+    setSelectedPref(pref);
+    // Auto-select first city
+    if (pref && pref.cities.length > 0) {
+      setCityId(pref.cities[0].id);
+    }
+    setSaved(false);
+  }
+
+  function handleCityChange(id: string | null) {
+    if (!id) return;
+    setCityId(id);
+    setSaved(false);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaved(false);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ weatherCityId: cityId }),
+      });
+      if (res.ok) setSaved(true);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const currentCity = WEATHER_AREAS.flatMap((p) => p.cities).find(
+    (c) => c.id === cityId,
+  );
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">読み込み中...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Weather Area Selection */}
+      <div className="rounded-lg border p-6">
+        <h2 className="mb-4 text-lg font-semibold">天気予報の地域設定</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          フォトクロックテンプレートの天気表示で使用する地域を設定します。
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {/* Prefecture selector */}
+          <div className="space-y-1.5">
+            <Label htmlFor="setting-pref">都道府県</Label>
+            <Select
+              value={selectedPref?.name ?? ""}
+              onValueChange={handlePrefChange}
+            >
+              <SelectTrigger id="setting-pref" className="w-full">
+                <SelectValue placeholder="都道府県を選択">
+                  {selectedPref?.name ?? "都道府県を選択"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {WEATHER_AREAS.map((pref) => (
+                  <SelectItem key={pref.name} value={pref.name}>
+                    {pref.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* City selector */}
+          <div className="space-y-1.5">
+            <Label htmlFor="setting-city">地域</Label>
+            <Select
+              value={cityId}
+              onValueChange={handleCityChange}
+              disabled={!selectedPref}
+            >
+              <SelectTrigger id="setting-city" className="w-full">
+                <SelectValue placeholder="地域を選択">
+                  {currentCity?.name ?? "地域を選択"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {selectedPref?.cities.map((city) => (
+                  <SelectItem key={city.id} value={city.id}>
+                    {city.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-center gap-3">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "保存中..." : "保存"}
+          </Button>
+          {saved && (
+            <span className="text-sm text-green-600">保存しました</span>
+          )}
+        </div>
+
+        {currentCity && (
+          <p className="mt-3 text-sm text-muted-foreground">
+            現在の設定: {selectedPref?.name} {currentCity.name}（コード:{" "}
+            {cityId}）
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -27,6 +27,7 @@ export function PhotoClockConfigEditor({
   const clockBgOpacity = (config.clockBgOpacity as number) ?? 0.5;
   const clockLayout = (config.clockLayout as string) ?? "standard";
   const is24Hour = (config.is24Hour as boolean) ?? true;
+  const showWeather = (config.showWeather as boolean) ?? false;
 
   const positionLabels: Record<string, string> = {
     "top-left": "左上",
@@ -156,6 +157,20 @@ export function PhotoClockConfigEditor({
         />
         <Label htmlFor="cfg-24h">24時間表示（OFFで12時間+AM/PM表記）</Label>
       </div>
+
+      <div className="flex items-center gap-3">
+        <Switch
+          id="cfg-weather"
+          checked={showWeather}
+          onCheckedChange={(v) => update("showWeather", v)}
+        />
+        <Label htmlFor="cfg-weather">天気予報を表示</Label>
+      </div>
+      {showWeather && (
+        <p className="text-xs text-muted-foreground">
+          表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
+        </p>
+      )}
     </div>
   );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,3 +57,12 @@ export const messages = sqliteTable("messages", {
     .default(sql`(datetime('now'))`)
     .$onUpdate(() => new Date().toISOString()),
 });
+
+export const settings = sqliteTable("settings", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`)
+    .$onUpdate(() => new Date().toISOString()),
+});

--- a/src/lib/weather-areas.ts
+++ b/src/lib/weather-areas.ts
@@ -1,0 +1,406 @@
+/** Weather area data from https://weather.tsukumijima.net/primary_area.xml */
+
+export interface WeatherCity {
+  id: string;
+  name: string;
+}
+
+export interface WeatherPrefecture {
+  name: string;
+  cities: WeatherCity[];
+}
+
+/** All prefectures and cities supported by the weather API */
+export const WEATHER_AREAS: WeatherPrefecture[] = [
+  {
+    name: "道北",
+    cities: [
+      { id: "011000", name: "稚内" },
+      { id: "012010", name: "旭川" },
+      { id: "012020", name: "留萌" },
+    ],
+  },
+  {
+    name: "道東",
+    cities: [
+      { id: "013010", name: "網走" },
+      { id: "013020", name: "北見" },
+      { id: "013030", name: "紋別" },
+      { id: "014010", name: "根室" },
+      { id: "014020", name: "釧路" },
+      { id: "014030", name: "帯広" },
+    ],
+  },
+  {
+    name: "道南",
+    cities: [
+      { id: "015010", name: "室蘭" },
+      { id: "015020", name: "浦河" },
+      { id: "017010", name: "函館" },
+      { id: "017020", name: "江差" },
+    ],
+  },
+  {
+    name: "道央",
+    cities: [
+      { id: "016010", name: "札幌" },
+      { id: "016020", name: "岩見沢" },
+      { id: "016030", name: "倶知安" },
+    ],
+  },
+  {
+    name: "青森県",
+    cities: [
+      { id: "020010", name: "青森" },
+      { id: "020020", name: "むつ" },
+      { id: "020030", name: "八戸" },
+    ],
+  },
+  {
+    name: "岩手県",
+    cities: [
+      { id: "030010", name: "盛岡" },
+      { id: "030020", name: "宮古" },
+      { id: "030030", name: "大船渡" },
+    ],
+  },
+  {
+    name: "宮城県",
+    cities: [
+      { id: "040010", name: "仙台" },
+      { id: "040020", name: "白石" },
+    ],
+  },
+  {
+    name: "秋田県",
+    cities: [
+      { id: "050010", name: "秋田" },
+      { id: "050020", name: "横手" },
+    ],
+  },
+  {
+    name: "山形県",
+    cities: [
+      { id: "060010", name: "山形" },
+      { id: "060020", name: "米沢" },
+      { id: "060030", name: "酒田" },
+      { id: "060040", name: "新庄" },
+    ],
+  },
+  {
+    name: "福島県",
+    cities: [
+      { id: "070010", name: "福島" },
+      { id: "070020", name: "小名浜" },
+      { id: "070030", name: "若松" },
+    ],
+  },
+  {
+    name: "茨城県",
+    cities: [
+      { id: "080010", name: "水戸" },
+      { id: "080020", name: "土浦" },
+    ],
+  },
+  {
+    name: "栃木県",
+    cities: [
+      { id: "090010", name: "宇都宮" },
+      { id: "090020", name: "大田原" },
+    ],
+  },
+  {
+    name: "群馬県",
+    cities: [
+      { id: "100010", name: "前橋" },
+      { id: "100020", name: "みなかみ" },
+    ],
+  },
+  {
+    name: "埼玉県",
+    cities: [
+      { id: "110010", name: "さいたま" },
+      { id: "110020", name: "熊谷" },
+      { id: "110030", name: "秩父" },
+    ],
+  },
+  {
+    name: "千葉県",
+    cities: [
+      { id: "120010", name: "千葉" },
+      { id: "120020", name: "銚子" },
+      { id: "120030", name: "館山" },
+    ],
+  },
+  {
+    name: "東京都",
+    cities: [
+      { id: "130010", name: "東京" },
+      { id: "130020", name: "大島" },
+      { id: "130030", name: "八丈島" },
+      { id: "130040", name: "父島" },
+    ],
+  },
+  {
+    name: "神奈川県",
+    cities: [
+      { id: "140010", name: "横浜" },
+      { id: "140020", name: "小田原" },
+    ],
+  },
+  {
+    name: "新潟県",
+    cities: [
+      { id: "150010", name: "新潟" },
+      { id: "150020", name: "長岡" },
+      { id: "150030", name: "高田" },
+      { id: "150040", name: "相川" },
+    ],
+  },
+  {
+    name: "富山県",
+    cities: [
+      { id: "160010", name: "富山" },
+      { id: "160020", name: "伏木" },
+    ],
+  },
+  {
+    name: "石川県",
+    cities: [
+      { id: "170010", name: "金沢" },
+      { id: "170020", name: "輪島" },
+    ],
+  },
+  {
+    name: "福井県",
+    cities: [
+      { id: "180010", name: "福井" },
+      { id: "180020", name: "敦賀" },
+    ],
+  },
+  {
+    name: "山梨県",
+    cities: [
+      { id: "190010", name: "甲府" },
+      { id: "190020", name: "河口湖" },
+    ],
+  },
+  {
+    name: "長野県",
+    cities: [
+      { id: "200010", name: "長野" },
+      { id: "200020", name: "松本" },
+      { id: "200030", name: "飯田" },
+    ],
+  },
+  {
+    name: "岐阜県",
+    cities: [
+      { id: "210010", name: "岐阜" },
+      { id: "210020", name: "高山" },
+    ],
+  },
+  {
+    name: "静岡県",
+    cities: [
+      { id: "220010", name: "静岡" },
+      { id: "220020", name: "網代" },
+      { id: "220030", name: "三島" },
+      { id: "220040", name: "浜松" },
+    ],
+  },
+  {
+    name: "愛知県",
+    cities: [
+      { id: "230010", name: "名古屋" },
+      { id: "230020", name: "豊橋" },
+    ],
+  },
+  {
+    name: "三重県",
+    cities: [
+      { id: "240010", name: "津" },
+      { id: "240020", name: "尾鷲" },
+    ],
+  },
+  {
+    name: "滋賀県",
+    cities: [
+      { id: "250010", name: "大津" },
+      { id: "250020", name: "彦根" },
+    ],
+  },
+  {
+    name: "京都府",
+    cities: [
+      { id: "260010", name: "京都" },
+      { id: "260020", name: "舞鶴" },
+    ],
+  },
+  {
+    name: "大阪府",
+    cities: [{ id: "270000", name: "大阪" }],
+  },
+  {
+    name: "兵庫県",
+    cities: [
+      { id: "280010", name: "神戸" },
+      { id: "280020", name: "豊岡" },
+    ],
+  },
+  {
+    name: "奈良県",
+    cities: [
+      { id: "290010", name: "奈良" },
+      { id: "290020", name: "風屋" },
+    ],
+  },
+  {
+    name: "和歌山県",
+    cities: [
+      { id: "300010", name: "和歌山" },
+      { id: "300020", name: "潮岬" },
+    ],
+  },
+  {
+    name: "鳥取県",
+    cities: [
+      { id: "310010", name: "鳥取" },
+      { id: "310020", name: "米子" },
+    ],
+  },
+  {
+    name: "島根県",
+    cities: [
+      { id: "320010", name: "松江" },
+      { id: "320020", name: "浜田" },
+      { id: "320030", name: "西郷" },
+    ],
+  },
+  {
+    name: "岡山県",
+    cities: [
+      { id: "330010", name: "岡山" },
+      { id: "330020", name: "津山" },
+    ],
+  },
+  {
+    name: "広島県",
+    cities: [
+      { id: "340010", name: "広島" },
+      { id: "340020", name: "庄原" },
+    ],
+  },
+  {
+    name: "山口県",
+    cities: [
+      { id: "350010", name: "下関" },
+      { id: "350020", name: "山口" },
+      { id: "350030", name: "柳井" },
+      { id: "350040", name: "萩" },
+    ],
+  },
+  {
+    name: "徳島県",
+    cities: [
+      { id: "360010", name: "徳島" },
+      { id: "360020", name: "日和佐" },
+    ],
+  },
+  {
+    name: "香川県",
+    cities: [{ id: "370000", name: "高松" }],
+  },
+  {
+    name: "愛媛県",
+    cities: [
+      { id: "380010", name: "松山" },
+      { id: "380020", name: "新居浜" },
+      { id: "380030", name: "宇和島" },
+    ],
+  },
+  {
+    name: "高知県",
+    cities: [
+      { id: "390010", name: "高知" },
+      { id: "390020", name: "室戸岬" },
+      { id: "390030", name: "清水" },
+    ],
+  },
+  {
+    name: "福岡県",
+    cities: [
+      { id: "400010", name: "福岡" },
+      { id: "400020", name: "八幡" },
+      { id: "400030", name: "飯塚" },
+      { id: "400040", name: "久留米" },
+    ],
+  },
+  {
+    name: "佐賀県",
+    cities: [
+      { id: "410010", name: "佐賀" },
+      { id: "410020", name: "伊万里" },
+    ],
+  },
+  {
+    name: "長崎県",
+    cities: [
+      { id: "420010", name: "長崎" },
+      { id: "420020", name: "佐世保" },
+      { id: "420030", name: "厳原" },
+      { id: "420040", name: "福江" },
+    ],
+  },
+  {
+    name: "熊本県",
+    cities: [
+      { id: "430010", name: "熊本" },
+      { id: "430020", name: "阿蘇乙姫" },
+      { id: "430030", name: "牛深" },
+      { id: "430040", name: "人吉" },
+    ],
+  },
+  {
+    name: "大分県",
+    cities: [
+      { id: "440010", name: "大分" },
+      { id: "440020", name: "中津" },
+      { id: "440030", name: "日田" },
+      { id: "440040", name: "佐伯" },
+    ],
+  },
+  {
+    name: "宮崎県",
+    cities: [
+      { id: "450010", name: "宮崎" },
+      { id: "450020", name: "延岡" },
+      { id: "450030", name: "都城" },
+      { id: "450040", name: "高千穂" },
+    ],
+  },
+  {
+    name: "鹿児島県",
+    cities: [
+      { id: "460010", name: "鹿児島" },
+      { id: "460020", name: "鹿屋" },
+      { id: "460030", name: "種子島" },
+      { id: "460040", name: "名瀬" },
+    ],
+  },
+  {
+    name: "沖縄県",
+    cities: [
+      { id: "471010", name: "那覇" },
+      { id: "471020", name: "名護" },
+      { id: "471030", name: "久米島" },
+      { id: "472000", name: "南大東" },
+      { id: "473000", name: "宮古島" },
+      { id: "474010", name: "石垣島" },
+      { id: "474020", name: "与那国島" },
+    ],
+  },
+];
+
+/** Default city ID (東京都東京) */
+export const DEFAULT_CITY_ID = "130010";


### PR DESCRIPTION
## 概要

フォトクロックテンプレートに天気予報表示機能を追加しました。

[天気予報 API（livedoor 天気互換）](https://weather.tsukumijima.net/) を利用し、今日の天気をオーバーレイ表示します。

## 新機能

### 天気予報表示（PhotoClock テンプレート）
- 天気アイコン（気象庁SVG）
- 天気テロップ（晴れ、曇り等）
- 現在の時間帯の降水確率
- 最高/最低気温
- 時計の反対側に自動配置

### 共通設定ページ
- サイドバーに「設定」リンク追加
- 都道府県 → 地域のカスケード選択
- 全国 142 地域をサポート
- デフォルト: 東京都東京 (130010)

### Weather API プロキシ
- `GET /api/weather` — 天気データ取得
- 30分のサーバーサイドキャッシュ
- 今日の天気データのみ返却

### Settings API
- `GET /api/settings` — 全設定取得
- `PATCH /api/settings` — 設定更新（upsert）
- `settings` テーブル（key-value形式）追加

## 仕様

- 天気表示はデフォルト **OFF**（ボード設定で有効化）
- 地域設定は設定ページから全ボード共通で変更
- 天気データは30分間キャッシュ（API負荷軽減）
- 外部画像: `www.jma.go.jp` の天気アイコンを `next.config.ts` で許可

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/lib/weather-areas.ts` | 全国都道府県・地域コードデータ（142地域） |
| `src/app/api/weather/route.ts` | 天気APIプロキシ（30分キャッシュ） |
| `src/app/api/settings/route.ts` | 共通設定API（GET/PATCH） |
| `src/components/board/WeatherDisplay.tsx` | 天気表示オーバーレイコンポーネント |
| `src/components/dashboard/SettingsClient.tsx` | 設定ページUI（地域選択） |
| `src/db/schema.ts` | `settings` テーブル追加 |
| `drizzle/0001_spicy_obadiah_stane.sql` | マイグレーション |
| `src/components/board/templates/PhotoClockBoard.tsx` | `showWeather` 設定追加 |
| `src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx` | 天気表示トグル追加 |
| `src/app/(dashboard)/layout.tsx` | サイドバーに設定リンク追加 |
| `src/app/(dashboard)/settings/page.tsx` | 設定ページ実装 |
| `next.config.ts` | jma.go.jp 画像許可 |
| `README.md` | 天気予報API謝辞追記 |

Closes #25