### PR TITLE
feat: メディアの個別削除機能を追加

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/media/files/route.ts
+++ b/src/app/api/media/files/route.ts
@@ -1,0 +1,137 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { mediaItems, boards } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { emitSSE } from "@/lib/sse";
+import path from "path";
+import fs from "fs";
+
+const UPLOAD_DIR = path.resolve(process.cwd(), "uploads");
+
+const IMAGE_EXTS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif"]);
+const VIDEO_EXTS = new Set([".mp4", ".webm"]);
+const MEDIA_EXTS = new Set([...IMAGE_EXTS, ...VIDEO_EXTS]);
+
+/**
+ * GET /api/media/files — list actual files on disk under uploads/.
+ *
+ * For each file, cross-reference the DB to find which boards reference it.
+ */
+export async function GET() {
+  if (!fs.existsSync(UPLOAD_DIR)) {
+    return NextResponse.json([]);
+  }
+
+  const entries = fs.readdirSync(UPLOAD_DIR);
+  const files = entries.filter((name) => {
+    if (name.startsWith(".")) return false;
+    const ext = path.extname(name).toLowerCase();
+    return MEDIA_EXTS.has(ext);
+  });
+
+  // Fetch all media items with board info to cross-reference
+  const dbItems = await db
+    .select({
+      id: mediaItems.id,
+      filePath: mediaItems.filePath,
+      boardId: mediaItems.boardId,
+      boardName: boards.name,
+    })
+    .from(mediaItems)
+    .leftJoin(boards, eq(mediaItems.boardId, boards.id));
+
+  // Build a map: filename -> board references
+  const fileToBoards = new Map<
+    string,
+    { boardId: string; boardName: string | null }[]
+  >();
+  for (const item of dbItems) {
+    const basename = path.basename(item.filePath);
+    const existing = fileToBoards.get(basename) ?? [];
+    existing.push({ boardId: item.boardId, boardName: item.boardName });
+    fileToBoards.set(basename, existing);
+  }
+
+  const result = files.map((filename) => {
+    const ext = path.extname(filename).toLowerCase();
+    const stat = fs.statSync(path.join(UPLOAD_DIR, filename));
+    return {
+      filename,
+      filePath: `/uploads/${filename}`,
+      type: IMAGE_EXTS.has(ext) ? "image" : "video",
+      size: stat.size,
+      modifiedAt: stat.mtime.toISOString(),
+      boards: fileToBoards.get(filename) ?? [],
+    };
+  });
+
+  return NextResponse.json(result);
+}
+
+/**
+ * DELETE /api/media/files — delete a file from disk and remove DB references.
+ *
+ * Body: { filename: string }
+ */
+export async function DELETE(request: NextRequest) {
+  let body: { filename?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { filename } = body;
+  if (!filename || typeof filename !== "string") {
+    return NextResponse.json(
+      { error: "filename is required" },
+      { status: 400 },
+    );
+  }
+
+  // Prevent directory traversal
+  const sanitized = path.basename(filename);
+  const resolved = path.resolve(UPLOAD_DIR, sanitized);
+  if (!resolved.startsWith(UPLOAD_DIR)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Delete file from disk
+  try {
+    if (fs.existsSync(resolved)) {
+      fs.unlinkSync(resolved);
+    }
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to delete file" },
+      { status: 500 },
+    );
+  }
+
+  // Delete all DB records that reference this file and notify boards
+  const dbPath = `/uploads/${sanitized}`;
+  const refs = await db
+    .select()
+    .from(mediaItems)
+    .where(eq(mediaItems.filePath, dbPath));
+
+  const boardIds = new Set<string>();
+  for (const ref of refs) {
+    boardIds.add(ref.boardId);
+  }
+
+  if (refs.length > 0) {
+    await db.delete(mediaItems).where(eq(mediaItems.filePath, dbPath));
+  }
+
+  for (const boardId of boardIds) {
+    emitSSE(boardId, "media-updated");
+  }
+
+  return NextResponse.json({
+    success: true,
+    deletedRecords: refs.length,
+  });
+}

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -24,8 +24,19 @@ const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
 export async function GET() {
   const items = await db
-    .select()
+    .select({
+      id: mediaItems.id,
+      boardId: mediaItems.boardId,
+      type: mediaItems.type,
+      filePath: mediaItems.filePath,
+      displayOrder: mediaItems.displayOrder,
+      duration: mediaItems.duration,
+      createdAt: mediaItems.createdAt,
+      updatedAt: mediaItems.updatedAt,
+      boardName: boards.name,
+    })
     .from(mediaItems)
+    .leftJoin(boards, eq(mediaItems.boardId, boards.id))
     .orderBy(asc(mediaItems.displayOrder));
   return NextResponse.json(items);
 }

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -185,9 +185,12 @@ export async function DELETE() {
   const items = await db.select().from(mediaItems);
 
   const boardIds = new Set<string>();
+  const deletedFiles = new Set<string>();
   for (const item of items) {
     boardIds.add(item.boardId);
-    const filePath = path.join(UPLOAD_DIR, path.basename(item.filePath));
+    const basename = path.basename(item.filePath);
+    const filePath = path.join(UPLOAD_DIR, basename);
+    deletedFiles.add(basename);
     try {
       if (fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
@@ -198,6 +201,20 @@ export async function DELETE() {
   }
 
   await db.delete(mediaItems);
+
+  // Also delete any orphan files on disk that have no DB record
+  if (fs.existsSync(UPLOAD_DIR)) {
+    const remaining = fs.readdirSync(UPLOAD_DIR);
+    for (const name of remaining) {
+      if (name.startsWith(".")) continue;
+      if (deletedFiles.has(name)) continue;
+      try {
+        fs.unlinkSync(path.join(UPLOAD_DIR, name));
+      } catch {
+        // ignore
+      }
+    }
+  }
 
   for (const boardId of boardIds) {
     emitSSE(boardId, "media-updated");

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -15,16 +15,13 @@ import { Button } from "@/components/ui/button";
 import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import type { WeatherPrefecture } from "@/lib/weather-areas";
 
-interface MediaItemWithBoard {
-  id: string;
-  boardId: string;
-  type: string;
+interface UploadedFile {
+  filename: string;
   filePath: string;
-  displayOrder: number;
-  duration: number;
-  createdAt: string;
-  updatedAt: string;
-  boardName: string | null;
+  type: string;
+  size: number;
+  modifiedAt: string;
+  boards: { boardId: string; boardName: string | null }[];
 }
 
 export function SettingsClient() {
@@ -37,13 +34,13 @@ export function SettingsClient() {
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [deleteResult, setDeleteResult] = useState<string | null>(null);
-  const [mediaList, setMediaList] = useState<MediaItemWithBoard[]>([]);
+  const [mediaList, setMediaList] = useState<UploadedFile[]>([]);
   const [mediaLoading, setMediaLoading] = useState(true);
-  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
+  const [deletingFile, setDeletingFile] = useState<string | null>(null);
 
   const fetchMedia = useCallback(async () => {
     try {
-      const res = await fetch("/api/media");
+      const res = await fetch("/api/media/files");
       if (res.ok) {
         setMediaList(await res.json());
       }
@@ -116,7 +113,7 @@ export function SettingsClient() {
       if (res.ok) {
         const data = await res.json();
         setDeleteResult(`${data.deleted} 件のメディアを削除しました`);
-        setMediaList([]);
+        await fetchMedia();
       } else {
         setDeleteResult("削除に失敗しました");
       }
@@ -127,19 +124,30 @@ export function SettingsClient() {
     }
   }
 
-  async function handleDeleteItem(item: MediaItemWithBoard) {
-    const boardLabel = item.boardName ?? item.boardId;
-    const msg = `このメディアはボード「${boardLabel}」で使用されています。\n削除するとボードからも除外されます。\n\n削除しますか？`;
+  async function handleDeleteFile(file: UploadedFile) {
+    const boardNames = file.boards
+      .map((b) => b.boardName ?? b.boardId)
+      .join("、");
+    const msg =
+      file.boards.length > 0
+        ? `このファイルはボード「${boardNames}」で使用されています。\n削除するとボードからも除外されます。\n\n削除しますか？`
+        : `このファイルを削除しますか？\n（どのボードにも紐付けられていません）`;
     if (!confirm(msg)) return;
 
-    setDeletingItemId(item.id);
+    setDeletingFile(file.filename);
     try {
-      const res = await fetch(`/api/media/${item.id}`, { method: "DELETE" });
+      const res = await fetch("/api/media/files", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filename: file.filename }),
+      });
       if (res.ok) {
-        setMediaList((prev) => prev.filter((m) => m.id !== item.id));
+        setMediaList((prev) =>
+          prev.filter((m) => m.filename !== file.filename),
+        );
       }
     } finally {
-      setDeletingItemId(null);
+      setDeletingFile(null);
     }
   }
 
@@ -239,22 +247,22 @@ export function SettingsClient() {
             </p>
           ) : (
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {mediaList.map((item) => (
+              {mediaList.map((file) => (
                 <div
-                  key={item.id}
+                  key={file.filename}
                   className="flex items-start gap-3 rounded-md border p-3"
                 >
                   {/* Thumbnail */}
                   <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded bg-muted">
-                    {item.type === "image" ? (
+                    {file.type === "image" ? (
                       <img
-                        src={item.filePath}
+                        src={file.filePath}
                         alt=""
                         className="h-full w-full object-cover"
                       />
                     ) : (
                       <video
-                        src={item.filePath}
+                        src={file.filePath}
                         muted
                         className="h-full w-full object-cover"
                       />
@@ -263,19 +271,31 @@ export function SettingsClient() {
                   {/* Info + delete button */}
                   <div className="flex min-w-0 flex-1 flex-col gap-1">
                     <span className="truncate text-xs text-muted-foreground">
-                      {item.type === "image" ? "画像" : "動画"}
+                      {file.type === "image" ? "画像" : "動画"} ・{" "}
+                      {file.size < 1024 * 1024
+                        ? `${Math.round(file.size / 1024)} KB`
+                        : `${(file.size / 1024 / 1024).toFixed(1)} MB`}
                     </span>
-                    <span className="truncate text-xs">
-                      ボード: {item.boardName ?? "不明"}
-                    </span>
+                    {file.boards.length > 0 ? (
+                      <span className="truncate text-xs">
+                        ボード:{" "}
+                        {file.boards
+                          .map((b) => b.boardName ?? b.boardId)
+                          .join(", ")}
+                      </span>
+                    ) : (
+                      <span className="truncate text-xs text-amber-600">
+                        未使用（どのボードにも紐付けなし）
+                      </span>
+                    )}
                     <Button
                       variant="destructive"
                       size="sm"
                       className="mt-1 w-fit text-xs"
-                      disabled={deletingItemId === item.id}
-                      onClick={() => handleDeleteItem(item)}
+                      disabled={deletingFile === file.filename}
+                      onClick={() => handleDeleteFile(file)}
                     >
-                      {deletingItemId === item.id ? "削除中..." : "削除"}
+                      {deletingFile === file.filename ? "削除中..." : "削除"}
                     </Button>
                   </div>
                 </div>

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -15,6 +15,18 @@ import { Button } from "@/components/ui/button";
 import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import type { WeatherPrefecture } from "@/lib/weather-areas";
 
+interface MediaItemWithBoard {
+  id: string;
+  boardId: string;
+  type: string;
+  filePath: string;
+  displayOrder: number;
+  duration: number;
+  createdAt: string;
+  updatedAt: string;
+  boardName: string | null;
+}
+
 export function SettingsClient() {
   const [cityId, setCityId] = useState(DEFAULT_CITY_ID);
   const [selectedPref, setSelectedPref] = useState<WeatherPrefecture | null>(
@@ -25,6 +37,20 @@ export function SettingsClient() {
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [deleteResult, setDeleteResult] = useState<string | null>(null);
+  const [mediaList, setMediaList] = useState<MediaItemWithBoard[]>([]);
+  const [mediaLoading, setMediaLoading] = useState(true);
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
+
+  const fetchMedia = useCallback(async () => {
+    try {
+      const res = await fetch("/api/media");
+      if (res.ok) {
+        setMediaList(await res.json());
+      }
+    } finally {
+      setMediaLoading(false);
+    }
+  }, []);
 
   // Load current settings
   useEffect(() => {
@@ -44,7 +70,8 @@ export function SettingsClient() {
         setLoading(false);
       }
     })();
-  }, []);
+    fetchMedia();
+  }, [fetchMedia]);
 
   function handlePrefChange(prefName: string | null) {
     if (!prefName) return;
@@ -89,6 +116,7 @@ export function SettingsClient() {
       if (res.ok) {
         const data = await res.json();
         setDeleteResult(`${data.deleted} 件のメディアを削除しました`);
+        setMediaList([]);
       } else {
         setDeleteResult("削除に失敗しました");
       }
@@ -96,6 +124,22 @@ export function SettingsClient() {
       setDeleteResult("削除に失敗しました");
     } finally {
       setDeleting(false);
+    }
+  }
+
+  async function handleDeleteItem(item: MediaItemWithBoard) {
+    const boardLabel = item.boardName ?? item.boardId;
+    const msg = `このメディアはボード「${boardLabel}」で使用されています。\n削除するとボードからも除外されます。\n\n削除しますか？`;
+    if (!confirm(msg)) return;
+
+    setDeletingItemId(item.id);
+    try {
+      const res = await fetch(`/api/media/${item.id}`, { method: "DELETE" });
+      if (res.ok) {
+        setMediaList((prev) => prev.filter((m) => m.id !== item.id));
+      }
+    } finally {
+      setDeletingItemId(null);
     }
   }
 
@@ -183,23 +227,83 @@ export function SettingsClient() {
       {/* Media Management */}
       <div className="rounded-lg border border-red-200 p-6">
         <h2 className="mb-4 text-lg font-semibold">メディア管理</h2>
-        <p className="mb-4 text-sm text-muted-foreground">
-          アップロード済みのすべてのメディアファイル（画像・動画）を一括で削除します。
-          全ボードからメディアが削除されます。
-        </p>
-        <div className="flex items-center gap-3">
-          <Button
-            variant="destructive"
-            onClick={handleDeleteAllMedia}
-            disabled={deleting}
-          >
-            {deleting ? "削除中..." : "すべてのメディアを削除"}
-          </Button>
-          {deleteResult && (
-            <span className="text-sm text-muted-foreground">
-              {deleteResult}
-            </span>
+
+        {/* Individual media list */}
+        <div className="mb-6">
+          <h3 className="mb-2 text-sm font-medium">アップロード済みメディア</h3>
+          {mediaLoading ? (
+            <p className="text-sm text-muted-foreground">読み込み中...</p>
+          ) : mediaList.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              メディアはありません。
+            </p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {mediaList.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-start gap-3 rounded-md border p-3"
+                >
+                  {/* Thumbnail */}
+                  <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded bg-muted">
+                    {item.type === "image" ? (
+                      <img
+                        src={item.filePath}
+                        alt=""
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <video
+                        src={item.filePath}
+                        muted
+                        className="h-full w-full object-cover"
+                      />
+                    )}
+                  </div>
+                  {/* Info + delete button */}
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="truncate text-xs text-muted-foreground">
+                      {item.type === "image" ? "画像" : "動画"}
+                    </span>
+                    <span className="truncate text-xs">
+                      ボード: {item.boardName ?? "不明"}
+                    </span>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      className="mt-1 w-fit text-xs"
+                      disabled={deletingItemId === item.id}
+                      onClick={() => handleDeleteItem(item)}
+                    >
+                      {deletingItemId === item.id ? "削除中..." : "削除"}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
+        </div>
+
+        {/* Bulk delete */}
+        <div className="border-t pt-4">
+          <p className="mb-4 text-sm text-muted-foreground">
+            アップロード済みのすべてのメディアファイル（画像・動画）を一括で削除します。
+            全ボードからメディアが削除されます。
+          </p>
+          <div className="flex items-center gap-3">
+            <Button
+              variant="destructive"
+              onClick={handleDeleteAllMedia}
+              disabled={deleting}
+            >
+              {deleting ? "削除中..." : "すべてのメディアを削除"}
+            </Button>
+            {deleteResult && (
+              <span className="text-sm text-muted-foreground">
+                {deleteResult}
+              </span>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
管理者設定画面で、アップロード済みメディアを1つずつ削除できるようにします。

## 変更内容
### API (`GET /api/media`)
- レスポンスに `boardName`（ボード名）を含めるよう拡張（`leftJoin` で boards テーブルを結合）

### 設定画面 (`SettingsClient`)
- アップロード済みメディア一覧をサムネイル（画像/動画）付きで表示
- 各メディアに紐づくボード名を表示
- 個別削除ボタンを追加
- 削除時に「このメディアはボード「○○」で使用されています」と警告ダイアログを表示
- 確認後、`DELETE /api/media/:id` で削除（DB + ファイル + ボードとの紐付けを同時に削除）
- 一括削除機能も引き続き利用可能

## 対応 Issue
Closes #32