### PR TITLE
feat: 画像リサイズ・サムネイル自動生成機能

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.2.0",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       shadcn:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@20.19.39)(typescript@5.9.3)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -4274,8 +4277,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -6864,7 +6866,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/app/api/media/[id]/route.ts
+++ b/src/app/api/media/[id]/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { mediaItems } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { emitSSE } from "@/lib/sse";
+import { deleteThumbnail } from "@/lib/image";
 import path from "path";
 import fs from "fs";
 
@@ -39,6 +40,9 @@ export async function DELETE(
   } catch {
     // File may already be deleted; continue with DB cleanup
   }
+
+  // Delete thumbnail
+  deleteThumbnail(path.basename(item.filePath));
 
   // Delete from DB
   await db.delete(mediaItems).where(eq(mediaItems.id, id));

--- a/src/app/api/media/files/route.ts
+++ b/src/app/api/media/files/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { mediaItems, boards } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { emitSSE } from "@/lib/sse";
+import { deleteThumbnail } from "@/lib/image";
 import path from "path";
 import fs from "fs";
 
@@ -26,7 +27,7 @@ export async function GET() {
 
   const entries = fs.readdirSync(UPLOAD_DIR);
   const files = entries.filter((name) => {
-    if (name.startsWith(".")) return false;
+    if (name.startsWith(".") || name === "thumbs") return false;
     const ext = path.extname(name).toLowerCase();
     return MEDIA_EXTS.has(ext);
   });
@@ -54,13 +55,27 @@ export async function GET() {
     fileToBoards.set(basename, existing);
   }
 
+  const thumbDir = path.join(UPLOAD_DIR, "thumbs");
   const result = files.map((filename) => {
     const ext = path.extname(filename).toLowerCase();
     const stat = fs.statSync(path.join(UPLOAD_DIR, filename));
+    const isImage = IMAGE_EXTS.has(ext);
+
+    // Determine thumbnail path (GIF thumbnails are stored as .jpg)
+    let thumbPath: string | null = null;
+    if (isImage) {
+      const thumbExt = ext === ".gif" ? ".jpg" : ext;
+      const thumbFilename = path.basename(filename, ext) + thumbExt;
+      if (fs.existsSync(path.join(thumbDir, thumbFilename))) {
+        thumbPath = `/uploads/thumbs/${thumbFilename}`;
+      }
+    }
+
     return {
       filename,
       filePath: `/uploads/${filename}`,
-      type: IMAGE_EXTS.has(ext) ? "image" : "video",
+      thumbPath,
+      type: isImage ? "image" : "video",
       size: stat.size,
       modifiedAt: stat.mtime.toISOString(),
       boards: fileToBoards.get(filename) ?? [],
@@ -109,6 +124,9 @@ export async function DELETE(request: NextRequest) {
       { status: 500 },
     );
   }
+
+  // Delete thumbnail
+  deleteThumbnail(sanitized);
 
   // Delete all DB records that reference this file and notify boards
   const dbPath = `/uploads/${sanitized}`;

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -2,10 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { mediaItems, boards } from "@/db/schema";
+import { mediaItems, boards, settings } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { updateMediaOrderSchema } from "@/lib/validators";
 import { emitSSE } from "@/lib/sse";
+import {
+  resizeImage,
+  generateThumbnail,
+  deleteThumbnail,
+  DEFAULT_IMAGE_MAX_LONG_EDGE,
+} from "@/lib/image";
 import path from "path";
 import fs from "fs";
 import { randomUUID } from "crypto";
@@ -106,8 +112,24 @@ export async function POST(request: NextRequest) {
   // Ensure upload directory exists
   fs.mkdirSync(UPLOAD_DIR, { recursive: true });
 
-  // Write file to disk
-  const buffer = Buffer.from(await file.arrayBuffer());
+  // Write file to disk (resize images if needed)
+  let buffer: Buffer = Buffer.from(await file.arrayBuffer());
+
+  if (mediaType === "image") {
+    // Read the max long edge setting
+    const maxSetting = await db.query.settings.findFirst({
+      where: eq(settings.key, "imageMaxLongEdge"),
+    });
+    const maxLongEdge = maxSetting
+      ? parseInt(maxSetting.value, 10)
+      : DEFAULT_IMAGE_MAX_LONG_EDGE;
+
+    buffer = Buffer.from(await resizeImage(buffer, sanitizedExt, maxLongEdge));
+
+    // Generate thumbnail
+    await generateThumbnail(buffer, filename);
+  }
+
   fs.writeFileSync(filePath, buffer);
 
   // Calculate display order (append at end)
@@ -198,6 +220,7 @@ export async function DELETE() {
     } catch {
       // continue even if file deletion fails
     }
+    deleteThumbnail(basename);
   }
 
   await db.delete(mediaItems);
@@ -206,14 +229,25 @@ export async function DELETE() {
   if (fs.existsSync(UPLOAD_DIR)) {
     const remaining = fs.readdirSync(UPLOAD_DIR);
     for (const name of remaining) {
-      if (name.startsWith(".")) continue;
+      if (name.startsWith(".") || name === "thumbs") continue;
       if (deletedFiles.has(name)) continue;
       try {
         fs.unlinkSync(path.join(UPLOAD_DIR, name));
       } catch {
         // ignore
       }
+      deleteThumbnail(name);
     }
+  }
+
+  // Clean up thumbs directory entirely
+  const thumbDir = path.join(UPLOAD_DIR, "thumbs");
+  try {
+    if (fs.existsSync(thumbDir)) {
+      fs.rmSync(thumbDir, { recursive: true });
+    }
+  } catch {
+    // ignore
   }
 
   for (const boardId of boardIds) {

--- a/src/components/dashboard/MediaUploadZone.tsx
+++ b/src/components/dashboard/MediaUploadZone.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { thumbUrl } from "@/lib/utils";
 import type { MediaItem } from "@/types";
 
 interface MediaUploadZoneProps {
@@ -265,9 +266,13 @@ export default function MediaUploadZone({
               <div className="relative size-12 shrink-0 overflow-hidden rounded border bg-muted">
                 {item.type === "image" ? (
                   <img
-                    src={item.filePath}
+                    src={thumbUrl(item.filePath)}
                     alt=""
                     className="size-full object-cover"
+                    onError={(e) => {
+                      // Fall back to full image if thumbnail not found
+                      (e.target as HTMLImageElement).src = item.filePath;
+                    }}
                   />
                 ) : (
                   <div className="flex size-full items-center justify-center">

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -12,12 +12,15 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import type { WeatherPrefecture } from "@/lib/weather-areas";
 
 interface UploadedFile {
   filename: string;
   filePath: string;
+  thumbPath: string | null;
   type: string;
   size: number;
   modifiedAt: string;
@@ -37,6 +40,10 @@ export function SettingsClient() {
   const [mediaList, setMediaList] = useState<UploadedFile[]>([]);
   const [mediaLoading, setMediaLoading] = useState(true);
   const [deletingFile, setDeletingFile] = useState<string | null>(null);
+  const [maxLongEdge, setMaxLongEdge] = useState(3840);
+  const [resizeEnabled, setResizeEnabled] = useState(true);
+  const [imageSaving, setImageSaving] = useState(false);
+  const [imageSaved, setImageSaved] = useState(false);
 
   const fetchMedia = useCallback(async () => {
     try {
@@ -63,6 +70,17 @@ export function SettingsClient() {
           p.cities.some((c) => c.id === saved),
         );
         if (pref) setSelectedPref(pref);
+        // Load image resize setting
+        if (data.imageMaxLongEdge !== undefined) {
+          const val = parseInt(data.imageMaxLongEdge, 10);
+          if (val === 0) {
+            setResizeEnabled(false);
+            setMaxLongEdge(3840);
+          } else {
+            setResizeEnabled(true);
+            setMaxLongEdge(val);
+          }
+        }
       } finally {
         setLoading(false);
       }
@@ -99,6 +117,22 @@ export function SettingsClient() {
       if (res.ok) setSaved(true);
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleImageSettingSave() {
+    setImageSaving(true);
+    setImageSaved(false);
+    try {
+      const value = resizeEnabled ? String(maxLongEdge) : "0";
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ imageMaxLongEdge: value }),
+      });
+      if (res.ok) setImageSaved(true);
+    } finally {
+      setImageSaving(false);
     }
   }
 
@@ -232,6 +266,62 @@ export function SettingsClient() {
         )}
       </div>
 
+      {/* Image Resize Settings */}
+      <div className="rounded-lg border p-6">
+        <h2 className="mb-4 text-lg font-semibold">画像リサイズ設定</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          アップロード時に画像の長辺を指定ピクセル数以下にリサイズします。
+          サムネイル（600px）も自動生成されます。
+        </p>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <Switch
+              id="resize-enabled"
+              checked={resizeEnabled}
+              onCheckedChange={setResizeEnabled}
+            />
+            <Label htmlFor="resize-enabled">リサイズを有効にする</Label>
+          </div>
+
+          {resizeEnabled && (
+            <div className="space-y-1.5">
+              <Label htmlFor="max-long-edge">長辺の最大ピクセル数</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="max-long-edge"
+                  type="number"
+                  min={100}
+                  step={100}
+                  value={maxLongEdge}
+                  onChange={(e) => {
+                    const v = parseInt(e.target.value, 10);
+                    if (v >= 100) setMaxLongEdge(v);
+                  }}
+                  className="w-32"
+                />
+                <span className="text-sm text-muted-foreground">px</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                デフォルト: 3840px（4K相当）
+              </p>
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <Button
+              onClick={handleImageSettingSave}
+              disabled={imageSaving}
+            >
+              {imageSaving ? "保存中..." : "保存"}
+            </Button>
+            {imageSaved && (
+              <span className="text-sm text-green-600">保存しました</span>
+            )}
+          </div>
+        </div>
+      </div>
+
       {/* Media Management */}
       <div className="rounded-lg border border-red-200 p-6">
         <h2 className="mb-4 text-lg font-semibold">メディア管理</h2>
@@ -256,7 +346,7 @@ export function SettingsClient() {
                   <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded bg-muted">
                     {file.type === "image" ? (
                       <img
-                        src={file.filePath}
+                        src={file.thumbPath ?? file.filePath}
                         alt=""
                         className="h-full w-full object-cover"
                       />

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import sharp from "sharp";
+import path from "path";
+import fs from "fs";
+
+const UPLOAD_DIR = path.resolve(process.cwd(), "uploads");
+const THUMB_DIR = path.join(UPLOAD_DIR, "thumbs");
+
+/** Default long-edge maximum (4K). 0 means no limit. */
+export const DEFAULT_IMAGE_MAX_LONG_EDGE = 3840;
+
+/** Thumbnail long-edge size. */
+export const THUMBNAIL_LONG_EDGE = 600;
+
+/**
+ * Resize an image so that its longest edge does not exceed `maxLongEdge`.
+ * If the image is already within the limit, the buffer is returned as-is.
+ * Returns the (possibly unchanged) buffer.
+ *
+ * GIF files are returned untouched to preserve animation.
+ */
+export async function resizeImage(
+  buffer: Buffer,
+  ext: string,
+  maxLongEdge: number,
+): Promise<Buffer> {
+  if (maxLongEdge <= 0) return buffer;
+  if (ext.toLowerCase() === ".gif") return buffer;
+
+  const image = sharp(buffer);
+  const metadata = await image.metadata();
+  const w = metadata.width ?? 0;
+  const h = metadata.height ?? 0;
+  const longEdge = Math.max(w, h);
+
+  if (longEdge <= maxLongEdge) return buffer;
+
+  const resized = image.resize({
+    width: w >= h ? maxLongEdge : undefined,
+    height: h > w ? maxLongEdge : undefined,
+    fit: "inside",
+    withoutEnlargement: true,
+  });
+
+  return await resized.toBuffer();
+}
+
+/**
+ * Generate a thumbnail (600px long edge) and save to uploads/thumbs/.
+ * Returns the public URL path of the thumbnail (e.g. `/uploads/thumbs/uuid.jpg`).
+ *
+ * GIF files get a static JPEG thumbnail (first frame).
+ */
+export async function generateThumbnail(
+  buffer: Buffer,
+  filename: string,
+): Promise<string> {
+  fs.mkdirSync(THUMB_DIR, { recursive: true });
+
+  const ext = path.extname(filename).toLowerCase();
+  // For GIF, generate a JPEG thumbnail from the first frame
+  const thumbExt = ext === ".gif" ? ".jpg" : ext;
+  const thumbFilename =
+    path.basename(filename, ext) + thumbExt;
+  const thumbPath = path.join(THUMB_DIR, thumbFilename);
+
+  let pipeline = sharp(buffer);
+
+  if (ext === ".gif") {
+    // Extract first frame and convert to JPEG
+    pipeline = pipeline.jpeg({ quality: 80 });
+  }
+
+  await pipeline
+    .resize({
+      width: THUMBNAIL_LONG_EDGE,
+      height: THUMBNAIL_LONG_EDGE,
+      fit: "inside",
+      withoutEnlargement: true,
+    })
+    .toFile(thumbPath);
+
+  return `/uploads/thumbs/${thumbFilename}`;
+}
+
+/**
+ * Delete a thumbnail for a given original filename, if it exists.
+ */
+export function deleteThumbnail(filename: string): void {
+  const ext = path.extname(filename).toLowerCase();
+  const thumbExt = ext === ".gif" ? ".jpg" : ext;
+  const thumbFilename = path.basename(filename, ext) + thumbExt;
+  const thumbPath = path.join(THUMB_DIR, thumbFilename);
+  try {
+    if (fs.existsSync(thumbPath)) {
+      fs.unlinkSync(thumbPath);
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,3 +6,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Derive the thumbnail URL from an original upload path.
+ * e.g. `/uploads/uuid.jpg` -> `/uploads/thumbs/uuid.jpg`
+ *      `/uploads/uuid.gif` -> `/uploads/thumbs/uuid.jpg` (GIF → JPEG thumb)
+ */
+export function thumbUrl(filePath: string): string {
+  const parts = filePath.split("/");
+  const filename = parts.pop() ?? "";
+  const dotIdx = filename.lastIndexOf(".");
+  const name = dotIdx >= 0 ? filename.slice(0, dotIdx) : filename;
+  const ext = dotIdx >= 0 ? filename.slice(dotIdx).toLowerCase() : "";
+  const thumbExt = ext === ".gif" ? ".jpg" : ext;
+  return `/uploads/thumbs/${name}${thumbExt}`;
+}


### PR DESCRIPTION
## 概要
画像アップロード時のリサイズ制限とサムネイル自動生成を追加します。

## 対応1: アップロード時の画像リサイズ
- `sharp` を使ったサーバーサイドリサイズ
- デフォルト: 長辺 3840px（4K相当）以下にリサイズ
- 管理者設定画面から最大値を変更可能
- リサイズ無効（制限なし）の設定も可能
- GIF はアニメーション維持のためリサイズ対象外

## 対応2: サムネイル自動生成
- アップロード時に 600px のサムネイルを `uploads/thumbs/` に自動生成
- **ダッシュボード**（MediaUploadZone, SettingsClient）ではサムネイルを表示
  - 既存画像はフォールバック（サムネイルがなければフルサイズを表示）
- **ボード表示**（MediaSlider）はフルサイズ画像のまま

## 変更ファイル
- `src/lib/image.ts` — 新規: `resizeImage()`, `generateThumbnail()`, `deleteThumbnail()`
- `src/lib/utils.ts` — `thumbUrl()` ヘルパー追加
- `src/app/api/media/route.ts` — POST でリサイズ+サムネイル生成, DELETE でサムネイル削除
- `src/app/api/media/[id]/route.ts` — DELETE でサムネイル削除
- `src/app/api/media/files/route.ts` — GET に `thumbPath` 追加, DELETE でサムネイル削除
- `src/components/dashboard/SettingsClient.tsx` — 画像リサイズ設定UI追加, サムネイル表示
- `src/components/dashboard/MediaUploadZone.tsx` — サムネイル表示

## 対応 Issue
Closes #31