### PR TITLE
feat: 管理者設定画面にSWバージョン情報を表示

### DIFF
--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+
+import { NextResponse } from "next/server";
+import packageJson from "../../../../package.json";
+
+const GITHUB_REPO = "HiroshiARAKI/e-web-board";
+
+export async function GET() {
+  const current = packageJson.version;
+  const releaseUrl = `https://github.com/${GITHUB_REPO}/releases/tag/v${current}`;
+
+  let latest: string | null = null;
+  let latestUrl: string | null = null;
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      {
+        headers: { Accept: "application/vnd.github.v3+json" },
+        next: { revalidate: 3600 },
+      },
+    );
+    if (res.ok) {
+      const data = await res.json();
+      const tag: string = data.tag_name ?? "";
+      latest = tag.replace(/^v/, "");
+      latestUrl = data.html_url ?? null;
+    }
+  } catch {
+    // GitHub API unavailable — ignore
+  }
+
+  const hasUpdate = latest ? isNewer(latest, current) : false;
+
+  return NextResponse.json({
+    current,
+    releaseUrl,
+    latest,
+    latestUrl,
+    hasUpdate,
+  });
+}
+
+/** Return true if `a` is semantically newer than `b` (semver compare). */
+function isNewer(a: string, b: string): boolean {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va > vb) return true;
+    if (va < vb) return false;
+  }
+  return false;
+}

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -27,6 +27,14 @@ interface UploadedFile {
   boards: { boardId: string; boardName: string | null }[];
 }
 
+interface VersionInfo {
+  current: string;
+  releaseUrl: string;
+  latest: string | null;
+  latestUrl: string | null;
+  hasUpdate: boolean;
+}
+
 export function SettingsClient() {
   const [cityId, setCityId] = useState(DEFAULT_CITY_ID);
   const [selectedPref, setSelectedPref] = useState<WeatherPrefecture | null>(
@@ -44,6 +52,7 @@ export function SettingsClient() {
   const [resizeEnabled, setResizeEnabled] = useState(true);
   const [imageSaving, setImageSaving] = useState(false);
   const [imageSaved, setImageSaved] = useState(false);
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
 
   const fetchMedia = useCallback(async () => {
     try {
@@ -86,6 +95,10 @@ export function SettingsClient() {
       }
     })();
     fetchMedia();
+    fetch("/api/version")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => { if (data) setVersionInfo(data); })
+      .catch(() => {});
   }, [fetchMedia]);
 
   function handlePrefChange(prefName: string | null) {
@@ -195,6 +208,39 @@ export function SettingsClient() {
 
   return (
     <div className="space-y-6">
+      {/* Version Info */}
+      {versionInfo && (
+        <div className="rounded-lg border p-6">
+          <h2 className="mb-4 text-lg font-semibold">バージョン情報</h2>
+          <div className="space-y-2">
+            <p className="text-sm">
+              現在のバージョン:{" "}
+              <a
+                href={versionInfo.releaseUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono font-semibold text-blue-600 hover:underline"
+              >
+                v{versionInfo.current}
+              </a>
+            </p>
+            {versionInfo.hasUpdate && versionInfo.latest && (
+              <p className="text-sm text-amber-600">
+                新しいバージョンがリリースされています:{" "}
+                <a
+                  href={versionInfo.latestUrl ?? versionInfo.releaseUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono font-semibold hover:underline"
+                >
+                  v{versionInfo.latest}
+                </a>
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Weather Area Selection */}
       <div className="rounded-lg border p-6">
         <h2 className="mb-4 text-lg font-semibold">天気予報の地域設定</h2>


### PR DESCRIPTION
# 管理者設定画面にSWバージョン情報を表示

close #34

## 変更内容

### `/api/version` エンドポイント追加
- `package.json` から現在のアプリバージョン（semVer）を取得
- GitHub Releases API (`repos/HiroshiARAKI/e-web-board/releases/latest`) で最新リリースを確認
- semver比較で更新の有無を判定
- レスポンス: `{ current, releaseUrl, latest, latestUrl, hasUpdate }`
- GitHub API の結果は1時間キャッシュ（`next.revalidate: 3600`）

### 管理者設定画面のUI追加
- 設定画面の最上部に「バージョン情報」セクションを表示
- 現在のバージョン番号をリリースノートページへのリンク付きで表示
- 新しいバージョンがリリースされている場合、`新しいバージョンがリリースされています: vX.Y.Z` と通知（amber色のテキスト）