### PR TITLE
feat: ボード表示画面に全画面表示・マウスカーソル自動非表示機能を追加

### DIFF
--- a/src/components/board/LiveBoard.tsx
+++ b/src/components/board/LiveBoard.tsx
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useSSE } from "@/hooks/useSSE";
 import type { Board, MediaItem, Message, BoardTemplateProps } from "@/types";
+
+const CURSOR_HIDE_DELAY = 3000;
 
 interface LiveBoardProps {
   board: Board;
@@ -27,7 +29,44 @@ export default function LiveBoard({
   const [board, setBoard] = useState(initialBoard);
   const [mediaItems, setMediaItems] = useState(initialMedia);
   const [messages, setMessages] = useState(initialMessages);
+  const [cursorVisible, setCursorVisible] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
+  // --- Cursor auto-hide ---
+  const resetCursorTimer = useCallback(() => {
+    setCursorVisible(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCursorVisible(false), CURSOR_HIDE_DELAY);
+  }, []);
+
+  useEffect(() => {
+    resetCursorTimer();
+    const onMove = () => resetCursorTimer();
+    window.addEventListener("mousemove", onMove);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [resetCursorTimer]);
+
+  // --- Fullscreen sync ---
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  const enterFullscreen = useCallback(() => {
+    containerRef.current?.requestFullscreen?.();
+  }, []);
+
+  const exitFullscreen = useCallback(() => {
+    if (document.fullscreenElement) document.exitFullscreen?.();
+  }, []);
+
+  // --- SSE live updates ---
   const refetchData = useCallback(async () => {
     try {
       const res = await fetch(`/api/boards/${initialBoard.id}`);
@@ -64,6 +103,27 @@ export default function LiveBoard({
   });
 
   return (
-    <TemplateComponent board={board} mediaItems={mediaItems} messages={messages} />
+    <div
+      ref={containerRef}
+      className="relative h-screen w-screen"
+      style={{ cursor: cursorVisible ? "auto" : "none" }}
+    >
+      <TemplateComponent board={board} mediaItems={mediaItems} messages={messages} />
+
+      {/* Expand / Restore button */}
+      <button
+        type="button"
+        onClick={isFullscreen ? exitFullscreen : enterFullscreen}
+        className="fixed bottom-4 left-4 z-50 rounded-md bg-black/50 px-3 py-1.5 text-xs text-white backdrop-blur transition-opacity hover:bg-black/70"
+        style={{
+          opacity: cursorVisible ? 1 : 0,
+          pointerEvents: cursorVisible ? "auto" : "none",
+          transition: "opacity 0.3s ease",
+        }}
+        title={isFullscreen ? "全画面を解除" : "全画面表示"}
+      >
+        {isFullscreen ? "⤓ 元に戻す" : "⤢ 全画面表示"}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
# ボード表示画面に全画面表示・マウスカーソル自動非表示機能を追加

close #37

## 変更内容

`LiveBoard.tsx` に以下の機能を追加:

### マウスカーソル自動非表示
- マウスを3秒間動かさないとカーソルが非表示になる
- マウスを動かすと即座に再表示される
- Netflix / Amazon Prime Video の視聴中UIと同様の挙動

### 全画面表示ボタン
- 画面左下にフロートする半透明ボタンを表示
- カーソルが非表示になるタイミングで同時にフェードアウト（`opacity` トランジション）
- クリックで Fullscreen API を呼び出し、アドレスバー・タブ・ブックマークバー等を非表示に

### 全画面解除ボタン
- 全画面中は「元に戻す」ボタンに切り替え
- 同様にカーソル非表示時にフェードアウト
- クリックまたは Esc キーで全画面を解除