### PR TITLE
feat: 全テンプレートに現在時刻・天気表示オプションを追加

### DIFF
--- a/src/components/board/templates/MessageBoard.tsx
+++ b/src/components/board/templates/MessageBoard.tsx
@@ -4,6 +4,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { DateTimeClock } from "@/components/board/DateTimeClock";
+import { WeatherDisplay } from "@/components/board/WeatherDisplay";
 import type { BoardTemplateProps, Message } from "@/types";
 
 /** Default config for the Message Board template */
@@ -13,6 +15,8 @@ export const messageBoardDefaultConfig = {
   backgroundColor: "#1e293b",
   textColor: "#f8fafc",
   accentColor: "#3b82f6",
+  showClock: false,
+  showWeather: false,
 };
 
 type MessageBoardConfig = typeof messageBoardDefaultConfig;
@@ -128,9 +132,19 @@ export default function MessageBoard({
         style={{ borderColor: config.accentColor + "40" }}
       >
         <h1 className="text-2xl font-bold">{board.name}</h1>
-        <div className="flex items-center gap-2 text-sm opacity-60">
-          <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-green-400" />
-          LIVE
+        <div className="flex items-center gap-4">
+          {config.showClock && (
+            <DateTimeClock
+              timeFontSize={20}
+              color={config.textColor}
+              bgOpacity={0}
+              layout="compact"
+            />
+          )}
+          <div className="flex items-center gap-2 text-sm opacity-60">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-green-400" />
+            LIVE
+          </div>
         </div>
       </div>
 
@@ -198,6 +212,16 @@ export default function MessageBoard({
           </AnimatePresence>
         )}
       </div>
+
+      {/* Weather bar */}
+      {config.showWeather && (
+        <div
+          className="border-t px-6 py-2"
+          style={{ borderColor: config.accentColor + "40" }}
+        >
+          <WeatherDisplay color={config.textColor} bgOpacity={0} />
+        </div>
+      )}
 
       {/* Footer */}
       <div

--- a/src/components/board/templates/RetroBoard.tsx
+++ b/src/components/board/templates/RetroBoard.tsx
@@ -4,6 +4,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { DateTimeClock } from "@/components/board/DateTimeClock";
+import { WeatherDisplay } from "@/components/board/WeatherDisplay";
 import type { BoardTemplateProps } from "@/types";
 
 /** Default config for the Retro Board template */
@@ -12,6 +14,8 @@ export const retroBoardDefaultConfig = {
   rows: 5,
   flipSpeed: 0.08,
   switchInterval: 5,
+  showClock: false,
+  showWeather: false,
 };
 
 type RetroBoardConfig = typeof retroBoardDefaultConfig;
@@ -148,13 +152,37 @@ export default function RetroBoard({
         >
           {board.name}
         </span>
-        <span
-          className="font-mono text-sm tracking-wider opacity-70"
-          style={{ color }}
-        >
-          ● LIVE
-        </span>
+        <div className="flex items-center gap-4">
+          <span
+            className="font-mono text-sm tracking-wider opacity-70"
+            style={{ color }}
+          >
+            ● LIVE
+          </span>
+        </div>
       </div>
+
+      {/* Clock & Weather bar */}
+      {(config.showClock || config.showWeather) && (
+        <div
+          className="flex items-center justify-between border-b px-6 py-1"
+          style={{ borderColor: color + "40" }}
+        >
+          <div className="flex-1">
+            {config.showWeather && (
+              <WeatherDisplay color={color} bgOpacity={0} />
+            )}
+          </div>
+          {config.showClock && (
+            <DateTimeClock
+              timeFontSize={18}
+              color={color}
+              bgOpacity={0}
+              layout="compact"
+            />
+          )}
+        </div>
+      )}
 
       {/* Message rows */}
       <div className="flex flex-1 flex-col justify-center">

--- a/src/components/board/templates/SimpleBoard.tsx
+++ b/src/components/board/templates/SimpleBoard.tsx
@@ -5,6 +5,8 @@
 import { MediaSlider } from "@/components/board/MediaSlider";
 import { TickerText } from "@/components/board/TickerText";
 import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
+import { DateTimeClock } from "@/components/board/DateTimeClock";
+import { WeatherDisplay } from "@/components/board/WeatherDisplay";
 import type { BoardTemplateProps } from "@/types";
 
 /** Default config for the Simple Board template */
@@ -15,6 +17,8 @@ export const simpleBoardDefaultConfig = {
   textColor: "#ffffff",
   tickerBgColor: "#1a1a2e",
   tickerFontFamily: "",
+  showClock: false,
+  showWeather: false,
 };
 
 type SimpleBoardConfig = typeof simpleBoardDefaultConfig;
@@ -46,8 +50,25 @@ export default function SimpleBoard({
         <GoogleFontLoader fonts={[config.tickerFontFamily]} />
       )}
       {/* Main area — slideshow */}
-      <div className="flex-1 min-h-0">
+      <div className="relative flex-1 min-h-0">
         <MediaSlider mediaItems={sorted} interval={config.slideInterval} />
+
+        {/* Clock & Weather overlay */}
+        {(config.showClock || config.showWeather) && (
+          <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
+            {config.showClock && (
+              <DateTimeClock
+                timeFontSize={36}
+                color="#ffffff"
+                bgOpacity={0.5}
+                layout="compact"
+              />
+            )}
+            {config.showWeather && (
+              <WeatherDisplay color="#ffffff" bgOpacity={0.5} />
+            )}
+          </div>
+        )}
       </div>
 
       {/* Bottom ticker */}

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -4,6 +4,7 @@
 
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 
 interface MessageBoardConfigEditorProps {
   config: Record<string, unknown>;
@@ -19,6 +20,8 @@ export function MessageBoardConfigEditor({
   const backgroundColor = (config.backgroundColor as string) ?? "#1e293b";
   const textColor = (config.textColor as string) ?? "#f8fafc";
   const accentColor = (config.accentColor as string) ?? "#3b82f6";
+  const showClock = (config.showClock as boolean) ?? false;
+  const showWeather = (config.showWeather as boolean) ?? false;
 
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
@@ -26,6 +29,29 @@ export function MessageBoardConfigEditor({
 
   return (
     <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Switch
+          id="cfg-showClock"
+          checked={showClock}
+          onCheckedChange={(v) => update("showClock", v)}
+        />
+        <Label htmlFor="cfg-showClock">現在時刻を表示</Label>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Switch
+          id="cfg-showWeather"
+          checked={showWeather}
+          onCheckedChange={(v) => update("showWeather", v)}
+        />
+        <Label htmlFor="cfg-showWeather">天気予報を表示</Label>
+      </div>
+      {showWeather && (
+        <p className="text-xs text-muted-foreground">
+          表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
+        </p>
+      )}
+
       <div className="space-y-1.5">
         <Label htmlFor="cfg-maxDisplay">最大表示件数</Label>
         <Input

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -4,6 +4,7 @@
 
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -25,6 +26,8 @@ export function RetroBoardConfigEditor({
   const rows = (config.rows as number) ?? 5;
   const flipSpeed = (config.flipSpeed as number) ?? 0.08;
   const switchInterval = (config.switchInterval as number) ?? 5;
+  const showClock = (config.showClock as boolean) ?? false;
+  const showWeather = (config.showWeather as boolean) ?? false;
 
   const colorLabels: Record<string, string> = {
     green: "グリーン",
@@ -112,6 +115,29 @@ export function RetroBoardConfigEditor({
           className="w-24"
         />
       </div>
+
+      <div className="flex items-center gap-3">
+        <Switch
+          id="cfg-showClock"
+          checked={showClock}
+          onCheckedChange={(v) => update("showClock", v)}
+        />
+        <Label htmlFor="cfg-showClock">現在時刻を表示</Label>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Switch
+          id="cfg-showWeather"
+          checked={showWeather}
+          onCheckedChange={(v) => update("showWeather", v)}
+        />
+        <Label htmlFor="cfg-showWeather">天気予報を表示</Label>
+      </div>
+      {showWeather && (
+        <p className="text-xs text-muted-foreground">
+          表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -4,6 +4,7 @@
 
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -61,6 +62,8 @@ export function SimpleBoardConfigEditor({
   const textColor = (config.textColor as string) ?? "#ffffff";
   const tickerBgColor = (config.tickerBgColor as string) ?? "#1a1a2e";
   const tickerFontFamily = (config.tickerFontFamily as string) ?? "";
+  const showClock = (config.showClock as boolean) ?? false;
+  const showWeather = (config.showWeather as boolean) ?? false;
 
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
@@ -76,6 +79,34 @@ export function SimpleBoardConfigEditor({
 
   return (
     <div className="space-y-6">
+      {/* Clock & Weather */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">時計・天気</h4>
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <Switch
+              id="cfg-showClock"
+              checked={showClock}
+              onCheckedChange={(v) => update("showClock", v)}
+            />
+            <Label htmlFor="cfg-showClock">現在時刻を表示</Label>
+          </div>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="cfg-showWeather"
+              checked={showWeather}
+              onCheckedChange={(v) => update("showWeather", v)}
+            />
+            <Label htmlFor="cfg-showWeather">天気予報を表示</Label>
+          </div>
+          {showWeather && (
+            <p className="text-xs text-muted-foreground">
+              表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
+            </p>
+          )}
+        </div>
+      </div>
+
       {/* Slideshow settings */}
       <div>
         <h4 className="mb-3 text-sm font-semibold">スライドショー</h4>


### PR DESCRIPTION
# 全テンプレートに現在時刻・天気表示オプションを追加

close #29

## 変更概要

フォトクロックテンプレートのみに提供されていた時刻表示・天気表示機能を、他の全テンプレートにも追加しました。デフォルトはOFFで、各ボードの設定エディタから個別に切り替え可能です。

## テンプレート別の表示デザイン

### シンプル掲示板 (SimpleBoard)
- 時計: スライドショー右上にオーバーレイ（コンパクトレイアウト、半透明黒背景）
- 天気: 時計の下にオーバーレイ

### メッセージ掲示板 (MessageBoard)
- 時計: ヘッダー右側にLIVEインジケーターと並べて表示（背景なし、テンプレートの文字色を使用）
- 天気: フッターの上に専用バーとして表示

### レトロ掲示板 (RetroBoard)
- 時計: ヘッダー右側にレトロカラー＋モノスペースで表示
- 天気: ヘッダー下に専用バーとして表示（レトロカラーに合わせた配色）

## 設定エディタの変更
各テンプレートの設定エディタに以下のトグルを追加:
- **現在時刻を表示** (`showClock`)
- **天気予報を表示** (`showWeather`)

天気予報ON時は設定ページへのリンクも表示されます。

## 変更ファイル
- `src/components/board/templates/SimpleBoard.tsx`
- `src/components/board/templates/MessageBoard.tsx`
- `src/components/board/templates/RetroBoard.tsx`
- `src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx`
- `src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx`
- `src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx`