### PR TITLE
fix: Docker ビルド時の SQLITE_BUSY エラーを修正

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,6 @@ RUN addgroup --system --gid 1001 nodejs && \
 # Copy standalone server
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
 
 # Copy drizzle migrations + migration runner
 COPY --from=builder /app/drizzle ./drizzle

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,13 +8,26 @@ import fs from "fs";
 
 const DB_PATH = path.resolve(process.cwd(), "data", "e-web-board.db");
 
-// Ensure data directory exists
-fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+type DbInstance = ReturnType<typeof drizzle<typeof schema>>;
 
-const sqlite = new Database(DB_PATH);
+let _db: DbInstance | undefined;
 
-// Enable WAL mode for better concurrent read performance
-sqlite.pragma("journal_mode = WAL");
-sqlite.pragma("foreign_keys = ON");
+function initDb(): DbInstance {
+  if (!_db) {
+    fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+    const sqlite = new Database(DB_PATH);
+    sqlite.pragma("journal_mode = WAL");
+    sqlite.pragma("busy_timeout = 5000");
+    sqlite.pragma("foreign_keys = ON");
+    _db = drizzle(sqlite, { schema });
+  }
+  return _db;
+}
 
-export const db = drizzle(sqlite, { schema });
+// Lazy proxy: DB connection is established on first access, not at import time.
+// This prevents SQLITE_BUSY errors when Next.js build workers evaluate modules concurrently.
+export const db: DbInstance = new Proxy({} as DbInstance, {
+  get(_, prop) {
+    return (initDb() as never)[prop];
+  },
+});


### PR DESCRIPTION
## 概要

`docker compose up -d` 実行時に `SqliteError: database is locked (SQLITE_BUSY)` でビルドが失敗する問題を修正します。

Closes #42

## 原因

`src/db/index.ts` がモジュール読み込み時（import 時）に即座に SQLite の接続を開いていたため、Next.js ビルド時に複数ワーカー（3 workers）が同時に同じ DB ファイルにアクセスし、ロック競合が発生。

## 修正内容

### 1. DB 接続の遅延初期化 (`src/db/index.ts`)
- `new Database()` をモジュール評価時ではなく、初回アクセス時に実行するよう Proxy パターンで遅延初期化に変更
- `busy_timeout = 5000` プラグマを追加し、万が一のロック競合時にも 5 秒間リトライ
- 既存コードの `import { db } from "@/db"` はそのまま動作（API 変更なし）

### 2. Dockerfile の修正 (`docker/Dockerfile`)
- `public/` ディレクトリが存在しないケースで `COPY --from=builder /app/public ./public` が失敗していたため、該当行を削除

## 検証

- [x] `pnpm build` — ローカルビルド成功
- [x] `docker compose build --no-cache` — Docker ビルド成功