### PR TITLE
feat: add objectFit (cover/contain) option for media display

### DIFF
--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -10,9 +10,11 @@ interface MediaSliderProps {
   mediaItems: MediaItem[];
   /** Interval between slides in seconds (default from board config) */
   interval?: number;
+  /** How media fits the container: "contain" (show all) or "cover" (fill, may crop) */
+  objectFit?: "contain" | "cover";
 }
 
-export function MediaSlider({ mediaItems, interval = 5 }: MediaSliderProps) {
+export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }: MediaSliderProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const advance = useCallback(() => {
@@ -57,7 +59,7 @@ export function MediaSlider({ mediaItems, interval = 5 }: MediaSliderProps) {
           {current.type === "video" ? (
             <video
               src={current.filePath}
-              className="h-full w-full object-contain"
+              className={`h-full w-full ${objectFit === "cover" ? "object-cover" : "object-contain"}`}
               autoPlay
               muted
               playsInline
@@ -67,7 +69,7 @@ export function MediaSlider({ mediaItems, interval = 5 }: MediaSliderProps) {
             <img
               src={current.filePath}
               alt=""
-              className="h-full w-full object-contain"
+              className={`h-full w-full ${objectFit === "cover" ? "object-cover" : "object-contain"}`}
             />
           )}
         </motion.div>

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -25,6 +25,7 @@ export const photoClockDefaultConfig = {
   clockLayout: "standard" as ClockLayout,
   is24Hour: true,
   showWeather: false,
+  objectFit: "contain" as "contain" | "cover",
 };
 
 type PhotoClockConfig = typeof photoClockDefaultConfig;
@@ -68,7 +69,7 @@ export default function PhotoClockBoard({
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-black">
       {/* Full-screen slideshow */}
-      <MediaSlider mediaItems={sorted} interval={config.slideInterval} />
+      <MediaSlider mediaItems={sorted} interval={config.slideInterval} objectFit={config.objectFit} />
 
       {/* Clock + Weather overlay */}
       <div

--- a/src/components/board/templates/SimpleBoard.tsx
+++ b/src/components/board/templates/SimpleBoard.tsx
@@ -19,6 +19,7 @@ export const simpleBoardDefaultConfig = {
   tickerFontFamily: "",
   showClock: false,
   showWeather: false,
+  objectFit: "contain" as "contain" | "cover",
 };
 
 type SimpleBoardConfig = typeof simpleBoardDefaultConfig;
@@ -51,7 +52,7 @@ export default function SimpleBoard({
       )}
       {/* Main area — slideshow */}
       <div className="relative flex-1 min-h-0">
-        <MediaSlider mediaItems={sorted} interval={config.slideInterval} />
+        <MediaSlider mediaItems={sorted} interval={config.slideInterval} objectFit={config.objectFit} />
 
         {/* Clock & Weather overlay */}
         {(config.showClock || config.showWeather) && (

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -30,6 +30,7 @@ export function PhotoClockConfigEditor({
   const clockLayout = (config.clockLayout as string) ?? "standard";
   const is24Hour = (config.is24Hour as boolean) ?? true;
   const showWeather = (config.showWeather as boolean) ?? false;
+  const objectFit = (config.objectFit as string) ?? "contain";
 
   const positionLabels: Record<string, string> = {
     "top-left": "左上",
@@ -65,6 +66,19 @@ export function PhotoClockConfigEditor({
           }
           className="w-24"
         />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
+        <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
+          <SelectTrigger id="cfg-objectFit" className="w-72">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="contain">全体表示（余白ができる場合あり）</SelectItem>
+            <SelectItem value="cover">全面表示（トリミングされる場合あり）</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="space-y-1.5">

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -72,7 +72,7 @@ export function PhotoClockConfigEditor({
         <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
         <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
           <SelectTrigger id="cfg-objectFit" className="w-72">
-            <SelectValue />
+            <SelectValue>{objectFit === "cover" ? "全面表示（トリミングされる場合あり）" : "全体表示（余白ができる場合あり）"}</SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="contain">全体表示（余白ができる場合あり）</SelectItem>

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -130,7 +130,7 @@ export function SimpleBoardConfigEditor({
             <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
             <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
               <SelectTrigger id="cfg-objectFit" className="w-72">
-                <SelectValue />
+                <SelectValue>{objectFit === "cover" ? "全面表示（トリミングされる場合あり）" : "全体表示（余白ができる場合あり）"}</SelectValue>
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="contain">全体表示（余白ができる場合あり）</SelectItem>

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -64,6 +64,7 @@ export function SimpleBoardConfigEditor({
   const tickerFontFamily = (config.tickerFontFamily as string) ?? "";
   const showClock = (config.showClock as boolean) ?? false;
   const showWeather = (config.showWeather as boolean) ?? false;
+  const objectFit = (config.objectFit as string) ?? "contain";
 
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
@@ -124,6 +125,18 @@ export function SimpleBoardConfigEditor({
               }
               className="w-24"
             />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
+            <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
+              <SelectTrigger id="cfg-objectFit" className="w-72">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="contain">全体表示（余白ができる場合あり）</SelectItem>
+                <SelectItem value="cover">全面表示（トリミングされる場合あり）</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="cfg-bgColor">背景色</Label>


### PR DESCRIPTION
## Summary

Closes #46

ボードごとにメディア（画像・動画）の表示モードを `contain`（全体表示）と `cover`（全面表示）から選択できるようにしました。

## Changes

### `MediaSlider.tsx`
- `objectFit` prop を追加（`"contain" | "cover"`、デフォルト `"contain"`）
- `<img>` / `<video>` の `object-fit` を動的に切り替え

### `SimpleBoard.tsx` / `PhotoClockBoard.tsx`
- `defaultConfig` に `objectFit: "contain"` を追加
- `<MediaSlider>` に `objectFit` を渡すように変更

### `SimpleBoardConfigEditor.tsx` / `PhotoClockConfigEditor.tsx`
- メディア表示モードの Select ドロップダウンを追加
  - **全体表示（余白ができる場合あり）** → `contain`
  - **全面表示（トリミングされる場合あり）** → `cover`

### Not affected
- `MessageBoard` / `RetroBoard` — `MediaSlider` を使用していないため変更なし