### PR TITLE
feat: add font selection to all templates with DotGothic16 & Source Code Pro

### DIFF
--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -19,6 +19,8 @@ interface DateTimeClockProps {
   bgOpacity?: number;
   /** Clock layout variant */
   layout?: ClockLayout;
+  /** Custom font family */
+  fontFamily?: string;
 }
 
 export function DateTimeClock({
@@ -27,6 +29,7 @@ export function DateTimeClock({
   color = "#ffffff",
   bgOpacity = 0.5,
   layout = "standard",
+  fontFamily,
 }: DateTimeClockProps) {
   const [now, setNow] = useState<Date | null>(null);
 
@@ -63,7 +66,7 @@ export function DateTimeClock({
     return (
       <div
         className="inline-flex items-center gap-4 rounded-lg px-5 py-2"
-        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
       >
         <span
           className="font-mono font-bold tabular-nums tracking-wider"
@@ -85,7 +88,7 @@ export function DateTimeClock({
     return (
       <div
         className="inline-flex flex-col items-center rounded-lg px-8 py-4"
-        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
       >
         <span
           className="font-mono font-bold tabular-nums tracking-wider"
@@ -113,7 +116,7 @@ export function DateTimeClock({
     return (
       <div
         className="inline-flex flex-col items-center rounded-lg px-6 py-3"
-        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
       >
         <span
           className="font-medium opacity-90"
@@ -135,7 +138,7 @@ export function DateTimeClock({
   return (
     <div
       className="inline-flex flex-col items-center rounded-lg px-6 py-3"
-      style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color }}
+      style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
     >
       <span
         className="font-mono font-bold tabular-nums tracking-wider"

--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -62,14 +62,16 @@ export function DateTimeClock({
 
   const dateFontSize = Math.max(14, Math.round(timeFontSize * 0.35));
 
+  const fontStyle = fontFamily || "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
+
   if (layout === "compact") {
     return (
       <div
         className="inline-flex items-center gap-4 rounded-lg px-5 py-2"
-        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontStyle }}
       >
         <span
-          className="font-mono font-bold tabular-nums tracking-wider"
+          className="font-bold tabular-nums tracking-wider"
           style={{ fontSize: timeFontSize }}
         >
           {timeStr}
@@ -88,16 +90,16 @@ export function DateTimeClock({
     return (
       <div
         className="inline-flex flex-col items-center rounded-lg px-8 py-4"
-        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontStyle }}
       >
         <span
-          className="font-mono font-bold tabular-nums tracking-wider"
+          className="font-bold tabular-nums tracking-wider"
           style={{ fontSize: timeFontSize * 1.3 }}
         >
           {hoursStr}:{minutes}
         </span>
         <span
-          className="font-mono tabular-nums opacity-70"
+          className="tabular-nums opacity-70"
           style={{ fontSize: Math.round(timeFontSize * 0.5) }}
         >
           :{seconds}{period}
@@ -116,7 +118,7 @@ export function DateTimeClock({
     return (
       <div
         className="inline-flex flex-col items-center rounded-lg px-6 py-3"
-        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
+        style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontStyle }}
       >
         <span
           className="font-medium opacity-90"
@@ -125,7 +127,7 @@ export function DateTimeClock({
           {dateStr}
         </span>
         <span
-          className="mt-1 font-mono font-bold tabular-nums tracking-wider"
+          className="mt-1 font-bold tabular-nums tracking-wider"
           style={{ fontSize: timeFontSize }}
         >
           {timeStr}
@@ -138,10 +140,10 @@ export function DateTimeClock({
   return (
     <div
       className="inline-flex flex-col items-center rounded-lg px-6 py-3"
-      style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontFamily || undefined }}
+      style={{ backgroundColor: `rgba(0, 0, 0, ${bgOpacity})`, color, fontFamily: fontStyle }}
     >
       <span
-        className="font-mono font-bold tabular-nums tracking-wider"
+        className="font-bold tabular-nums tracking-wider"
         style={{ fontSize: timeFontSize }}
       >
         {timeStr}

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -24,11 +24,14 @@ interface WeatherData {
 interface WeatherDisplayProps {
   color?: string;
   bgOpacity?: number;
+  /** Custom font family */
+  fontFamily?: string;
 }
 
 export function WeatherDisplay({
   color = "#ffffff",
   bgOpacity = 0.5,
+  fontFamily,
 }: WeatherDisplayProps) {
   const [weather, setWeather] = useState<WeatherData | null>(null);
 
@@ -62,6 +65,7 @@ export function WeatherDisplay({
       style={{
         backgroundColor: `rgba(0,0,0,${bgOpacity})`,
         color,
+        fontFamily: fontFamily || undefined,
       }}
     >
       {/* Weather icon */}

--- a/src/components/board/templates/MessageBoard.tsx
+++ b/src/components/board/templates/MessageBoard.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { DateTimeClock } from "@/components/board/DateTimeClock";
 import { WeatherDisplay } from "@/components/board/WeatherDisplay";
+import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
 import type { BoardTemplateProps, Message } from "@/types";
 
 /** Default config for the Message Board template */
@@ -17,6 +18,7 @@ export const messageBoardDefaultConfig = {
   accentColor: "#3b82f6",
   showClock: false,
   showWeather: false,
+  fontFamily: "",
 };
 
 type MessageBoardConfig = typeof messageBoardDefaultConfig;
@@ -124,8 +126,11 @@ export default function MessageBoard({
   return (
     <div
       className="flex h-screen w-screen flex-col overflow-hidden"
-      style={{ backgroundColor: config.backgroundColor, color: config.textColor }}
+      style={{ backgroundColor: config.backgroundColor, color: config.textColor, fontFamily: config.fontFamily || undefined }}
     >
+      {config.fontFamily && (
+        <GoogleFontLoader fonts={[config.fontFamily]} />
+      )}
       {/* Header */}
       <div
         className="flex items-center justify-between border-b px-6 py-4"
@@ -139,6 +144,7 @@ export default function MessageBoard({
               color={config.textColor}
               bgOpacity={0}
               layout="compact"
+              fontFamily={config.fontFamily || undefined}
             />
           )}
           <div className="flex items-center gap-2 text-sm opacity-60">
@@ -219,7 +225,7 @@ export default function MessageBoard({
           className="border-t px-6 py-2"
           style={{ borderColor: config.accentColor + "40" }}
         >
-          <WeatherDisplay color={config.textColor} bgOpacity={0} />
+          <WeatherDisplay color={config.textColor} bgOpacity={0} fontFamily={config.fontFamily || undefined} />
         </div>
       )}
 

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -5,6 +5,7 @@
 import { MediaSlider } from "@/components/board/MediaSlider";
 import { DateTimeClock } from "@/components/board/DateTimeClock";
 import { WeatherDisplay } from "@/components/board/WeatherDisplay";
+import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
 import type { ClockLayout } from "@/components/board/DateTimeClock";
 import type { BoardTemplateProps } from "@/types";
 
@@ -26,6 +27,7 @@ export const photoClockDefaultConfig = {
   is24Hour: true,
   showWeather: false,
   objectFit: "contain" as "contain" | "cover",
+  fontFamily: "",
 };
 
 type PhotoClockConfig = typeof photoClockDefaultConfig;
@@ -68,6 +70,9 @@ export default function PhotoClockBoard({
 
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-black">
+      {config.fontFamily && (
+        <GoogleFontLoader fonts={[config.fontFamily]} />
+      )}
       {/* Full-screen slideshow */}
       <MediaSlider mediaItems={sorted} interval={config.slideInterval} objectFit={config.objectFit} />
 
@@ -81,11 +86,13 @@ export default function PhotoClockBoard({
           color={config.clockColor}
           bgOpacity={config.clockBgOpacity}
           layout={config.clockLayout}
+          fontFamily={config.fontFamily || undefined}
         />
         {config.showWeather && (
           <WeatherDisplay
             color={config.clockColor}
             bgOpacity={config.clockBgOpacity}
+            fontFamily={config.fontFamily || undefined}
           />
         )}
       </div>

--- a/src/components/board/templates/RetroBoard.tsx
+++ b/src/components/board/templates/RetroBoard.tsx
@@ -90,7 +90,7 @@ function RetroRow({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.15 }}
-          className="flex overflow-hidden font-mono text-2xl font-bold tracking-widest md:text-3xl lg:text-4xl"
+          className="flex overflow-hidden text-2xl font-bold tracking-widest md:text-3xl lg:text-4xl"
         >
           {text.split("").map((char, i) => (
             <FlipChar
@@ -142,7 +142,7 @@ export default function RetroBoard({
   }
 
   return (
-    <div className="flex h-screen w-screen flex-col bg-[#0a0a0a]" style={{ fontFamily: config.fontFamily || undefined }}>
+    <div className="flex h-screen w-screen flex-col bg-[#0a0a0a]" style={{ fontFamily: config.fontFamily || "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" }}>
       {config.fontFamily && (
         <GoogleFontLoader fonts={[config.fontFamily]} />
       )}
@@ -152,14 +152,14 @@ export default function RetroBoard({
         style={{ borderColor: color }}
       >
         <span
-          className="font-mono text-sm font-bold uppercase tracking-[0.3em]"
+          className="text-sm font-bold uppercase tracking-[0.3em]"
           style={{ color, textShadow: glow }}
         >
           {board.name}
         </span>
         <div className="flex items-center gap-4">
           <span
-            className="font-mono text-sm tracking-wider opacity-70"
+            className="text-sm tracking-wider opacity-70"
             style={{ color }}
           >
             ● LIVE

--- a/src/components/board/templates/RetroBoard.tsx
+++ b/src/components/board/templates/RetroBoard.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { DateTimeClock } from "@/components/board/DateTimeClock";
 import { WeatherDisplay } from "@/components/board/WeatherDisplay";
+import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
 import type { BoardTemplateProps } from "@/types";
 
 /** Default config for the Retro Board template */
@@ -16,6 +17,7 @@ export const retroBoardDefaultConfig = {
   switchInterval: 5,
   showClock: false,
   showWeather: false,
+  fontFamily: "",
 };
 
 type RetroBoardConfig = typeof retroBoardDefaultConfig;
@@ -140,7 +142,10 @@ export default function RetroBoard({
   }
 
   return (
-    <div className="flex h-screen w-screen flex-col bg-[#0a0a0a]">
+    <div className="flex h-screen w-screen flex-col bg-[#0a0a0a]" style={{ fontFamily: config.fontFamily || undefined }}>
+      {config.fontFamily && (
+        <GoogleFontLoader fonts={[config.fontFamily]} />
+      )}
       {/* Header bar */}
       <div
         className="flex items-center justify-between border-b-2 px-6 py-3"
@@ -170,7 +175,7 @@ export default function RetroBoard({
         >
           <div className="flex-1">
             {config.showWeather && (
-              <WeatherDisplay color={color} bgOpacity={0} />
+              <WeatherDisplay color={color} bgOpacity={0} fontFamily={config.fontFamily || undefined} />
             )}
           </div>
           {config.showClock && (
@@ -179,6 +184,7 @@ export default function RetroBoard({
               color={color}
               bgOpacity={0}
               layout="compact"
+              fontFamily={config.fontFamily || undefined}
             />
           )}
         </div>

--- a/src/components/board/templates/SimpleBoard.tsx
+++ b/src/components/board/templates/SimpleBoard.tsx
@@ -63,10 +63,11 @@ export default function SimpleBoard({
                 color="#ffffff"
                 bgOpacity={0.5}
                 layout="compact"
+                fontFamily={config.tickerFontFamily || undefined}
               />
             )}
             {config.showWeather && (
-              <WeatherDisplay color="#ffffff" bgOpacity={0.5} />
+              <WeatherDisplay color="#ffffff" bgOpacity={0.5} fontFamily={config.tickerFontFamily || undefined} />
             )}
           </div>
         )}

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -5,6 +5,33 @@
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { GOOGLE_FONTS, buildGoogleFontsUrl } from "@/lib/fonts";
+import { useEffect } from "react";
+
+/** Load ALL Google Fonts so the dropdown and preview can display them */
+function useLoadAllGoogleFonts() {
+  useEffect(() => {
+    const families = GOOGLE_FONTS.map((f) => f.value).filter(Boolean);
+    const url = buildGoogleFontsUrl(families);
+    if (!url) return;
+
+    const linkId = "google-fonts-all";
+    if (document.getElementById(linkId)) return;
+
+    const link = document.createElement("link");
+    link.id = linkId;
+    link.rel = "stylesheet";
+    link.href = url;
+    document.head.appendChild(link);
+  }, []);
+}
 
 interface MessageBoardConfigEditorProps {
   config: Record<string, unknown>;
@@ -15,6 +42,8 @@ export function MessageBoardConfigEditor({
   config,
   onChange,
 }: MessageBoardConfigEditorProps) {
+  useLoadAllGoogleFonts();
+
   const maxDisplayCount = (config.maxDisplayCount as number) ?? 10;
   const fontSize = (config.fontSize as number) ?? 20;
   const backgroundColor = (config.backgroundColor as string) ?? "#1e293b";
@@ -22,6 +51,7 @@ export function MessageBoardConfigEditor({
   const accentColor = (config.accentColor as string) ?? "#3b82f6";
   const showClock = (config.showClock as boolean) ?? false;
   const showWeather = (config.showWeather as boolean) ?? false;
+  const fontFamily = (config.fontFamily as string) ?? "";
 
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
@@ -136,6 +166,31 @@ export function MessageBoardConfigEditor({
             maxLength={7}
           />
         </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-font">フォント</Label>
+        <Select
+          value={fontFamily}
+          onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
+        >
+          <SelectTrigger id="cfg-font" className="w-64">
+            <SelectValue placeholder="フォントを選択">
+              {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {GOOGLE_FONTS.map((f) => (
+              <SelectItem
+                key={f.value || "__default__"}
+                value={f.value || "__default__"}
+                style={f.value ? { fontFamily: f.value } : undefined}
+              >
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
     </div>
   );

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -12,6 +12,26 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { GOOGLE_FONTS, buildGoogleFontsUrl } from "@/lib/fonts";
+import { useEffect } from "react";
+
+/** Load ALL Google Fonts so the dropdown and preview can display them */
+function useLoadAllGoogleFonts() {
+  useEffect(() => {
+    const families = GOOGLE_FONTS.map((f) => f.value).filter(Boolean);
+    const url = buildGoogleFontsUrl(families);
+    if (!url) return;
+
+    const linkId = "google-fonts-all";
+    if (document.getElementById(linkId)) return;
+
+    const link = document.createElement("link");
+    link.id = linkId;
+    link.rel = "stylesheet";
+    link.href = url;
+    document.head.appendChild(link);
+  }, []);
+}
 
 interface PhotoClockConfigEditorProps {
   config: Record<string, unknown>;
@@ -22,6 +42,8 @@ export function PhotoClockConfigEditor({
   config,
   onChange,
 }: PhotoClockConfigEditorProps) {
+  useLoadAllGoogleFonts();
+
   const slideInterval = (config.slideInterval as number) ?? 8;
   const clockPosition = (config.clockPosition as string) ?? "bottom-right";
   const clockFontSize = (config.clockFontSize as number) ?? 48;
@@ -31,6 +53,7 @@ export function PhotoClockConfigEditor({
   const is24Hour = (config.is24Hour as boolean) ?? true;
   const showWeather = (config.showWeather as boolean) ?? false;
   const objectFit = (config.objectFit as string) ?? "contain";
+  const fontFamily = (config.fontFamily as string) ?? "";
 
   const positionLabels: Record<string, string> = {
     "top-left": "左上",
@@ -187,6 +210,31 @@ export function PhotoClockConfigEditor({
           表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
         </p>
       )}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-font">フォント</Label>
+        <Select
+          value={fontFamily}
+          onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
+        >
+          <SelectTrigger id="cfg-font" className="w-64">
+            <SelectValue placeholder="フォントを選択">
+              {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {GOOGLE_FONTS.map((f) => (
+              <SelectItem
+                key={f.value || "__default__"}
+                value={f.value || "__default__"}
+                style={f.value ? { fontFamily: f.value } : undefined}
+              >
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -12,6 +12,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { GOOGLE_FONTS, buildGoogleFontsUrl } from "@/lib/fonts";
+import { useEffect } from "react";
+
+/** Load ALL Google Fonts so the dropdown and preview can display them */
+function useLoadAllGoogleFonts() {
+  useEffect(() => {
+    const families = GOOGLE_FONTS.map((f) => f.value).filter(Boolean);
+    const url = buildGoogleFontsUrl(families);
+    if (!url) return;
+
+    const linkId = "google-fonts-all";
+    if (document.getElementById(linkId)) return;
+
+    const link = document.createElement("link");
+    link.id = linkId;
+    link.rel = "stylesheet";
+    link.href = url;
+    document.head.appendChild(link);
+  }, []);
+}
 
 interface RetroBoardConfigEditorProps {
   config: Record<string, unknown>;
@@ -22,12 +42,15 @@ export function RetroBoardConfigEditor({
   config,
   onChange,
 }: RetroBoardConfigEditorProps) {
+  useLoadAllGoogleFonts();
+
   const displayColor = (config.displayColor as string) ?? "green";
   const rows = (config.rows as number) ?? 5;
   const flipSpeed = (config.flipSpeed as number) ?? 0.08;
   const switchInterval = (config.switchInterval as number) ?? 5;
   const showClock = (config.showClock as boolean) ?? false;
   const showWeather = (config.showWeather as boolean) ?? false;
+  const fontFamily = (config.fontFamily as string) ?? "";
 
   const colorLabels: Record<string, string> = {
     green: "グリーン",
@@ -138,6 +161,31 @@ export function RetroBoardConfigEditor({
           表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
         </p>
       )}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="cfg-font">フォント</Label>
+        <Select
+          value={fontFamily}
+          onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
+        >
+          <SelectTrigger id="cfg-font" className="w-64">
+            <SelectValue placeholder="フォントを選択">
+              {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {GOOGLE_FONTS.map((f) => (
+              <SelectItem
+                key={f.value || "__default__"}
+                value={f.value || "__default__"}
+                style={f.value ? { fontFamily: f.value } : undefined}
+              >
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -18,6 +18,8 @@ export const GOOGLE_FONTS = [
   { value: "Reggae One", label: "Reggae One" },
   { value: "RocknRoll One", label: "RocknRoll One" },
   { value: "Train One", label: "Train One" },
+  { value: "DotGothic16", label: "DotGothic16（ドット風）" },
+  { value: "Source Code Pro", label: "Source Code Pro（等幅）" },
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Closes #48

全テンプレートでフォントを選択できるようにし、DotGothic16（ドット風）と Source Code Pro（等幅）を追加しました。選択したフォントは時刻・天気表示にも適用されます。

## Changes

### `src/lib/fonts.ts`
- `DotGothic16（ドット風）` と `Source Code Pro（等幅）` を GOOGLE_FONTS リストに追加

### `src/components/board/DateTimeClock.tsx` / `WeatherDisplay.tsx`
- `fontFamily` prop を追加し、全レイアウトバリアントに適用

### Board Templates
- **SimpleBoard** — 既存の `tickerFontFamily` を時計・天気にも適用
- **PhotoClockBoard** — `fontFamily` config 追加、GoogleFontLoader + 時計・天気に適用
- **MessageBoard** — `fontFamily` config 追加、ボード全体 + 時計・天気に適用
- **RetroBoard** — `fontFamily` config 追加、ボード全体 + 時計・天気に適用

### Config Editors
- **PhotoClockConfigEditor** — フォント選択ドロップダウン追加
- **MessageBoardConfigEditor** — フォント選択ドロップダウン追加
- **RetroBoardConfigEditor** — フォント選択ドロップダウン追加
- SimpleBoardConfigEditor — 既存のフォント選択で対応済み