### PR TITLE
feat: add ticker font size and position options for SimpleBoard

### DIFF
--- a/src/components/board/templates/SimpleBoard.tsx
+++ b/src/components/board/templates/SimpleBoard.tsx
@@ -17,6 +17,8 @@ export const simpleBoardDefaultConfig = {
   textColor: "#ffffff",
   tickerBgColor: "#1a1a2e",
   tickerFontFamily: "",
+  tickerFontSize: 18,
+  tickerPosition: "bottom" as "top" | "bottom",
   showClock: false,
   showWeather: false,
   objectFit: "contain" as "contain" | "cover",
@@ -42,6 +44,29 @@ export default function SimpleBoard({
 
   const tickerMessages = messages.map((m) => m.content);
 
+  // Dynamic ticker height based on font size + padding
+  const tickerHeight = config.tickerFontSize + 24;
+
+  const tickerElement = tickerMessages.length > 0 && (
+    <div
+      className="flex items-center border-white/10 px-4 font-medium shrink-0"
+      style={{
+        color: config.textColor,
+        backgroundColor: config.tickerBgColor,
+        height: tickerHeight,
+        fontSize: config.tickerFontSize,
+        borderTop: config.tickerPosition === "bottom" ? "1px solid rgba(255,255,255,0.1)" : undefined,
+        borderBottom: config.tickerPosition === "top" ? "1px solid rgba(255,255,255,0.1)" : undefined,
+      }}
+    >
+      <TickerText
+        messages={tickerMessages}
+        speed={config.tickerSpeed}
+        fontFamily={config.tickerFontFamily || undefined}
+      />
+    </div>
+  );
+
   return (
     <div
       className="flex h-screen w-screen flex-col"
@@ -50,6 +75,10 @@ export default function SimpleBoard({
       {config.tickerFontFamily && (
         <GoogleFontLoader fonts={[config.tickerFontFamily]} />
       )}
+
+      {/* Top ticker */}
+      {config.tickerPosition === "top" && tickerElement}
+
       {/* Main area — slideshow */}
       <div className="relative flex-1 min-h-0">
         <MediaSlider mediaItems={sorted} interval={config.slideInterval} objectFit={config.objectFit} />
@@ -74,18 +103,7 @@ export default function SimpleBoard({
       </div>
 
       {/* Bottom ticker */}
-      {tickerMessages.length > 0 && (
-        <div
-          className="h-14 flex items-center border-t border-white/10 px-4 text-lg font-medium"
-          style={{ color: config.textColor, backgroundColor: config.tickerBgColor }}
-        >
-          <TickerText
-            messages={tickerMessages}
-            speed={config.tickerSpeed}
-            fontFamily={config.tickerFontFamily || undefined}
-          />
-        </div>
-      )}
+      {config.tickerPosition === "bottom" && tickerElement}
     </div>
   );
 }

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -62,6 +62,8 @@ export function SimpleBoardConfigEditor({
   const textColor = (config.textColor as string) ?? "#ffffff";
   const tickerBgColor = (config.tickerBgColor as string) ?? "#1a1a2e";
   const tickerFontFamily = (config.tickerFontFamily as string) ?? "";
+  const tickerFontSize = (config.tickerFontSize as number) ?? 18;
+  const tickerPosition = (config.tickerPosition as string) ?? "bottom";
   const showClock = (config.showClock as boolean) ?? false;
   const showWeather = (config.showWeather as boolean) ?? false;
   const objectFit = (config.objectFit as string) ?? "contain";
@@ -176,6 +178,37 @@ export function SimpleBoardConfigEditor({
               }
               className="w-24"
             />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-tickerFontSize">文字サイズ ({tickerFontSize}px)</Label>
+            <input
+              id="cfg-tickerFontSize"
+              type="range"
+              min={12}
+              max={64}
+              step={1}
+              value={tickerFontSize}
+              onChange={(e) => update("tickerFontSize", Number(e.target.value))}
+              className="w-48"
+            />
+            <div className="flex justify-between text-xs text-muted-foreground w-48">
+              <span>12px</span>
+              <span>64px</span>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-tickerPosition">表示位置</Label>
+            <Select value={tickerPosition} onValueChange={(v) => update("tickerPosition", v)}>
+              <SelectTrigger id="cfg-tickerPosition" className="w-48">
+                <SelectValue>{tickerPosition === "top" ? "上部" : "下部"}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="bottom">下部</SelectItem>
+                <SelectItem value="top">上部</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-1.5">


### PR DESCRIPTION
## Summary

Closes #49

シンプル掲示板のティッカー（流れる文字）にフォントサイズ変更と表示位置（上部/下部）の選択機能を追加しました。

## Changes

### `SimpleBoard.tsx`
- `tickerFontSize` (default: 18px) — フォントサイズ設定。帯の高さも自動で追従
- `tickerPosition` (default: \"bottom\") — ティッカーの表示位置（上部 or 下部）
- 固定 `h-14` / `text-lg` を動的な `height` / `fontSize` スタイルに変更

### `SimpleBoardConfigEditor.tsx`
- **文字サイズ**: 12px〜64px のレンジスライダー
- **表示位置**: 「上部」「下部」の Select ドロップダウン