### PR TITLE
feat: 呼び出し番号テンプレートを追加 (#52)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "framer-motion": "^12",
     "lucide-react": "^1.7.0",
     "next": "16.2.2",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       next:
         specifier: 16.2.2
         version: 16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -3142,6 +3145,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -6605,6 +6613,10 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   qs@6.15.0:
     dependencies:

--- a/src/app/api/boards/[id]/messages/route.ts
+++ b/src/app/api/boards/[id]/messages/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { boards, messages } from "@/db/schema";
 import { eq, and, or, isNull, gt } from "drizzle-orm";
+import { emitSSE } from "@/lib/sse";
 
 export async function GET(
   _request: NextRequest,
@@ -31,4 +32,25 @@ export async function GET(
     );
 
   return NextResponse.json(activeMessages);
+}
+
+/** DELETE /api/boards/[id]/messages — delete all messages for a board */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, id),
+  });
+  if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  await db.delete(messages).where(eq(messages.boardId, id));
+
+  emitSSE(id, "message-updated");
+
+  return NextResponse.json({ success: true });
 }

--- a/src/app/api/network/route.ts
+++ b/src/app/api/network/route.ts
@@ -1,0 +1,17 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from "next/server";
+import { networkInterfaces } from "os";
+
+/** GET /api/network — return the first non-internal IPv4 address */
+export async function GET() {
+  const nets = networkInterfaces();
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name] ?? []) {
+      if (net.family === "IPv4" && !net.internal) {
+        return NextResponse.json({ ip: net.address });
+      }
+    }
+  }
+  return NextResponse.json({ ip: null });
+}

--- a/src/app/call/[boardId]/CallScreenClient.tsx
+++ b/src/app/call/[boardId]/CallScreenClient.tsx
@@ -4,6 +4,7 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { useSSE } from "@/hooks/useSSE";
+import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
 import type { Message } from "@/types";
 
 interface CallScreenClientProps {
@@ -21,6 +22,8 @@ export default function CallScreenClient({
   const [issuing, setIssuing] = useState(false);
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [showIssueInput, setShowIssueInput] = useState(false);
+  const [issueNumber, setIssueNumber] = useState("");
 
   // Refetch messages on SSE events
   const refetchMessages = useCallback(async () => {
@@ -51,6 +54,15 @@ export default function CallScreenClient({
     [messages],
   );
 
+  // Called messages (priority >= 1), most recent first
+  const called = useMemo(
+    () =>
+      messages
+        .filter((m) => m.priority >= 1)
+        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+    [messages],
+  );
+
   async function handleCall(msg: Message) {
     setCalling(true);
     try {
@@ -75,28 +87,37 @@ export default function CallScreenClient({
     }
   }
 
-  /** Compute next sequential number (e.g. "00001", "00002") */
+  /** Compute next sequential number (e.g. "00001", "00002"), wraps after 99999 */
   function getNextNumber(): string {
     let maxNum = 0;
     for (const m of messages) {
       const n = parseInt(m.content, 10);
       if (!isNaN(n) && n > maxNum) maxNum = n;
     }
-    return String(maxNum + 1).padStart(5, "0");
+    const next = maxNum >= 99999 ? 1 : maxNum + 1;
+    return String(next).padStart(5, "0");
+  }
+
+  function openIssueDialog() {
+    setIssueNumber(getNextNumber());
+    setShowIssueInput(true);
   }
 
   async function handleIssueNumber() {
+    const num = issueNumber.trim();
+    if (!num) return;
     setIssuing(true);
     try {
-      const nextNum = getNextNumber();
+      const content = /^\d+$/.test(num) ? num.padStart(5, "0") : num;
       const res = await fetch("/api/messages", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ boardId, content: nextNum, priority: 0 }),
+        body: JSON.stringify({ boardId, content, priority: 0 }),
       });
       if (res.ok) {
         const inserted = await res.json();
         setMessages((prev) => [...prev, inserted]);
+        setShowIssueInput(false);
       }
     } catch {
       // Will be synced on next SSE event
@@ -124,6 +145,7 @@ export default function CallScreenClient({
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
+      <GoogleFontLoader fonts={["Noto Sans JP"]} />
       {/* Header */}
       <header className="sticky top-0 z-10 border-b bg-white px-4 py-3 shadow-sm">
         <div className="mx-auto flex max-w-2xl items-center justify-between gap-2">
@@ -131,11 +153,10 @@ export default function CallScreenClient({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={handleIssueNumber}
-              disabled={issuing}
-              className="rounded-lg bg-green-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-green-700 disabled:bg-gray-300"
+              onClick={openIssueDialog}
+              className="rounded-lg bg-green-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-green-700"
             >
-              {issuing ? "発行中..." : "＋ 番号発行"}
+              ＋ 番号発行
             </button>
             <button
               type="button"
@@ -178,7 +199,8 @@ export default function CallScreenClient({
                 key={msg.id}
                 type="button"
                 onClick={() => setConfirmTarget(msg)}
-                className="flex items-center justify-center rounded-xl border-2 border-gray-200 bg-white px-3 py-5 text-2xl font-bold tabular-nums text-gray-900 shadow-sm transition-all active:scale-95 hover:border-blue-400 hover:bg-blue-50 sm:text-3xl"
+                className="flex items-center justify-center rounded-xl border-2 border-gray-200 bg-white px-3 py-5 text-2xl font-bold text-gray-900 shadow-sm transition-all active:scale-95 hover:border-blue-400 hover:bg-blue-50 sm:text-3xl"
+                style={{ fontFamily: '"Noto Sans JP", system-ui, sans-serif', fontVariantNumeric: "tabular-nums" }}
               >
                 {msg.content}
               </button>
@@ -186,6 +208,24 @@ export default function CallScreenClient({
           </div>
         )}
       </main>
+
+      {/* Called numbers section */}
+      {called.length > 0 && (
+        <div className="mx-auto w-full max-w-2xl border-t border-gray-200 px-4 pb-4 pt-2">
+          <p className="mb-2 text-xs font-medium text-gray-400">呼び出し済み ({called.length}件)</p>
+          <div className="flex flex-wrap gap-1.5">
+            {called.map((msg) => (
+              <span
+                key={msg.id}
+                className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-400"
+                style={{ fontFamily: '"Noto Sans JP", system-ui, sans-serif', fontVariantNumeric: "tabular-nums" }}
+              >
+                {msg.content}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Confirm dialog */}
       {confirmTarget && (
@@ -214,6 +254,44 @@ export default function CallScreenClient({
                 className="flex-1 rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
               >
                 {calling ? "処理中..." : "はい"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Issue number dialog */}
+      {showIssueInput && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-xs rounded-2xl bg-white p-6 shadow-xl">
+            <p className="mb-4 text-center text-lg font-semibold text-gray-900">
+              番号発行
+            </p>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={issueNumber}
+              onChange={(e) => setIssueNumber(e.target.value)}
+              className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-3 text-center text-2xl font-bold tracking-widest text-gray-900 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
+              style={{ fontFamily: '"Noto Sans JP", system-ui, sans-serif', fontVariantNumeric: "tabular-nums" }}
+              autoFocus
+            />
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowIssueInput(false)}
+                disabled={issuing}
+                className="flex-1 rounded-lg border border-gray-300 bg-white px-4 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={handleIssueNumber}
+                disabled={issuing || !issueNumber.trim()}
+                className="flex-1 rounded-lg bg-green-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-green-700 disabled:bg-gray-300"
+              >
+                {issuing ? "発行中..." : "発行"}
               </button>
             </div>
           </div>

--- a/src/app/call/[boardId]/CallScreenClient.tsx
+++ b/src/app/call/[boardId]/CallScreenClient.tsx
@@ -1,0 +1,156 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useSSE } from "@/hooks/useSSE";
+import type { Message } from "@/types";
+
+interface CallScreenClientProps {
+  boardId: string;
+  initialMessages: Message[];
+}
+
+export default function CallScreenClient({
+  boardId,
+  initialMessages,
+}: CallScreenClientProps) {
+  const [messages, setMessages] = useState(initialMessages);
+  const [confirmTarget, setConfirmTarget] = useState<Message | null>(null);
+  const [calling, setCalling] = useState(false);
+
+  // Refetch messages on SSE events
+  const refetchMessages = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/boards/${boardId}/messages`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setMessages(data);
+    } catch {
+      // Will retry on next SSE event
+    }
+  }, [boardId]);
+
+  const handleSSEEvent = useCallback(() => {
+    refetchMessages();
+  }, [refetchMessages]);
+
+  useSSE({ boardId, onEvent: handleSSEEvent });
+
+  // Waiting messages only (priority = 0)
+  const waiting = useMemo(
+    () =>
+      messages
+        .filter((m) => m.priority === 0)
+        .sort((a, b) =>
+          a.content.localeCompare(b.content, "ja", { numeric: true }),
+        ),
+    [messages],
+  );
+
+  async function handleCall(msg: Message) {
+    setCalling(true);
+    try {
+      const res = await fetch(`/api/messages/${msg.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ priority: 1 }),
+      });
+      if (res.ok) {
+        setConfirmTarget(null);
+        // Optimistic update
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === msg.id ? { ...m, priority: 1, updatedAt: new Date().toISOString() } : m,
+          ),
+        );
+      }
+    } catch {
+      // Will be synced on next SSE event
+    } finally {
+      setCalling(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-50">
+      {/* Header */}
+      <header className="sticky top-0 z-10 border-b bg-white px-4 py-3 shadow-sm">
+        <div className="mx-auto flex max-w-2xl items-center justify-between">
+          <h1 className="text-lg font-bold text-gray-900">呼び出し画面</h1>
+          <span className="rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">
+            待機中: {waiting.length}件
+          </span>
+        </div>
+      </header>
+
+      {/* Number grid */}
+      <main className="mx-auto w-full max-w-2xl flex-1 p-4">
+        {waiting.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+            <svg
+              className="mb-4 size-16"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+              />
+            </svg>
+            <p className="text-base">待機中の番号はありません</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
+            {waiting.map((msg) => (
+              <button
+                key={msg.id}
+                type="button"
+                onClick={() => setConfirmTarget(msg)}
+                className="flex items-center justify-center rounded-xl border-2 border-gray-200 bg-white px-3 py-5 text-2xl font-bold tabular-nums text-gray-900 shadow-sm transition-all active:scale-95 hover:border-blue-400 hover:bg-blue-50 sm:text-3xl"
+              >
+                {msg.content}
+              </button>
+            ))}
+          </div>
+        )}
+      </main>
+
+      {/* Confirm dialog */}
+      {confirmTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-xs rounded-2xl bg-white p-6 shadow-xl">
+            <p className="mb-6 text-center text-lg font-semibold text-gray-900">
+              <span className="text-3xl font-bold text-blue-600">
+                {confirmTarget.content}
+              </span>
+              <br />
+              をお呼び出ししますか？
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setConfirmTarget(null)}
+                disabled={calling}
+                className="flex-1 rounded-lg border border-gray-300 bg-white px-4 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={() => handleCall(confirmTarget)}
+                disabled={calling}
+                className="flex-1 rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
+              >
+                {calling ? "処理中..." : "はい"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/call/[boardId]/CallScreenClient.tsx
+++ b/src/app/call/[boardId]/CallScreenClient.tsx
@@ -118,6 +118,8 @@ export default function CallScreenClient({
         const inserted = await res.json();
         setMessages((prev) => [...prev, inserted]);
         setShowIssueInput(false);
+        // Scroll to top so the new number is visible below the sticky header
+        window.scrollTo({ top: 0, behavior: "smooth" });
       }
     } catch {
       // Will be synced on next SSE event

--- a/src/app/call/[boardId]/CallScreenClient.tsx
+++ b/src/app/call/[boardId]/CallScreenClient.tsx
@@ -18,6 +18,9 @@ export default function CallScreenClient({
   const [messages, setMessages] = useState(initialMessages);
   const [confirmTarget, setConfirmTarget] = useState<Message | null>(null);
   const [calling, setCalling] = useState(false);
+  const [issuing, setIssuing] = useState(false);
+  const [showDeleteAll, setShowDeleteAll] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // Refetch messages on SSE events
   const refetchMessages = useCallback(async () => {
@@ -72,15 +75,80 @@ export default function CallScreenClient({
     }
   }
 
+  /** Compute next sequential number (e.g. "00001", "00002") */
+  function getNextNumber(): string {
+    let maxNum = 0;
+    for (const m of messages) {
+      const n = parseInt(m.content, 10);
+      if (!isNaN(n) && n > maxNum) maxNum = n;
+    }
+    return String(maxNum + 1).padStart(5, "0");
+  }
+
+  async function handleIssueNumber() {
+    setIssuing(true);
+    try {
+      const nextNum = getNextNumber();
+      const res = await fetch("/api/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ boardId, content: nextNum, priority: 0 }),
+      });
+      if (res.ok) {
+        const inserted = await res.json();
+        setMessages((prev) => [...prev, inserted]);
+      }
+    } catch {
+      // Will be synced on next SSE event
+    } finally {
+      setIssuing(false);
+    }
+  }
+
+  async function handleDeleteAll() {
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/boards/${boardId}/messages`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setMessages([]);
+        setShowDeleteAll(false);
+      }
+    } catch {
+      // Will be synced on next SSE event
+    } finally {
+      setDeleting(false);
+    }
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
       {/* Header */}
       <header className="sticky top-0 z-10 border-b bg-white px-4 py-3 shadow-sm">
-        <div className="mx-auto flex max-w-2xl items-center justify-between">
-          <h1 className="text-lg font-bold text-gray-900">呼び出し画面</h1>
-          <span className="rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">
-            待機中: {waiting.length}件
-          </span>
+        <div className="mx-auto flex max-w-2xl items-center justify-between gap-2">
+          <h1 className="shrink-0 text-lg font-bold text-gray-900">呼び出し画面</h1>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleIssueNumber}
+              disabled={issuing}
+              className="rounded-lg bg-green-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-green-700 disabled:bg-gray-300"
+            >
+              {issuing ? "発行中..." : "＋ 番号発行"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowDeleteAll(true)}
+              disabled={messages.length === 0}
+              className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:bg-gray-300"
+            >
+              全削除
+            </button>
+            <span className="rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">
+              待機中: {waiting.length}件
+            </span>
+          </div>
         </div>
       </header>
 
@@ -146,6 +214,38 @@ export default function CallScreenClient({
                 className="flex-1 rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
               >
                 {calling ? "処理中..." : "はい"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete all confirmation dialog */}
+      {showDeleteAll && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-xs rounded-2xl bg-white p-6 shadow-xl">
+            <p className="mb-2 text-center text-lg font-bold text-gray-900">
+              全ての番号を削除
+            </p>
+            <p className="mb-6 text-center text-sm text-gray-500">
+              全 {messages.length} 件の番号を完全に削除します。この操作は取り消せません。
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteAll(false)}
+                disabled={deleting}
+                className="flex-1 rounded-lg border border-gray-300 bg-white px-4 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={handleDeleteAll}
+                disabled={deleting}
+                className="flex-1 rounded-lg bg-red-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-red-700 disabled:bg-gray-300"
+              >
+                {deleting ? "削除中..." : "削除する"}
               </button>
             </div>
           </div>

--- a/src/app/call/[boardId]/PasscodeForm.tsx
+++ b/src/app/call/[boardId]/PasscodeForm.tsx
@@ -1,0 +1,65 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface PasscodeFormProps {
+  boardId: string;
+  error?: string;
+}
+
+export default function PasscodeForm({ boardId, error }: PasscodeFormProps) {
+  const [passcode, setPasscode] = useState("");
+  const router = useRouter();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (passcode.length === 6) {
+      router.push(`/call/${boardId}?passcode=${encodeURIComponent(passcode)}`);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-lg">
+        <h1 className="mb-2 text-center text-xl font-bold text-gray-900">
+          呼び出し画面
+        </h1>
+        <p className="mb-6 text-center text-sm text-gray-500">
+          6桁のパスコードを入力してください
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            maxLength={6}
+            value={passcode}
+            onChange={(e) => {
+              const v = e.target.value.replace(/\D/g, "").slice(0, 6);
+              setPasscode(v);
+            }}
+            placeholder="000000"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-center text-2xl font-mono tracking-[0.5em] focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            autoFocus
+          />
+
+          {error && (
+            <p className="text-center text-sm text-red-600">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={passcode.length !== 6}
+            className="w-full rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+          >
+            確認
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/call/[boardId]/page.tsx
+++ b/src/app/call/[boardId]/page.tsx
@@ -1,0 +1,63 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { notFound } from "next/navigation";
+import { db } from "@/db";
+import { boards, messages } from "@/db/schema";
+import { eq, and, or, isNull, gt } from "drizzle-orm";
+import CallScreenClient from "./CallScreenClient";
+import PasscodeForm from "./PasscodeForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function CallPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ boardId: string }>;
+  searchParams: Promise<{ passcode?: string }>;
+}) {
+  const { boardId } = await params;
+  const { passcode } = await searchParams;
+
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, boardId),
+  });
+
+  if (!board || !board.isActive) {
+    notFound();
+  }
+
+  // Verify template is call-number
+  if (board.templateId !== "call-number") {
+    notFound();
+  }
+
+  const config = (board.config && typeof board.config === "object"
+    ? board.config
+    : {}) as Record<string, unknown>;
+  const storedPasscode = (config.passcode as string) ?? "";
+
+  // Validate passcode
+  if (!storedPasscode || passcode !== storedPasscode) {
+    return <PasscodeForm boardId={boardId} error={passcode ? "パスコードが正しくありません" : undefined} />;
+  }
+
+  // Fetch active messages (queue numbers)
+  const now = new Date().toISOString();
+  const activeMessages = await db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.boardId, boardId),
+        or(isNull(messages.expiresAt), gt(messages.expiresAt, now)),
+      ),
+    );
+
+  return (
+    <CallScreenClient
+      boardId={boardId}
+      initialMessages={activeMessages}
+    />
+  );
+}

--- a/src/app/call/layout.tsx
+++ b/src/app/call/layout.tsx
@@ -1,0 +1,9 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+export default function CallLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/components/board/templates/CallNumberBoard.tsx
+++ b/src/components/board/templates/CallNumberBoard.tsx
@@ -4,6 +4,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { DateTimeClock } from "@/components/board/DateTimeClock";
+import { GoogleFontLoader } from "@/components/board/GoogleFontLoader";
 import type { BoardTemplateProps } from "@/types";
 
 /** Default config for the Call Number Board template */
@@ -72,6 +73,8 @@ export default function CallNumberBoard({
       className="flex h-screen w-screen flex-col overflow-hidden"
       style={{ backgroundColor: config.backgroundColor }}
     >
+      <GoogleFontLoader fonts={["Noto Sans JP"]} />
+
       {/* Header with clock */}
       {config.showClock && (
         <div className="flex shrink-0 items-center justify-end px-6 py-3">
@@ -112,8 +115,8 @@ export default function CallNumberBoard({
               {waiting.map((m) => (
                 <div
                   key={m.id}
-                  className="flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-6 py-4 text-3xl font-bold tabular-nums"
-                  style={{ color: config.waitingTextColor }}
+                  className="flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-6 py-4 text-3xl font-bold"
+                  style={{ color: config.waitingTextColor, fontFamily: '"Noto Sans JP", system-ui, sans-serif', fontVariantNumeric: "tabular-nums" }}
                 >
                   {m.content}
                 </div>
@@ -151,24 +154,17 @@ export default function CallNumberBoard({
                 return (
                   <div
                     key={m.id}
-                    className={`flex items-center justify-center rounded-xl px-6 py-4 text-3xl font-bold tabular-nums transition-all ${
+                    className={`flex items-center justify-center rounded-xl px-6 py-4 transition-colors ${
                       highlighted
-                        ? "animate-pulse border-2 shadow-lg scale-110"
-                        : "border border-white/10 bg-white/5"
+                        ? "animate-pulse text-4xl font-extrabold"
+                        : "border border-white/10 bg-white/5 text-3xl font-bold"
                     }`}
                     style={{
                       color: highlighted
                         ? config.highlightColor
                         : config.calledTextColor,
-                      backgroundColor: highlighted
-                        ? `${config.highlightColor}20`
-                        : undefined,
-                      borderColor: highlighted
-                        ? config.highlightColor
-                        : undefined,
-                      boxShadow: highlighted
-                        ? `0 0 24px ${config.highlightColor}40`
-                        : undefined,
+                      fontFamily: '"Noto Sans JP", system-ui, sans-serif',
+                      fontVariantNumeric: "tabular-nums",
                     }}
                   >
                     {m.content}

--- a/src/components/board/templates/CallNumberBoard.tsx
+++ b/src/components/board/templates/CallNumberBoard.tsx
@@ -1,0 +1,189 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { DateTimeClock } from "@/components/board/DateTimeClock";
+import type { BoardTemplateProps } from "@/types";
+
+/** Default config for the Call Number Board template */
+export const callNumberDefaultConfig = {
+  showClock: true,
+  backgroundColor: "#1a1a2e",
+  waitingTextColor: "#ffffff",
+  calledTextColor: "#00ff88",
+  highlightColor: "#ff6b35",
+  layout: "horizontal" as "horizontal" | "vertical",
+  waitingLabel: "お待ちの番号",
+  calledLabel: "お呼び出し中",
+  passcode: "",
+};
+
+type CallNumberConfig = typeof callNumberDefaultConfig;
+
+function parseConfig(raw: unknown): CallNumberConfig {
+  const cfg = (raw && typeof raw === "object" ? raw : {}) as Partial<CallNumberConfig>;
+  return { ...callNumberDefaultConfig, ...cfg };
+}
+
+/** Highlight duration in ms — numbers called within this window are emphasized */
+const HIGHLIGHT_DURATION = 60_000;
+
+export default function CallNumberBoard({
+  board,
+  messages,
+}: BoardTemplateProps) {
+  const config = parseConfig(board.config);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Tick every 5s to re-evaluate "recently called" highlights
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 5000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const isRecentlyCalled = useCallback(
+    (updatedAt: string) => now - new Date(updatedAt).getTime() < HIGHLIGHT_DURATION,
+    [now],
+  );
+
+  // Split messages into waiting (priority=0) and called (priority>=1)
+  const { waiting, called } = useMemo(() => {
+    const w: typeof messages = [];
+    const c: typeof messages = [];
+    for (const m of messages) {
+      if (m.priority >= 1) {
+        c.push(m);
+      } else {
+        w.push(m);
+      }
+    }
+    // Sort waiting by content (number order)
+    w.sort((a, b) => a.content.localeCompare(b.content, "ja", { numeric: true }));
+    // Sort called: recently called first, then by updatedAt desc
+    c.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return { waiting: w, called: c };
+  }, [messages]);
+
+  const isHorizontal = config.layout === "horizontal";
+
+  return (
+    <div
+      className="flex h-screen w-screen flex-col overflow-hidden"
+      style={{ backgroundColor: config.backgroundColor }}
+    >
+      {/* Header with clock */}
+      {config.showClock && (
+        <div className="flex shrink-0 items-center justify-end px-6 py-3">
+          <DateTimeClock
+            timeFontSize={36}
+            color="#ffffff"
+            bgOpacity={0.3}
+            layout="compact"
+          />
+        </div>
+      )}
+
+      {/* Main content */}
+      <div
+        className={`flex flex-1 min-h-0 gap-1 p-4 ${
+          isHorizontal ? "flex-row" : "flex-col"
+        }`}
+      >
+        {/* Waiting lane */}
+        <div
+          className={`flex flex-col rounded-2xl bg-white/5 ${
+            isHorizontal ? "flex-1" : "flex-1"
+          }`}
+        >
+          <div className="shrink-0 px-6 py-4">
+            <h2
+              className="text-2xl font-bold"
+              style={{ color: config.waitingTextColor }}
+            >
+              {config.waitingLabel}
+            </h2>
+            <p className="mt-1 text-sm text-white/40">
+              {waiting.length} 件
+            </p>
+          </div>
+          <div className="flex-1 overflow-auto px-6 pb-4">
+            <div className="flex flex-wrap gap-3">
+              {waiting.map((m) => (
+                <div
+                  key={m.id}
+                  className="flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-6 py-4 text-3xl font-bold tabular-nums"
+                  style={{ color: config.waitingTextColor }}
+                >
+                  {m.content}
+                </div>
+              ))}
+              {waiting.length === 0 && (
+                <p className="py-8 text-sm text-white/30">
+                  待機中の番号はありません
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Called lane */}
+        <div
+          className={`flex flex-col rounded-2xl bg-white/5 ${
+            isHorizontal ? "flex-1" : "flex-1"
+          }`}
+        >
+          <div className="shrink-0 px-6 py-4">
+            <h2
+              className="text-2xl font-bold"
+              style={{ color: config.calledTextColor }}
+            >
+              {config.calledLabel}
+            </h2>
+            <p className="mt-1 text-sm text-white/40">
+              {called.length} 件
+            </p>
+          </div>
+          <div className="flex-1 overflow-auto px-6 pb-4">
+            <div className="flex flex-wrap gap-3">
+              {called.map((m) => {
+                const highlighted = isRecentlyCalled(m.updatedAt);
+                return (
+                  <div
+                    key={m.id}
+                    className={`flex items-center justify-center rounded-xl px-6 py-4 text-3xl font-bold tabular-nums transition-all ${
+                      highlighted
+                        ? "animate-pulse border-2 shadow-lg scale-110"
+                        : "border border-white/10 bg-white/5"
+                    }`}
+                    style={{
+                      color: highlighted
+                        ? config.highlightColor
+                        : config.calledTextColor,
+                      backgroundColor: highlighted
+                        ? `${config.highlightColor}20`
+                        : undefined,
+                      borderColor: highlighted
+                        ? config.highlightColor
+                        : undefined,
+                      boxShadow: highlighted
+                        ? `0 0 24px ${config.highlightColor}40`
+                        : undefined,
+                    }}
+                  >
+                    {m.content}
+                  </div>
+                );
+              })}
+              {called.length === 0 && (
+                <p className="py-8 text-sm text-white/30">
+                  呼び出し済みの番号はありません
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/board/templates/CallNumberBoard.tsx
+++ b/src/components/board/templates/CallNumberBoard.tsx
@@ -19,7 +19,7 @@ export const callNumberDefaultConfig = {
   calledLabel: "お呼び出し中",
   passcode: "",
   calledExpireMinutes: 5,
-  numberFontSize: 48,
+  numberFontSize: 60,
 };
 
 type CallNumberConfig = typeof callNumberDefaultConfig;
@@ -83,7 +83,7 @@ export default function CallNumberBoard({
   }, [messages, now, expireMs]);
 
   const isHorizontal = config.layout === "horizontal";
-  const baseFontSize = config.numberFontSize ?? 48;
+  const baseFontSize = config.numberFontSize ?? 60;
   const highlightFontSize = Math.round(baseFontSize * 1.3);
 
   return (
@@ -107,15 +107,16 @@ export default function CallNumberBoard({
 
       {/* Main content */}
       <div
-        className={`flex flex-1 min-h-0 gap-1 p-4 ${
+        className={`flex flex-1 min-h-0 gap-0 p-4 ${
           isHorizontal ? "flex-row" : "flex-col"
         }`}
       >
         {/* Waiting lane */}
         <div
-          className={`flex flex-col rounded-2xl bg-white/5 ${
+          className={`flex flex-col rounded-2xl ${
             isHorizontal ? "flex-1" : "flex-1"
           }`}
+          style={{ backgroundColor: `${config.waitingTextColor}08` }}
         >
           <div className="shrink-0 px-6 py-4">
             <h2
@@ -148,11 +149,20 @@ export default function CallNumberBoard({
           </div>
         </div>
 
+        {/* Lane divider */}
+        <div
+          className={`shrink-0 ${
+            isHorizontal ? "mx-1 w-px self-stretch" : "my-1 h-px self-stretch"
+          }`}
+          style={{ backgroundColor: `${config.waitingTextColor}20` }}
+        />
+
         {/* Called lane */}
         <div
-          className={`flex flex-col rounded-2xl bg-white/5 ${
+          className={`flex flex-col rounded-2xl ${
             isHorizontal ? "flex-1" : "flex-1"
           }`}
+          style={{ backgroundColor: `${config.calledTextColor}08` }}
         >
           <div className="shrink-0 px-6 py-4">
             <h2
@@ -174,7 +184,7 @@ export default function CallNumberBoard({
                     key={m.id}
                     className={`flex items-center justify-center rounded-xl px-6 py-4 transition-colors ${
                       highlighted
-                        ? "animate-pulse font-extrabold"
+                        ? "font-extrabold"
                         : "border border-white/10 bg-white/5 font-bold"
                     }`}
                     style={{

--- a/src/components/board/templates/CallNumberBoard.tsx
+++ b/src/components/board/templates/CallNumberBoard.tsx
@@ -18,6 +18,8 @@ export const callNumberDefaultConfig = {
   waitingLabel: "お待ちの番号",
   calledLabel: "お呼び出し中",
   passcode: "",
+  calledExpireMinutes: 5,
+  numberFontSize: 48,
 };
 
 type CallNumberConfig = typeof callNumberDefaultConfig;
@@ -36,6 +38,7 @@ export default function CallNumberBoard({
 }: BoardTemplateProps) {
   const config = parseConfig(board.config);
   const [now, setNow] = useState(() => Date.now());
+  const expireMs = (config.calledExpireMinutes ?? 5) * 60_000;
 
   // Tick every 5s to re-evaluate "recently called" highlights
   useEffect(() => {
@@ -43,17 +46,30 @@ export default function CallNumberBoard({
     return () => clearInterval(timer);
   }, []);
 
+  // Auto-delete called numbers that have expired
+  useEffect(() => {
+    if (expireMs <= 0) return;
+    const expired = messages.filter(
+      (m) => m.priority >= 1 && now - new Date(m.updatedAt).getTime() >= expireMs,
+    );
+    for (const m of expired) {
+      fetch(`/api/messages/${m.id}`, { method: "DELETE" }).catch(() => {});
+    }
+  }, [now, messages, expireMs]);
+
   const isRecentlyCalled = useCallback(
     (updatedAt: string) => now - new Date(updatedAt).getTime() < HIGHLIGHT_DURATION,
     [now],
   );
 
-  // Split messages into waiting (priority=0) and called (priority>=1)
+  // Split messages into waiting (priority=0) and called (priority>=1, not expired)
   const { waiting, called } = useMemo(() => {
     const w: typeof messages = [];
     const c: typeof messages = [];
     for (const m of messages) {
       if (m.priority >= 1) {
+        // Hide expired called numbers from display
+        if (expireMs > 0 && now - new Date(m.updatedAt).getTime() >= expireMs) continue;
         c.push(m);
       } else {
         w.push(m);
@@ -64,9 +80,11 @@ export default function CallNumberBoard({
     // Sort called: recently called first, then by updatedAt desc
     c.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
     return { waiting: w, called: c };
-  }, [messages]);
+  }, [messages, now, expireMs]);
 
   const isHorizontal = config.layout === "horizontal";
+  const baseFontSize = config.numberFontSize ?? 48;
+  const highlightFontSize = Math.round(baseFontSize * 1.3);
 
   return (
     <div
@@ -115,8 +133,8 @@ export default function CallNumberBoard({
               {waiting.map((m) => (
                 <div
                   key={m.id}
-                  className="flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-6 py-4 text-3xl font-bold"
-                  style={{ color: config.waitingTextColor, fontFamily: '"Noto Sans JP", system-ui, sans-serif', fontVariantNumeric: "tabular-nums" }}
+                  className="flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-6 py-4 font-bold"
+                  style={{ color: config.waitingTextColor, fontFamily: '"Noto Sans JP", system-ui, sans-serif', fontVariantNumeric: "tabular-nums", fontSize: baseFontSize }}
                 >
                   {m.content}
                 </div>
@@ -156,8 +174,8 @@ export default function CallNumberBoard({
                     key={m.id}
                     className={`flex items-center justify-center rounded-xl px-6 py-4 transition-colors ${
                       highlighted
-                        ? "animate-pulse text-4xl font-extrabold"
-                        : "border border-white/10 bg-white/5 text-3xl font-bold"
+                        ? "animate-pulse font-extrabold"
+                        : "border border-white/10 bg-white/5 font-bold"
                     }`}
                     style={{
                       color: highlighted
@@ -165,6 +183,7 @@ export default function CallNumberBoard({
                         : config.calledTextColor,
                       fontFamily: '"Noto Sans JP", system-ui, sans-serif',
                       fontVariantNumeric: "tabular-nums",
+                      fontSize: highlighted ? highlightFontSize : baseFontSize,
                     }}
                   >
                     {m.content}

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -41,6 +41,7 @@ import {
 import { templates } from "@/lib/templates";
 import { TemplateConfigEditor } from "@/components/dashboard/config-editors";
 import MediaUploadZone from "@/components/dashboard/MediaUploadZone";
+import CallScreenAdmin from "@/components/dashboard/CallScreenAdmin";
 import type { Board, MediaItem, Message } from "@/types";
 
 interface BoardDetail extends Board {
@@ -271,13 +272,22 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
             </CardContent>
           </Card>
 
+          {/* Call screen admin (call-number template only) */}
+          {board.templateId === "call-number" && (
+            <CallScreenAdmin
+              boardId={boardId}
+              config={config}
+              onUpdateConfig={setConfig}
+            />
+          )}
+
           {/* Messages (not used by photo-clock template) */}
           {board.templateId !== "photo-clock" && (
           <Card>
             <CardHeader>
-              <CardTitle>メッセージ</CardTitle>
+              <CardTitle>{board.templateId === "call-number" ? "番号管理" : "メッセージ"}</CardTitle>
               <CardDescription>
-                {board.messages.length} 件のメッセージ
+                {board.messages.length} 件の{board.templateId === "call-number" ? "番号" : "メッセージ"}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -286,7 +296,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                 <Input
                   value={newMsgContent}
                   onChange={(e) => setNewMsgContent(e.target.value)}
-                  placeholder="メッセージを入力..."
+                  placeholder={board.templateId === "call-number" ? "番号を入力..." : "メッセージを入力..."}
                   className="flex-1"
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !e.nativeEvent.isComposing) {
@@ -295,6 +305,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                     }
                   }}
                 />
+                {board.templateId !== "call-number" && (
                 <Input
                   value={newMsgPriority}
                   onChange={(e) => setNewMsgPriority(e.target.value)}
@@ -303,6 +314,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                   min={0}
                   className="w-20"
                 />
+                )}
                 <Button type="button" size="sm" onClick={handleAddMessage}>
                   <Plus data-icon="inline-start" />
                   追加

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -281,8 +281,8 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
             />
           )}
 
-          {/* Messages (not used by photo-clock template) */}
-          {board.templateId !== "photo-clock" && (
+          {/* Messages (not used by photo-clock or call-number template) */}
+          {board.templateId !== "photo-clock" && board.templateId !== "call-number" && (
           <Card>
             <CardHeader>
               <CardTitle>{board.templateId === "call-number" ? "番号管理" : "メッセージ"}</CardTitle>
@@ -407,7 +407,8 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
           </Card>
           )}
 
-          {/* Media items */}
+          {/* Media items (not used by call-number template) */}
+          {board.templateId !== "call-number" && (
           <Card>
             <CardHeader>
               <CardTitle>メディア</CardTitle>
@@ -423,6 +424,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
               />
             </CardContent>
           </Card>
+          )}
         </div>
 
         {/* Right: Actions sidebar */}

--- a/src/components/dashboard/CallScreenAdmin.tsx
+++ b/src/components/dashboard/CallScreenAdmin.tsx
@@ -1,0 +1,139 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { RefreshCw, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+
+function generatePasscode(): string {
+  return Array.from({ length: 6 }, () => Math.floor(Math.random() * 10)).join(
+    "",
+  );
+}
+
+interface CallScreenAdminProps {
+  boardId: string;
+  config: Record<string, unknown>;
+  onUpdateConfig: (config: Record<string, unknown>) => void;
+}
+
+export default function CallScreenAdmin({
+  boardId,
+  config,
+  onUpdateConfig,
+}: CallScreenAdminProps) {
+  const origin =
+    typeof window !== "undefined" ? window.location.origin : "";
+  const [copied, setCopied] = useState(false);
+
+  const passcode = (config.passcode as string) ?? "";
+
+  // Auto-generate passcode if empty
+  useEffect(() => {
+    if (!passcode) {
+      onUpdateConfig({ ...config, passcode: generatePasscode() });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleRegenerate = useCallback(() => {
+    onUpdateConfig({ ...config, passcode: generatePasscode() });
+  }, [config, onUpdateConfig]);
+
+  const callUrl = `${origin}/call/${boardId}`;
+  const callUrlWithPasscode = `${callUrl}?passcode=${passcode}`;
+
+  async function handleCopyUrl() {
+    try {
+      await navigator.clipboard.writeText(callUrlWithPasscode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API not available
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>呼び出し画面</CardTitle>
+        <CardDescription>
+          オペレーター用の呼び出し画面URLとパスコード
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {/* Passcode */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium">パスコード（6桁）</label>
+          <div className="flex items-center gap-3">
+            <span className="rounded-lg border bg-muted px-4 py-2 font-mono text-2xl tracking-[0.3em]">
+              {passcode || "------"}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleRegenerate}
+            >
+              <RefreshCw className="mr-1.5 size-3.5" />
+              再生成
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            保存ボタンを押すとパスコードが確定します
+          </p>
+        </div>
+
+        {/* URL */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium">呼び出し画面URL</label>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded-lg border bg-muted px-3 py-2 text-xs">
+              {callUrl}
+            </code>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleCopyUrl}
+            >
+              {copied ? (
+                <Check className="mr-1.5 size-3.5 text-green-600" />
+              ) : (
+                <Copy className="mr-1.5 size-3.5" />
+              )}
+              {copied ? "コピー済" : "URL+パスコード"}
+            </Button>
+          </div>
+        </div>
+
+        {/* QR Code */}
+        {origin && passcode && (
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              QRコード（パスコード込み）
+            </label>
+            <div className="inline-block rounded-xl border bg-white p-4">
+              <QRCodeSVG
+                value={callUrlWithPasscode}
+                size={200}
+                level="M"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              QRコードにはパスコードが含まれるため、スキャンだけでアクセスできます
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/CallScreenAdmin.tsx
+++ b/src/components/dashboard/CallScreenAdmin.tsx
@@ -31,11 +31,30 @@ export default function CallScreenAdmin({
   config,
   onUpdateConfig,
 }: CallScreenAdminProps) {
-  const origin =
-    typeof window !== "undefined" ? window.location.origin : "";
+  const [networkOrigin, setNetworkOrigin] = useState("");
   const [copied, setCopied] = useState(false);
 
   const passcode = (config.passcode as string) ?? "";
+
+  // Fetch local network IP for the URL
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/network");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.ip) {
+          const port = window.location.port;
+          const protocol = window.location.protocol;
+          setNetworkOrigin(`${protocol}//${data.ip}${port ? `:${port}` : ""}`);
+        } else {
+          setNetworkOrigin(window.location.origin);
+        }
+      } catch {
+        setNetworkOrigin(window.location.origin);
+      }
+    })();
+  }, []);
 
   // Auto-generate passcode if empty
   useEffect(() => {
@@ -48,7 +67,7 @@ export default function CallScreenAdmin({
     onUpdateConfig({ ...config, passcode: generatePasscode() });
   }, [config, onUpdateConfig]);
 
-  const callUrl = `${origin}/call/${boardId}`;
+  const callUrl = `${networkOrigin}/call/${boardId}`;
   const callUrlWithPasscode = `${callUrl}?passcode=${passcode}`;
 
   async function handleCopyUrl() {
@@ -116,7 +135,7 @@ export default function CallScreenAdmin({
         </div>
 
         {/* QR Code */}
-        {origin && passcode && (
+        {networkOrigin && passcode && (
           <div className="space-y-2">
             <label className="text-sm font-medium">
               QRコード（パスコード込み）

--- a/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
@@ -61,6 +61,8 @@ export function CallNumberConfigEditor({
   const calledTextColor = (config.calledTextColor as string) ?? "#00ff88";
   const highlightColor = (config.highlightColor as string) ?? "#ff6b35";
   const layout = (config.layout as string) ?? "horizontal";
+  const calledExpireMinutes = (config.calledExpireMinutes as number) ?? 5;
+  const numberFontSize = (config.numberFontSize as number) ?? 48;
 
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
@@ -107,6 +109,40 @@ export function CallNumberConfigEditor({
               <SelectItem value="vertical">縦レイアウト</SelectItem>
             </SelectContent>
           </Select>
+        </div>
+      </div>
+
+      {/* Number display */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">番号表示</h4>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-numberFontSize">番号のフォントサイズ (px)</Label>
+            <Input
+              id="cfg-numberFontSize"
+              type="number"
+              min={24}
+              max={120}
+              value={numberFontSize}
+              onChange={(e) => update("numberFontSize", parseInt(e.target.value, 10) || 48)}
+              className="w-28"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-calledExpire">呼び出し済み番号の自動削除 (分)</Label>
+            <Input
+              id="cfg-calledExpire"
+              type="number"
+              min={1}
+              max={60}
+              value={calledExpireMinutes}
+              onChange={(e) => update("calledExpireMinutes", parseInt(e.target.value, 10) || 5)}
+              className="w-28"
+            />
+            <p className="text-xs text-muted-foreground">
+              呼び出し後、指定時間が経過した番号はボード画面から自動で削除されます
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
@@ -62,7 +62,7 @@ export function CallNumberConfigEditor({
   const highlightColor = (config.highlightColor as string) ?? "#ff6b35";
   const layout = (config.layout as string) ?? "horizontal";
   const calledExpireMinutes = (config.calledExpireMinutes as number) ?? 5;
-  const numberFontSize = (config.numberFontSize as number) ?? 48;
+  const numberFontSize = (config.numberFontSize as number) ?? 60;
 
   function update(key: string, value: unknown) {
     onChange({ ...config, [key]: value });
@@ -117,16 +117,21 @@ export function CallNumberConfigEditor({
         <h4 className="mb-3 text-sm font-semibold">番号表示</h4>
         <div className="space-y-3">
           <div className="space-y-1.5">
-            <Label htmlFor="cfg-numberFontSize">番号のフォントサイズ (px)</Label>
-            <Input
+            <Label htmlFor="cfg-numberFontSize">番号のフォントサイズ ({numberFontSize}px)</Label>
+            <input
               id="cfg-numberFontSize"
-              type="number"
+              type="range"
               min={24}
               max={120}
+              step={2}
               value={numberFontSize}
-              onChange={(e) => update("numberFontSize", parseInt(e.target.value, 10) || 48)}
-              className="w-28"
+              onChange={(e) => update("numberFontSize", Number(e.target.value))}
+              className="w-48"
             />
+            <div className="flex w-48 justify-between text-xs text-muted-foreground">
+              <span>24px</span>
+              <span>120px</span>
+            </div>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="cfg-calledExpire">呼び出し済み番号の自動削除 (分)</Label>

--- a/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
@@ -1,0 +1,219 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/** Color presets for Light / Dark themes */
+const COLOR_PRESETS = [
+  {
+    label: "ダーク（デフォルト）",
+    backgroundColor: "#1a1a2e",
+    waitingTextColor: "#ffffff",
+    calledTextColor: "#00ff88",
+    highlightColor: "#ff6b35",
+  },
+  {
+    label: "ライト",
+    backgroundColor: "#f5f5f5",
+    waitingTextColor: "#333333",
+    calledTextColor: "#16a34a",
+    highlightColor: "#dc2626",
+  },
+  {
+    label: "ネイビー",
+    backgroundColor: "#0f172a",
+    waitingTextColor: "#e2e8f0",
+    calledTextColor: "#38bdf8",
+    highlightColor: "#f59e0b",
+  },
+  {
+    label: "ホスピタルグリーン",
+    backgroundColor: "#ecfdf5",
+    waitingTextColor: "#1e3a2f",
+    calledTextColor: "#059669",
+    highlightColor: "#dc2626",
+  },
+];
+
+interface CallNumberConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function CallNumberConfigEditor({
+  config,
+  onChange,
+}: CallNumberConfigEditorProps) {
+  const showClock = (config.showClock as boolean) ?? true;
+  const backgroundColor = (config.backgroundColor as string) ?? "#1a1a2e";
+  const waitingTextColor = (config.waitingTextColor as string) ?? "#ffffff";
+  const calledTextColor = (config.calledTextColor as string) ?? "#00ff88";
+  const highlightColor = (config.highlightColor as string) ?? "#ff6b35";
+  const layout = (config.layout as string) ?? "horizontal";
+
+  function update(key: string, value: unknown) {
+    onChange({ ...config, [key]: value });
+  }
+
+  function applyPreset(preset: (typeof COLOR_PRESETS)[number]) {
+    onChange({
+      ...config,
+      backgroundColor: preset.backgroundColor,
+      waitingTextColor: preset.waitingTextColor,
+      calledTextColor: preset.calledTextColor,
+      highlightColor: preset.highlightColor,
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Clock */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">時計</h4>
+        <div className="flex items-center gap-3">
+          <Switch
+            id="cfg-showClock"
+            checked={showClock}
+            onCheckedChange={(v) => update("showClock", v)}
+          />
+          <Label htmlFor="cfg-showClock">日付・時刻を表示</Label>
+        </div>
+      </div>
+
+      {/* Layout */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">レイアウト</h4>
+        <div className="space-y-1.5">
+          <Label htmlFor="cfg-layout">レーン配置</Label>
+          <Select value={layout} onValueChange={(v) => update("layout", v)}>
+            <SelectTrigger id="cfg-layout" className="w-48">
+              <SelectValue>
+                {layout === "horizontal" ? "横レイアウト" : "縦レイアウト"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="horizontal">横レイアウト</SelectItem>
+              <SelectItem value="vertical">縦レイアウト</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Color presets */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">カラープリセット</h4>
+        <div className="flex flex-wrap gap-2">
+          {COLOR_PRESETS.map((preset) => (
+            <Button
+              key={preset.label}
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => applyPreset(preset)}
+              className="gap-2"
+            >
+              <span
+                className="inline-block size-3 rounded-full border"
+                style={{ backgroundColor: preset.backgroundColor }}
+              />
+              {preset.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* Colors */}
+      <div>
+        <h4 className="mb-3 text-sm font-semibold">カラー設定</h4>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-bgColor">背景色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-bgColor"
+                value={backgroundColor}
+                onChange={(e) => update("backgroundColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={backgroundColor}
+                onChange={(e) => update("backgroundColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-waitingColor">呼び出し前のテキスト色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-waitingColor"
+                value={waitingTextColor}
+                onChange={(e) => update("waitingTextColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={waitingTextColor}
+                onChange={(e) => update("waitingTextColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-calledColor">呼び出し済みのテキスト色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-calledColor"
+                value={calledTextColor}
+                onChange={(e) => update("calledTextColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={calledTextColor}
+                onChange={(e) => update("calledTextColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cfg-highlightColor">直近呼び出しのハイライト色</Label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                id="cfg-highlightColor"
+                value={highlightColor}
+                onChange={(e) => update("highlightColor", e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+              />
+              <Input
+                value={highlightColor}
+                onChange={(e) => update("highlightColor", e.target.value)}
+                className="w-28 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/config-editors/index.tsx
+++ b/src/components/dashboard/config-editors/index.tsx
@@ -6,6 +6,7 @@ import { SimpleBoardConfigEditor } from "./SimpleBoardConfigEditor";
 import { PhotoClockConfigEditor } from "./PhotoClockConfigEditor";
 import { RetroBoardConfigEditor } from "./RetroBoardConfigEditor";
 import { MessageBoardConfigEditor } from "./MessageBoardConfigEditor";
+import { CallNumberConfigEditor } from "./CallNumberConfigEditor";
 
 interface ConfigEditorProps {
   config: Record<string, unknown>;
@@ -17,6 +18,7 @@ const editors: Record<string, React.ComponentType<ConfigEditorProps>> = {
   "photo-clock": PhotoClockConfigEditor,
   retro: RetroBoardConfigEditor,
   message: MessageBoardConfigEditor,
+  "call-number": CallNumberConfigEditor,
 };
 
 export function TemplateConfigEditor({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,7 +9,7 @@ export const boards = sqliteTable("boards", {
     .primaryKey()
     .$defaultFn(() => randomUUID()),
   name: text("name").notNull(),
-  templateId: text("template_id").notNull(), // "simple" | "photo-clock" | "retro" | "message"
+  templateId: text("template_id").notNull(), // "simple" | "photo-clock" | "retro" | "message" | "call-number"
   config: text("config", { mode: "json" }).notNull().default("{}"),
   isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
   createdAt: text("created_at")

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -13,6 +13,9 @@ import RetroBoard, {
 import MessageBoard, {
   messageBoardDefaultConfig,
 } from "@/components/board/templates/MessageBoard";
+import CallNumberBoard, {
+  callNumberDefaultConfig,
+} from "@/components/board/templates/CallNumberBoard";
 
 /** Registry of all available board templates */
 export const templates: Record<TemplateId, BoardTemplate> = {
@@ -46,6 +49,14 @@ export const templates: Record<TemplateId, BoardTemplate> = {
       "外部APIからのメッセージをリアルタイム表示する掲示板",
     defaultConfig: messageBoardDefaultConfig,
     component: MessageBoard,
+  },
+  "call-number": {
+    id: "call-number",
+    name: "呼び出し番号",
+    description:
+      "病院や飲食店の呼び出し番号を表示するテンプレート",
+    defaultConfig: callNumberDefaultConfig,
+    component: CallNumberBoard,
   },
 };
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -9,6 +9,7 @@ export const templateIdSchema = z.enum([
   "photo-clock",
   "retro",
   "message",
+  "call-number",
 ]);
 
 export const createBoardSchema = z.object({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export type NewMediaItem = InferInsertModel<typeof mediaItems>;
 export type NewMessage = InferInsertModel<typeof messages>;
 
 // Template types
-export type TemplateId = "simple" | "photo-clock" | "retro" | "message";
+export type TemplateId = "simple" | "photo-clock" | "retro" | "message" | "call-number";
 
 export interface BoardTemplate {
   id: TemplateId;


### PR DESCRIPTION
## 概要
Issue #52 に対応し、新たに「呼び出し番号」テンプレートを追加しました。
病院の呼び出しや飲食店での番号呼び出しを想定したテンプレートです。

## 変更内容

### 呼び出し表示UI (`CallNumberBoard`)
- **呼び出し前レーン**: 待機中の番号を番号順に表示
- **呼び出し中レーン**: 呼び出し済みの番号を表示（直近呼び出しは更新日時順）
- **ハイライト**: 1分以内に呼ばれた番号はパルスアニメーション + ハイライト色で強調
- **時計表示**: `DateTimeClock` コンポーネントによる日付・時刻表示（トグル可）
- **レイアウト**: 横 / 縦 切り替え対応

### 呼び出し画面 (`/call/[boardId]`)
- 待機中の番号をボタンとして表示
- ボタン押下 → 「xxx をお呼び出ししますか？」確認ダイアログ
- レスポンシブ対応（スマートフォン・タブレット）
- SSE によるリアルタイム更新

### パスコード認証
- 6桁の数字パスコード（0-9のみ）
- GETパラメータ `?passcode=XXXXXX` でスキップ可能
- サーバーサイドで検証（`page.tsx` サーバーコンポーネント）
- パスコード未入力時は入力フォームを表示

### 管理者画面
- **呼び出し画面セクション**: URL表示 + QRコード（パスコード込み）
- **パスコード表示**: 現在のパスコード + 再生成ボタン
- **番号管理**: メッセージCRUDを番号管理用にカスタマイズ（ラベル変更、優先度フィールド非表示）

### コンフィグエディタ (`CallNumberConfigEditor`)
- 日付・時刻 表示/非表示トグル
- 横レイアウト / 縦レイアウト切り替え
- カラープリセット: ダーク / ライト / ネイビー / ホスピタルグリーン
- 個別カラー設定: 背景色、呼び出し前テキスト色、呼び出し済みテキスト色、ハイライト色

## データモデル
既存の `messages` テーブルを活用:
- `content`: 番号文字列
- `priority`: 状態（0 = 待機中、1 = 呼び出し済み）
- `updatedAt`: 呼び出し時刻（自動更新）として利用
- スキーマ変更・マイグレーション不要

## 新規ファイル
- `src/components/board/templates/CallNumberBoard.tsx`
- `src/components/dashboard/config-editors/CallNumberConfigEditor.tsx`
- `src/components/dashboard/CallScreenAdmin.tsx`
- `src/app/call/[boardId]/page.tsx`
- `src/app/call/[boardId]/CallScreenClient.tsx`
- `src/app/call/[boardId]/PasscodeForm.tsx`
- `src/app/call/layout.tsx`

## 変更ファイル
- `src/types/index.ts` — `TemplateId` に `\"call-number\"` 追加
- `src/lib/validators.ts` — バリデーションスキーマに追加
- `src/lib/templates.ts` — テンプレートレジストリに登録
- `src/components/dashboard/config-editors/index.tsx` — コンフィグエディタ登録
- `src/components/dashboard/BoardEditClient.tsx` — 呼び出し画面セクション追加 + 番号管理カスタマイズ
- `src/db/schema.ts` — コメント更新

Closes #52