### PR TITLE
fix: Docker buildでsettingsテーブル未作成によるプリレンダリングエラーを修正 (#59)

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -35,6 +35,12 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // Read cookies first to signal Next.js that this layout is dynamic.
+  // This prevents static prerendering from hitting DB queries during build
+  // when the database has not been migrated yet (e.g. Docker build).
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(PIN_SESSION_COOKIE)?.value;
+
   // Check if PIN is configured
   const pinRow = await db.query.settings.findFirst({
     where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
@@ -45,8 +51,6 @@ export default async function DashboardLayout({
   }
 
   // Check session cookie
-  const cookieStore = await cookies();
-  const sessionToken = cookieStore.get(PIN_SESSION_COOKIE)?.value;
 
   if (!sessionToken) {
     redirect("/pin");


### PR DESCRIPTION
## 概要
Closes #59

Docker build 時に `pnpm build` が `/boards/new` のプリレンダリングで `SqliteError: no such table: settings` エラーで失敗する問題を修正。

## 原因
`(dashboard)/layout.tsx` の PIN 認証チェックで、DB クエリ (`db.query.settings.findFirst(...)`) が `cookies()` より先に実行されていた。Next.js はビルド時にページの静的生成を試みるが、`cookies()` が呼ばれる前に DB アクセスが走るため、Docker ビルド環境（DB 未マイグレーション）でテーブル不在エラーが発生。

## 修正内容
`cookies()` の呼び出しを DB クエリより前に移動。Next.js は `cookies()` を検出すると該当ルートを dynamic rendering に切り替えるため、ビルド時のプリレンダリングをスキップするようになる。

**Before**: DB query → `cookies()` → session check  
**After**: `cookies()` → DB query → session check