### PR TITLE
feat: 管理者画面にダークモードを導入 (#58)

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -67,7 +67,7 @@ export default async function DashboardLayout({
 
   return (
     <ThemeProvider>
-      <div id="dashboard-theme-root" className="flex min-h-full bg-background text-foreground">
+      <div id="dashboard-theme-root" className="flex min-h-dvh bg-background text-foreground">
         {/* Sidebar */}
         <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
           <div className="flex h-14 items-center px-4">

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -9,6 +9,7 @@ import { db } from "@/db";
 import { settings } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { PIN_SESSION_COOKIE, PIN_SETTINGS } from "@/lib/pin";
+import { ThemeProvider } from "@/components/dashboard/ThemeProvider";
 
 function SidebarLink({
   href,
@@ -65,30 +66,32 @@ export default async function DashboardLayout({
   }
 
   return (
-    <div className="flex min-h-full">
-      {/* Sidebar */}
-      <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
-        <div className="flex h-14 items-center px-4">
-          <Link href="/boards" className="flex items-center gap-2 font-bold">
-            <MonitorPlay className="size-5" />
-            <span>e-Web Board</span>
-          </Link>
-        </div>
-        <Separator />
-        <nav className="flex-1 space-y-1 px-2 py-3">
-          <SidebarLink href="/boards" icon={LayoutDashboard}>
-            ボード管理
-          </SidebarLink>
-          <SidebarLink href="/settings" icon={Settings}>
-            設定
-          </SidebarLink>
-        </nav>
-      </aside>
+    <ThemeProvider>
+      <div id="dashboard-theme-root" className="flex min-h-full bg-background text-foreground">
+        {/* Sidebar */}
+        <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
+          <div className="flex h-14 items-center px-4">
+            <Link href="/boards" className="flex items-center gap-2 font-bold">
+              <MonitorPlay className="size-5" />
+              <span>e-Web Board</span>
+            </Link>
+          </div>
+          <Separator />
+          <nav className="flex-1 space-y-1 px-2 py-3">
+            <SidebarLink href="/boards" icon={LayoutDashboard}>
+              ボード管理
+            </SidebarLink>
+            <SidebarLink href="/settings" icon={Settings}>
+              設定
+            </SidebarLink>
+          </nav>
+        </aside>
 
-      {/* Main content */}
-      <main className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-5xl px-6 py-8">{children}</div>
-      </main>
-    </div>
+        {/* Main content */}
+        <main className="flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-5xl px-6 py-8">{children}</div>
+        </main>
+      </div>
+    </ThemeProvider>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,3 +130,10 @@
     @apply font-sans;
   }
 }
+
+/* Smooth theme transition for dashboard dark mode */
+#dashboard-theme-root,
+#dashboard-theme-root * {
+  transition: background-color 300ms ease, color 300ms ease,
+    border-color 300ms ease;
+}

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -17,6 +17,7 @@ import { Switch } from "@/components/ui/switch";
 import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import type { WeatherPrefecture } from "@/lib/weather-areas";
 import { PinInput } from "@/components/auth/PinInput";
+import { useTheme, type Theme } from "@/components/dashboard/ThemeProvider";
 
 interface UploadedFile {
   filename: string;
@@ -54,6 +55,7 @@ export function SettingsClient() {
   const [imageSaving, setImageSaving] = useState(false);
   const [imageSaved, setImageSaved] = useState(false);
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+  const { theme, setTheme } = useTheme();
 
   // PIN/Email change states
   const [pinConfigured, setPinConfigured] = useState(false);
@@ -361,6 +363,33 @@ export function SettingsClient() {
           </div>
         </div>
       )}
+
+      {/* Theme Selection */}
+      <div className="rounded-lg border p-6">
+        <h2 className="mb-4 text-lg font-semibold">テーマ設定</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          管理画面の表示テーマを選択します。
+        </p>
+        <div className="flex gap-3">
+          {([
+            { value: "system" as Theme, label: "システムに準拠" },
+            { value: "light" as Theme, label: "ライト" },
+            { value: "dark" as Theme, label: "ダーク" },
+          ]).map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setTheme(opt.value)}
+              className={`rounded-lg border px-4 py-2 text-sm transition-colors ${
+                theme === opt.value
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border hover:bg-accent hover:text-accent-foreground"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Weather Area Selection */}
       <div className="rounded-lg border p-6">

--- a/src/components/dashboard/ThemeProvider.tsx
+++ b/src/components/dashboard/ThemeProvider.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from "react";
+
+export type Theme = "system" | "light" | "dark";
+
+const STORAGE_KEY = "e-web-board-theme";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "system",
+  setTheme: () => {},
+});
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+function getResolvedTheme(theme: Theme): "light" | "dark" {
+  if (theme !== "system") return theme;
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("system");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      setThemeState(stored);
+    }
+    setMounted(true);
+  }, []);
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t);
+    localStorage.setItem(STORAGE_KEY, t);
+  }, []);
+
+  // Apply .dark class to the wrapper element
+  useEffect(() => {
+    if (!mounted) return;
+
+    function apply() {
+      const resolved = getResolvedTheme(theme);
+      const el = document.getElementById("dashboard-theme-root");
+      if (!el) return;
+      el.classList.toggle("dark", resolved === "dark");
+    }
+
+    apply();
+
+    // Listen for system theme changes when set to "system"
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
+  }, [theme, mounted]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}


### PR DESCRIPTION
## 概要
Closes #58

管理者画面にダークモードを導入。

## 変更内容

### テーマ設定（3択）
- **システムに準拠** — OS の `prefers-color-scheme` に追従（デフォルト）
- **ライト** — 従来の白基調
- **ダーク** — ダークモード

### 実装
- `ThemeProvider` コンポーネント（`src/components/dashboard/ThemeProvider.tsx`）
  - `localStorage` でテーマ設定を不揮発保存
  - `matchMedia` でシステムテーマ変更にリアルタイム追従
  - `#dashboard-theme-root` 要素に `.dark` クラスを付与/除去
- ダッシュボード `layout.tsx` を `ThemeProvider` でラップ
- 設定画面にテーマ選択 UI を追加（バージョン情報の下）

### 仕組み
`globals.css` に既存の `.dark` CSS 変数定義と `@custom-variant dark (&:is(.dark *))` があるため、`#dashboard-theme-root` に `.dark` クラスを付与するだけで shadcn/ui コンポーネント含めダッシュボード全体がダークモードに切り替わる。ボード表示画面には影響しない。