### PR TITLE
feat: メールアドレス+パスワードによる管理者認証の導入 (#69)

### DIFF
--- a/drizzle/0003_users_auth_sessions.sql
+++ b/drizzle/0003_users_auth_sessions.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`email` text NOT NULL,
+	`password_hash` text NOT NULL,
+	`pin_hash` text,
+	`role` text NOT NULL DEFAULT 'admin',
+	`last_full_auth_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_user_id_unique` ON `users` (`user_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);
+--> statement-breakpoint
+CREATE TABLE `auth_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`session_token` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `auth_sessions_session_token_unique` ON `auth_sessions` (`session_token`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776087028300,
       "tag": "0002_equal_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776700000000,
+      "tag": "0003_users_auth_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -6,10 +6,16 @@ import { Separator } from "@/components/ui/separator";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { db } from "@/db";
-import { settings } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { PIN_SESSION_COOKIE, PIN_SETTINGS } from "@/lib/pin";
+import { users, authSessions, settings } from "@/db/schema";
+import { eq, and, gt } from "drizzle-orm";
+import {
+  AUTH_SESSION_COOKIE,
+  DEFAULT_AUTH_EXPIRE_DAYS,
+  AUTH_EXPIRE_DAYS_KEY,
+  isFullAuthValid,
+} from "@/lib/auth";
 import { ThemeProvider } from "@/components/dashboard/ThemeProvider";
+import { LogoutButton } from "@/components/dashboard/LogoutButton";
 
 function SidebarLink({
   href,
@@ -37,31 +43,35 @@ export default async function DashboardLayout({
   children: React.ReactNode;
 }) {
   // Read cookies first to signal Next.js that this layout is dynamic.
-  // This prevents static prerendering from hitting DB queries during build
-  // when the database has not been migrated yet (e.g. Docker build).
   const cookieStore = await cookies();
-  const sessionToken = cookieStore.get(PIN_SESSION_COOKIE)?.value;
-
-  // Check if PIN is configured
-  const pinRow = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
-  });
-
-  if (!pinRow?.value) {
-    redirect("/pin/setup");
-  }
-
-  // Check session cookie
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
 
   if (!sessionToken) {
     redirect("/pin");
   }
 
-  const storedSession = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.SESSION_SECRET),
+  // Validate session
+  const session = await db.query.authSessions.findFirst({
+    where: and(
+      eq(authSessions.sessionToken, sessionToken),
+      gt(authSessions.expiresAt, new Date().toISOString()),
+    ),
+    with: { user: true },
   });
 
-  if (!storedSession?.value || storedSession.value !== sessionToken) {
+  if (!session) {
+    redirect("/pin");
+  }
+
+  // Check full-auth validity
+  const expireSetting = await db.query.settings.findFirst({
+    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
+  });
+  const expireDays = expireSetting?.value
+    ? parseInt(expireSetting.value, 10)
+    : DEFAULT_AUTH_EXPIRE_DAYS;
+
+  if (!isFullAuthValid(session.user.lastFullAuthAt, expireDays)) {
     redirect("/pin");
   }
 
@@ -70,11 +80,12 @@ export default async function DashboardLayout({
       <div id="dashboard-theme-root" className="flex min-h-dvh bg-background text-foreground">
         {/* Sidebar */}
         <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
-          <div className="flex h-14 items-center px-4">
+          <div className="flex h-14 items-center justify-between px-4">
             <Link href="/boards" className="flex items-center gap-2 font-bold">
               <MonitorPlay className="size-5" />
               <span>Keinage</span>
             </Link>
+            <LogoutButton />
           </div>
           <Separator />
           <nav className="flex-1 space-y-1 px-2 py-3">

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { users, pinAttempts } from "@/db/schema";
+import { users, pinAttempts, authSessions } from "@/db/schema";
 import { eq, or, and, gt } from "drizzle-orm";
-import { verifyPassword } from "@/lib/auth";
+import { verifyPassword, AUTH_SESSION_COOKIE, SESSION_MAX_AGE } from "@/lib/auth";
 import {
   MAX_PIN_ATTEMPTS,
   IP_BLOCK_DURATION_MS,
+  generateSessionToken,
 } from "@/lib/pin";
 
 /** POST /api/auth/credentials/login — email/userId + password login */
@@ -87,11 +88,30 @@ export async function POST(request: NextRequest) {
   // Clear IP attempts on success
   await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
 
+  const now = new Date().toISOString();
+
   // Record full-auth timestamp
   await db
     .update(users)
-    .set({ lastFullAuthAt: new Date().toISOString() })
+    .set({ lastFullAuthAt: now })
     .where(eq(users.id, user.id));
 
-  return NextResponse.json({ success: true });
+  // Create session
+  const sessionToken = generateSessionToken();
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000).toISOString();
+
+  await db.insert(authSessions).values({
+    userId: user.id,
+    sessionToken,
+    expiresAt,
+  });
+
+  const res = NextResponse.json({ success: true });
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+  return res;
 }

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -1,0 +1,97 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users, pinAttempts } from "@/db/schema";
+import { eq, or, and, gt } from "drizzle-orm";
+import { verifyPassword } from "@/lib/auth";
+import {
+  MAX_PIN_ATTEMPTS,
+  IP_BLOCK_DURATION_MS,
+} from "@/lib/pin";
+
+/** POST /api/auth/credentials/login — email/userId + password login */
+export async function POST(request: NextRequest) {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown";
+
+  // IP rate-limit (shared with PIN attempts)
+  const blockThreshold = new Date(
+    Date.now() - IP_BLOCK_DURATION_MS,
+  ).toISOString();
+  const recentAttempts = await db
+    .select()
+    .from(pinAttempts)
+    .where(
+      and(
+        eq(pinAttempts.ipAddress, ip),
+        gt(pinAttempts.attemptedAt, blockThreshold),
+      ),
+    );
+
+  if (recentAttempts.length >= MAX_PIN_ATTEMPTS) {
+    return NextResponse.json(
+      {
+        error:
+          "試行回数の上限に達しました。24時間後に再度お試しください。",
+        blocked: true,
+      },
+      { status: 429 },
+    );
+  }
+
+  const body = await request.json();
+  const { identifier, password } = body as {
+    identifier?: string;
+    password?: string;
+  };
+
+  if (!identifier || !password) {
+    return NextResponse.json(
+      { error: "ユーザーIDまたはメールアドレスとパスワードを入力してください" },
+      { status: 400 },
+    );
+  }
+
+  const user = await db.query.users.findFirst({
+    where: or(
+      eq(users.email, identifier),
+      eq(users.userId, identifier),
+    ),
+  });
+
+  // Constant-time failure to prevent user enumeration
+  if (!user) {
+    await db.insert(pinAttempts).values({ ipAddress: ip });
+    return NextResponse.json(
+      { error: "ユーザーIDまたはパスワードが正しくありません" },
+      { status: 401 },
+    );
+  }
+
+  const valid = await verifyPassword(password, user.passwordHash);
+  if (!valid) {
+    await db.insert(pinAttempts).values({ ipAddress: ip });
+    const remaining = MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
+    return NextResponse.json(
+      {
+        error: `ユーザーIDまたはパスワードが正しくありません${remaining > 0 ? `（残り${remaining}回）` : ""}`,
+        remaining,
+      },
+      { status: 401 },
+    );
+  }
+
+  // Clear IP attempts on success
+  await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
+
+  // Record full-auth timestamp
+  await db
+    .update(users)
+    .set({ lastFullAuthAt: new Date().toISOString() })
+    .where(eq(users.id, user.id));
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/auth/credentials/setup/route.ts
+++ b/src/app/api/auth/credentials/setup/route.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { hashPassword, AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { generateSessionToken } from "@/lib/pin";
+
+/** POST /api/auth/credentials/setup — initial admin user registration */
+export async function POST(request: NextRequest) {
+  // Ensure no user exists yet
+  const existing = await db.select().from(users).limit(1);
+  if (existing.length > 0) {
+    return NextResponse.json(
+      { error: "管理者は既に登録されています" },
+      { status: 400 },
+    );
+  }
+
+  const body = await request.json();
+  const { userId, email, password } = body as {
+    userId?: string;
+    email?: string;
+    password?: string;
+  };
+
+  if (
+    !userId ||
+    !/^[a-zA-Z0-9_\-]{3,32}$/.test(userId)
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "ユーザーIDは3〜32文字の英数字・アンダースコア・ハイフンで入力してください",
+      },
+      { status: 400 },
+    );
+  }
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json(
+      { error: "有効なメールアドレスを入力してください" },
+      { status: 400 },
+    );
+  }
+  if (!password || password.length < 8) {
+    return NextResponse.json(
+      { error: "パスワードは8文字以上で入力してください" },
+      { status: 400 },
+    );
+  }
+
+  const passwordHash = await hashPassword(password);
+
+  await db.insert(users).values({
+    userId,
+    email,
+    passwordHash,
+    role: "admin",
+    lastFullAuthAt: new Date().toISOString(),
+  });
+
+  // Return a setup-complete token for the PIN setup step (short TTL client-side token)
+  const setupToken = generateSessionToken();
+
+  const res = NextResponse.json({ success: true, setupToken });
+  // Provide a temporary setup cookie so PIN setup route can verify continuity
+  res.cookies.set(AUTH_SESSION_COOKIE, setupToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 15, // 15 minutes for setup
+  });
+  return res;
+}

--- a/src/app/api/auth/password/change/route.ts
+++ b/src/app/api/auth/password/change/route.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users, authSessions } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { verifyPassword, hashPassword, AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { cookies } from "next/headers";
+
+/** PATCH /api/auth/password/change — change admin password (requires current password) */
+export async function PATCH(request: NextRequest) {
+  // Verify session
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  if (!sessionToken) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const session = await db.query.authSessions.findFirst({
+    where: eq(authSessions.sessionToken, sessionToken),
+    with: { user: true },
+  });
+
+  if (!session || session.expiresAt < new Date().toISOString()) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { currentPassword, newPassword } = body as {
+    currentPassword?: string;
+    newPassword?: string;
+  };
+
+  if (!currentPassword || !newPassword) {
+    return NextResponse.json(
+      { error: "現在のパスワードと新しいパスワードを入力してください" },
+      { status: 400 },
+    );
+  }
+  if (newPassword.length < 8) {
+    return NextResponse.json(
+      { error: "新しいパスワードは8文字以上で入力してください" },
+      { status: 400 },
+    );
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.userId),
+  });
+  if (!user) {
+    return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+
+  const valid = await verifyPassword(currentPassword, user.passwordHash);
+  if (!valid) {
+    return NextResponse.json(
+      { error: "現在のパスワードが正しくありません" },
+      { status: 401 },
+    );
+  }
+
+  const newHash = await hashPassword(newPassword);
+  await db
+    .update(users)
+    .set({ passwordHash: newHash })
+    .where(eq(users.id, user.id));
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/auth/pin/change/route.ts
+++ b/src/app/api/auth/pin/change/route.ts
@@ -2,29 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings } from "@/db/schema";
+import { users, authSessions } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import {
-  hashPin,
-  verifyPin,
-  PIN_SETTINGS,
-  PIN_SESSION_COOKIE,
-} from "@/lib/pin";
+import { hashPin, verifyPin } from "@/lib/pin";
+import { AUTH_SESSION_COOKIE } from "@/lib/auth";
 import { cookies } from "next/headers";
 
-/** PATCH /api/auth/pin/change — change PIN (requires current PIN) or email */
+/** PATCH /api/auth/pin/change — change PIN or email (requires active session) */
 export async function PATCH(request: NextRequest) {
   // Verify session
   const cookieStore = await cookies();
-  const sessionToken = cookieStore.get(PIN_SESSION_COOKIE)?.value;
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
   if (!sessionToken) {
     return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
   }
 
-  const storedSession = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.SESSION_SECRET),
+  const session = await db.query.authSessions.findFirst({
+    where: eq(authSessions.sessionToken, sessionToken),
+    with: { user: true },
   });
-  if (!storedSession?.value || storedSession.value !== sessionToken) {
+  if (!session || session.expiresAt < new Date().toISOString()) {
     return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
   }
 
@@ -36,6 +33,13 @@ export async function PATCH(request: NextRequest) {
     newEmail?: string;
   };
 
+  const adminUser = await db.query.users.findFirst({
+    where: eq(users.id, session.userId),
+  });
+  if (!adminUser) {
+    return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+
   if (action === "verifyCurrentPin") {
     if (!currentPin || !/^\d{6}$/.test(currentPin)) {
       return NextResponse.json(
@@ -43,10 +47,7 @@ export async function PATCH(request: NextRequest) {
         { status: 400 },
       );
     }
-    const row = await db.query.settings.findFirst({
-      where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
-    });
-    if (!row?.value || !verifyPin(currentPin, row.value)) {
+    if (!adminUser.pinHash || !verifyPin(currentPin, adminUser.pinHash)) {
       return NextResponse.json(
         { error: "PINが正しくありません" },
         { status: 401 },
@@ -69,25 +70,17 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    // Verify current PIN
-    const row = await db.query.settings.findFirst({
-      where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
-    });
-    if (!row?.value || !verifyPin(currentPin, row.value)) {
+    if (!adminUser.pinHash || !verifyPin(currentPin, adminUser.pinHash)) {
       return NextResponse.json(
         { error: "現在のPINが正しくありません" },
         { status: 401 },
       );
     }
 
-    // Update PIN hash
     await db
-      .insert(settings)
-      .values({ key: PIN_SETTINGS.PIN_HASH, value: hashPin(newPin) })
-      .onConflictDoUpdate({
-        target: settings.key,
-        set: { value: hashPin(newPin), updatedAt: new Date().toISOString() },
-      });
+      .update(users)
+      .set({ pinHash: hashPin(newPin) })
+      .where(eq(users.id, adminUser.id));
 
     return NextResponse.json({ success: true });
   }
@@ -101,12 +94,9 @@ export async function PATCH(request: NextRequest) {
     }
 
     await db
-      .insert(settings)
-      .values({ key: PIN_SETTINGS.PIN_EMAIL, value: newEmail })
-      .onConflictDoUpdate({
-        target: settings.key,
-        set: { value: newEmail, updatedAt: new Date().toISOString() },
-      });
+      .update(users)
+      .set({ email: newEmail })
+      .where(eq(users.id, adminUser.id));
 
     return NextResponse.json({ success: true });
   }

--- a/src/app/api/auth/pin/forgot/route.ts
+++ b/src/app/api/auth/pin/forgot/route.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings, pinResetTokens } from "@/db/schema";
+import { users, pinResetTokens } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { generateResetToken, PIN_SETTINGS, RESET_TOKEN_TTL_MS } from "@/lib/pin";
+import { generateResetToken, RESET_TOKEN_TTL_MS } from "@/lib/pin";
 import { isSmtpConfigured, sendPinResetEmail } from "@/lib/mail";
 import { networkInterfaces } from "os";
 
@@ -33,11 +33,11 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const row = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_EMAIL),
+  const adminUser = await db.query.users.findFirst({
+    where: eq(users.email, email),
   });
 
-  if (!row?.value || row.value !== email) {
+  if (!adminUser) {
     // Always return success to prevent email enumeration
     return NextResponse.json({ success: true, method: isSmtpConfigured() ? "email" : "link" });
   }
@@ -49,8 +49,6 @@ export async function POST(request: NextRequest) {
   await db.insert(pinResetTokens).values({ token, expiresAt });
 
   // Build reset URL
-  // If accessed via localhost, replace with local network IP for cross-device access.
-  // If accessed via a real domain, keep it as-is.
   const requestHost = request.headers.get("host") || "localhost:3000";
   const protocol = request.headers.get("x-forwarded-proto") || "http";
   const hostname = requestHost.split(":")[0];
@@ -65,7 +63,6 @@ export async function POST(request: NextRequest) {
   }
   const resetUrl = `${protocol}://${host}/pin/reset/${token}`;
 
-  // If SMTP is configured, send email; otherwise return URL directly
   if (isSmtpConfigured()) {
     await sendPinResetEmail(email, resetUrl);
     return NextResponse.json({ success: true, method: "email" });

--- a/src/app/api/auth/pin/logout/route.ts
+++ b/src/app/api/auth/pin/logout/route.ts
@@ -1,12 +1,23 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
-import { PIN_SESSION_COOKIE } from "@/lib/pin";
+import { db } from "@/db";
+import { authSessions } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { AUTH_SESSION_COOKIE } from "@/lib/auth";
 import { cookies } from "next/headers";
 
-/** POST /api/auth/pin/logout — clear session cookie */
+/** POST /api/auth/pin/logout — clear session */
 export async function POST() {
   const cookieStore = await cookies();
-  cookieStore.delete(PIN_SESSION_COOKIE);
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+
+  if (sessionToken) {
+    await db
+      .delete(authSessions)
+      .where(eq(authSessions.sessionToken, sessionToken));
+  }
+
+  cookieStore.delete(AUTH_SESSION_COOKIE);
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/auth/pin/reset/route.ts
+++ b/src/app/api/auth/pin/reset/route.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings, pinResetTokens } from "@/db/schema";
+import { users, pinResetTokens } from "@/db/schema";
 import { eq, and, isNull, gt } from "drizzle-orm";
-import { hashPin, PIN_SETTINGS } from "@/lib/pin";
+import { hashPin } from "@/lib/pin";
 
 /** POST /api/auth/pin/reset — change PIN using a valid reset token */
 export async function POST(request: NextRequest) {
@@ -48,12 +48,19 @@ export async function POST(request: NextRequest) {
     .set({ usedAt: now })
     .where(eq(pinResetTokens.id, resetToken.id));
 
-  // Update PIN hash
-  const pinHash = hashPin(pin);
+  // Update PIN hash on admin user
+  const adminUser = await db.query.users.findFirst();
+  if (!adminUser) {
+    return NextResponse.json(
+      { error: "管理者ユーザーが見つかりません" },
+      { status: 400 },
+    );
+  }
+
   await db
-    .update(settings)
-    .set({ value: pinHash, updatedAt: now })
-    .where(eq(settings.key, PIN_SETTINGS.PIN_HASH));
+    .update(users)
+    .set({ pinHash: hashPin(pin) })
+    .where(eq(users.id, adminUser.id));
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/auth/pin/setup/route.ts
+++ b/src/app/api/auth/pin/setup/route.ts
@@ -2,23 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings } from "@/db/schema";
+import { users, authSessions, settings } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { hashPin, generateSessionToken } from "@/lib/pin";
 import {
-  hashPin,
-  generateSessionToken,
-  PIN_SESSION_COOKIE,
-  PIN_SESSION_MAX_AGE,
-  PIN_SETTINGS,
-} from "@/lib/pin";
+  AUTH_SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  DEFAULT_AUTH_EXPIRE_DAYS,
+  AUTH_EXPIRE_DAYS_KEY,
+  isFullAuthValid,
+} from "@/lib/auth";
+import { cookies } from "next/headers";
 
-/** POST /api/auth/pin/setup — initial PIN + email registration */
+/** POST /api/auth/pin/setup — set initial PIN for the admin user */
 export async function POST(request: NextRequest) {
-  // Check PIN is not already set
-  const existing = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
-  });
-  if (existing?.value) {
+  // Verify that at least one user (admin) exists
+  const adminUser = await db.query.users.findFirst();
+  if (!adminUser) {
+    return NextResponse.json(
+      { error: "管理者アカウントが未登録です。先にメールアドレスとパスワードを登録してください" },
+      { status: 400 },
+    );
+  }
+
+  // Check that PIN is not already set
+  if (adminUser.pinHash) {
     return NextResponse.json(
       { error: "PINは既に設定されています" },
       { status: 400 },
@@ -26,7 +34,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { pin, email } = body as { pin?: string; email?: string };
+  const { pin } = body as { pin?: string };
 
   if (!pin || !/^\d{6}$/.test(pin)) {
     return NextResponse.json(
@@ -34,52 +42,57 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+
+  // Retrieve configured auth expire days
+  const expireSetting = await db.query.settings.findFirst({
+    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
+  });
+  const expireDays = expireSetting?.value
+    ? parseInt(expireSetting.value, 10)
+    : DEFAULT_AUTH_EXPIRE_DAYS;
+
+  // Verify full-auth is still valid (set during credentials/setup)
+  if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {
     return NextResponse.json(
-      { error: "有効なメールアドレスを入力してください" },
-      { status: 400 },
+      { error: "認証セッションが無効です。再度ログインしてください" },
+      { status: 401 },
     );
   }
 
-  const pinHash = hashPin(pin);
-
-  // Save PIN hash and email
+  // Save PIN hash to users table
   await db
-    .insert(settings)
-    .values([
-      { key: PIN_SETTINGS.PIN_HASH, value: pinHash },
-      { key: PIN_SETTINGS.PIN_EMAIL, value: email },
-    ])
-    .onConflictDoUpdate({
-      target: settings.key,
-      set: { value: pinHash, updatedAt: new Date().toISOString() },
-    });
+    .update(users)
+    .set({ pinHash: hashPin(pin) })
+    .where(eq(users.id, adminUser.id));
 
-  // Also save email separately (onConflictDoUpdate uses the last set value)
-  await db
-    .insert(settings)
-    .values({ key: PIN_SETTINGS.PIN_EMAIL, value: email })
-    .onConflictDoUpdate({
-      target: settings.key,
-      set: { value: email, updatedAt: new Date().toISOString() },
-    });
+  // Delete any previous setup cookie session
+  const cookieStore = await cookies();
+  const existingToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  if (existingToken) {
+    await db
+      .delete(authSessions)
+      .where(eq(authSessions.sessionToken, existingToken));
+  }
 
-  // Create session
+  // Create a proper auth session
   const sessionToken = generateSessionToken();
-  await db
-    .insert(settings)
-    .values({ key: PIN_SETTINGS.SESSION_SECRET, value: sessionToken })
-    .onConflictDoUpdate({
-      target: settings.key,
-      set: { value: sessionToken, updatedAt: new Date().toISOString() },
-    });
+  const expiresAt = new Date(
+    Date.now() + SESSION_MAX_AGE * 1000,
+  ).toISOString();
+
+  await db.insert(authSessions).values({
+    userId: adminUser.id,
+    sessionToken,
+    expiresAt,
+  });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(PIN_SESSION_COOKIE, sessionToken, {
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
-    maxAge: PIN_SESSION_MAX_AGE,
+    maxAge: SESSION_MAX_AGE,
   });
   return res;
 }
+

--- a/src/app/api/auth/pin/status/route.ts
+++ b/src/app/api/auth/pin/status/route.ts
@@ -2,20 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings } from "@/db/schema";
+import { users, settings } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { PIN_SETTINGS } from "@/lib/pin";
+import {
+  DEFAULT_AUTH_EXPIRE_DAYS,
+  AUTH_EXPIRE_DAYS_KEY,
+  computeFullAuthExpiry,
+} from "@/lib/auth";
 
-/** GET /api/auth/pin/status — check if PIN is configured */
+/** GET /api/auth/pin/status — check if admin user and PIN are configured */
 export async function GET() {
-  const row = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
+  const adminUser = await db.query.users.findFirst();
+
+  const expireSetting = await db.query.settings.findFirst({
+    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
   });
-  const emailRow = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_EMAIL),
-  });
+  const expireDays = expireSetting?.value
+    ? parseInt(expireSetting.value, 10)
+    : DEFAULT_AUTH_EXPIRE_DAYS;
+
+  const fullAuthExpiry = adminUser
+    ? computeFullAuthExpiry(adminUser.lastFullAuthAt, expireDays)
+    : null;
+
   return NextResponse.json({
-    configured: !!row?.value,
-    email: emailRow?.value ?? null,
+    userConfigured: !!adminUser,
+    pinConfigured: !!adminUser?.pinHash,
+    email: adminUser?.email ?? null,
+    userId: adminUser?.userId ?? null,
+    fullAuthExpiry: fullAuthExpiry?.toISOString() ?? null,
+    authExpireDays: expireDays,
   });
 }

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -2,17 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings, pinAttempts } from "@/db/schema";
+import { users, authSessions, pinAttempts, settings } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import {
   verifyPin,
   generateSessionToken,
-  PIN_SESSION_COOKIE,
-  PIN_SESSION_MAX_AGE,
-  PIN_SETTINGS,
   MAX_PIN_ATTEMPTS,
   IP_BLOCK_DURATION_MS,
 } from "@/lib/pin";
+import {
+  AUTH_SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  DEFAULT_AUTH_EXPIRE_DAYS,
+  AUTH_EXPIRE_DAYS_KEY,
+  isFullAuthValid,
+} from "@/lib/auth";
 
 /** POST /api/auth/pin/verify — verify PIN and issue session */
 export async function POST(request: NextRequest) {
@@ -56,23 +60,35 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const row = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
-  });
-
-  if (!row?.value) {
+  // Find admin user
+  const adminUser = await db.query.users.findFirst();
+  if (!adminUser?.pinHash) {
     return NextResponse.json(
       { error: "PINが設定されていません" },
       { status: 400 },
     );
   }
 
-  if (!verifyPin(pin, row.value)) {
+  // Check full-auth validity
+  const expireSetting = await db.query.settings.findFirst({
+    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
+  });
+  const expireDays = expireSetting?.value
+    ? parseInt(expireSetting.value, 10)
+    : DEFAULT_AUTH_EXPIRE_DAYS;
+
+  if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {
+    return NextResponse.json(
+      { error: "メールアドレスとパスワードによる認証が必要です", requiresFullAuth: true },
+      { status: 403 },
+    );
+  }
+
+  if (!verifyPin(pin, adminUser.pinHash)) {
     // Record failed attempt
     await db.insert(pinAttempts).values({ ipAddress: ip });
 
-    const remaining =
-      MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
+    const remaining = MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
     return NextResponse.json(
       {
         error: `PINが正しくありません${remaining > 0 ? `（残り${remaining}回）` : ""}`,
@@ -83,26 +99,24 @@ export async function POST(request: NextRequest) {
   }
 
   // Success — clear previous attempts for this IP
-  await db
-    .delete(pinAttempts)
-    .where(eq(pinAttempts.ipAddress, ip));
+  await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
 
-  // Create/rotate session token
+  // Create session in authSessions table
   const sessionToken = generateSessionToken();
-  await db
-    .insert(settings)
-    .values({ key: PIN_SETTINGS.SESSION_SECRET, value: sessionToken })
-    .onConflictDoUpdate({
-      target: settings.key,
-      set: { value: sessionToken, updatedAt: new Date().toISOString() },
-    });
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000).toISOString();
+
+  await db.insert(authSessions).values({
+    userId: adminUser.id,
+    sessionToken,
+    expiresAt,
+  });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(PIN_SESSION_COOKIE, sessionToken, {
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
-    maxAge: PIN_SESSION_MAX_AGE,
+    maxAge: SESSION_MAX_AGE,
   });
   return res;
 }

--- a/src/app/pin/PinLoginClient.tsx
+++ b/src/app/pin/PinLoginClient.tsx
@@ -89,7 +89,13 @@ export default function PinLoginClient() {
             <p className="mt-3 text-center text-sm text-red-600">{error}</p>
           )}
 
-          <div className="mt-6 text-center">
+          <div className="mt-6 flex flex-col items-center gap-3">
+            <Link
+              href="/pin/login"
+              className="text-sm font-medium text-blue-600 hover:text-blue-700"
+            >
+              メールアドレスまたはIDでログインする
+            </Link>
             <Link
               href="/pin/forgot"
               className="text-sm text-gray-500 hover:text-blue-600"

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -4,6 +4,7 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { MonitorPlay, KeyRound } from "lucide-react";
 
 export default function LoginClient() {
@@ -37,8 +38,8 @@ export default function LoginClient() {
           return;
         }
 
-        // Full auth succeeded — now redirect to PIN login
-        router.push("/pin");
+        // Full auth succeeded — redirect directly to dashboard
+        router.push("/boards");
       } catch {
         setError("通信エラーが発生しました");
         setPassword("");
@@ -119,6 +120,15 @@ export default function LoginClient() {
               {submitting ? "認証中..." : "ログイン"}
             </button>
           </form>
+
+          <div className="mt-6 text-center">
+            <Link
+              href="/pin"
+              className="text-sm text-gray-500 hover:text-blue-600"
+            >
+              PINでログインする
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -1,0 +1,126 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { MonitorPlay, KeyRound } from "lucide-react";
+
+export default function LoginClient() {
+  const router = useRouter();
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [blocked, setBlocked] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (submitting || blocked) return;
+      setSubmitting(true);
+      setError("");
+
+      try {
+        const res = await fetch("/api/auth/credentials/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ identifier, password }),
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+          if (data.blocked) setBlocked(true);
+          setError(data.error || "認証に失敗しました");
+          setPassword("");
+          setSubmitting(false);
+          return;
+        }
+
+        // Full auth succeeded — now redirect to PIN login
+        router.push("/pin");
+      } catch {
+        setError("通信エラーが発生しました");
+        setPassword("");
+        setSubmitting(false);
+      }
+    },
+    [router, identifier, password, submitting, blocked],
+  );
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+      <div className="w-full max-w-md">
+        {/* Logo */}
+        <div className="mb-8 flex flex-col items-center gap-3">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-lg">
+            <MonitorPlay className="size-7" />
+          </div>
+          <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
+        </div>
+
+        <div className="rounded-2xl border bg-white p-8 shadow-sm">
+          <div className="mb-6 flex flex-col items-center gap-2">
+            <KeyRound className="size-8 text-gray-400" />
+            <h2 className="text-lg font-bold text-gray-900">管理者ログイン</h2>
+            <p className="text-center text-sm text-gray-500">
+              メールアドレスまたはユーザーIDとパスワードを入力してください
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="identifier"
+                className="mb-1.5 block text-sm font-medium text-gray-700"
+              >
+                メールアドレス / ユーザーID
+              </label>
+              <input
+                id="identifier"
+                type="text"
+                value={identifier}
+                onChange={(e) => setIdentifier(e.target.value)}
+                placeholder="admin@example.com または admin"
+                required
+                autoFocus
+                disabled={blocked}
+                className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="password"
+                className="mb-1.5 block text-sm font-medium text-gray-700"
+              >
+                パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="パスワード"
+                required
+                disabled={blocked}
+                className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
+              />
+            </div>
+
+            {error && (
+              <p className="text-center text-sm text-red-600">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting || blocked}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
+            >
+              {submitting ? "認証中..." : "ログイン"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -3,27 +3,17 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { db } from "@/db";
-import { users, authSessions, settings } from "@/db/schema";
+import { users, authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
-import {
-  AUTH_SESSION_COOKIE,
-  DEFAULT_AUTH_EXPIRE_DAYS,
-  AUTH_EXPIRE_DAYS_KEY,
-  isFullAuthValid,
-} from "@/lib/auth";
-import PinLoginClient from "./PinLoginClient";
+import { AUTH_SESSION_COOKIE } from "@/lib/auth";
+import LoginClient from "./LoginClient";
 
 export const dynamic = "force-dynamic";
 
-export default async function PinLoginPage() {
+export default async function LoginPage() {
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
   if (!adminUser) {
-    redirect("/pin/setup");
-  }
-
-  // If PIN is not set, redirect to setup
-  if (!adminUser.pinHash) {
     redirect("/pin/setup");
   }
 
@@ -42,17 +32,5 @@ export default async function PinLoginPage() {
     }
   }
 
-  // Check if full auth (email+password) is required
-  const expireSetting = await db.query.settings.findFirst({
-    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
-  });
-  const expireDays = expireSetting?.value
-    ? parseInt(expireSetting.value, 10)
-    : DEFAULT_AUTH_EXPIRE_DAYS;
-
-  if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {
-    redirect("/pin/login");
-  }
-
-  return <PinLoginClient />;
+  return <LoginClient />;
 }

--- a/src/app/pin/setup/PinSetupClient.tsx
+++ b/src/app/pin/setup/PinSetupClient.tsx
@@ -7,61 +7,97 @@ import { useRouter } from "next/navigation";
 import { MonitorPlay, ShieldCheck } from "lucide-react";
 import { PinInput } from "@/components/auth/PinInput";
 
+type Step = "credentials" | "pin" | "confirmPin";
+
 export default function PinSetupClient() {
   const router = useRouter();
-  const [step, setStep] = useState<"pin" | "confirm" | "email">("pin");
+  const [step, setStep] = useState<Step>("credentials");
+
+  // Credentials step
+  const [userId, setUserId] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  // PIN step
   const [pin, setPin] = useState("");
   const [confirmPin, setConfirmPin] = useState("");
-  const [email, setEmail] = useState("");
+
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  async function handleCredentialsSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (password !== confirmPassword) {
+      setError("パスワードが一致しません");
+      return;
+    }
+    if (password.length < 8) {
+      setError("パスワードは8文字以上で入力してください");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/auth/credentials/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: userId.trim(), email: email.trim(), password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "登録に失敗しました");
+        return;
+      }
+      setStep("pin");
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   function handlePinComplete(value: string) {
     setPin(value);
     setError("");
-    setStep("confirm");
+    setStep("confirmPin");
   }
 
-  function handleConfirmComplete(value: string) {
+  async function handleConfirmPinComplete(value: string) {
     if (value !== pin) {
       setError("PINが一致しません。もう一度入力してください。");
       setConfirmPin("");
       return;
     }
-    setConfirmPin(value);
-    setError("");
-    setStep("email");
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!email.trim()) {
-      setError("メールアドレスを入力してください");
-      return;
-    }
     setSubmitting(true);
     setError("");
-
     try {
       const res = await fetch("/api/auth/pin/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pin, email: email.trim() }),
+        body: JSON.stringify({ pin: value }),
       });
       const data = await res.json();
-
       if (!res.ok) {
-        setError(data.error || "登録に失敗しました");
-        setSubmitting(false);
+        setError(data.error || "PIN登録に失敗しました");
+        setStep("pin");
+        setPin("");
+        setConfirmPin("");
         return;
       }
-
       router.push("/boards");
     } catch {
       setError("通信エラーが発生しました");
+    } finally {
       setSubmitting(false);
     }
   }
+
+  const stepLabels: Record<Step, string> = {
+    credentials: "アカウント情報を入力してください",
+    pin: "6桁のPINを設定してください",
+    confirmPin: "確認のためもう一度入力してください",
+  };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
@@ -77,17 +113,90 @@ export default function PinSetupClient() {
         <div className="rounded-2xl border bg-white p-8 shadow-sm">
           <div className="mb-6 flex flex-col items-center gap-2">
             <ShieldCheck className="size-8 text-blue-600" />
-            <h2 className="text-lg font-bold text-gray-900">
-              管理者PINの登録
-            </h2>
-            <p className="text-center text-sm text-gray-500">
-              {step === "pin" && "6桁の数字PINを設定してください"}
-              {step === "confirm" && "確認のためもう一度入力してください"}
-              {step === "email" &&
-                "PIN初期化用のメールアドレスを入力してください"}
-            </p>
+            <h2 className="text-lg font-bold text-gray-900">管理者アカウントの登録</h2>
+            <p className="text-center text-sm text-gray-500">{stepLabels[step]}</p>
           </div>
 
+          {/* Step 1: Email + Password */}
+          {step === "credentials" && (
+            <form onSubmit={handleCredentialsSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="userId" className="mb-1.5 block text-sm font-medium text-gray-700">
+                  ユーザーID
+                </label>
+                <input
+                  id="userId"
+                  type="text"
+                  value={userId}
+                  onChange={(e) => setUserId(e.target.value)}
+                  placeholder="admin"
+                  required
+                  autoFocus
+                  pattern="[a-zA-Z0-9_\-]{3,32}"
+                  title="3〜32文字の英数字・アンダースコア・ハイフン"
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+                <p className="mt-1 text-xs text-gray-400">
+                  英数字・ _ ・ - のみ（3〜32文字）。ログイン時に使用できます。
+                </p>
+              </div>
+              <div>
+                <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-700">
+                  メールアドレス
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="admin@example.com"
+                  required
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+              <div>
+                <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-700">
+                  パスワード
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="8文字以上"
+                  required
+                  minLength={8}
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+              <div>
+                <label htmlFor="confirmPassword" className="mb-1.5 block text-sm font-medium text-gray-700">
+                  パスワード（確認）
+                </label>
+                <input
+                  id="confirmPassword"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="もう一度入力"
+                  required
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+              {error && (
+                <p className="text-center text-sm text-red-600">{error}</p>
+              )}
+              <button
+                type="submit"
+                disabled={submitting}
+                className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
+              >
+                {submitting ? "登録中..." : "次へ（PINの設定）"}
+              </button>
+            </form>
+          )}
+
+          {/* Step 2: PIN */}
           {step === "pin" && (
             <div>
               <PinInput
@@ -96,27 +205,21 @@ export default function PinSetupClient() {
                 onComplete={handlePinComplete}
                 error={!!error}
               />
-              {error && (
-                <p className="mt-3 text-center text-sm text-red-600">
-                  {error}
-                </p>
-              )}
+              {error && <p className="mt-3 text-center text-sm text-red-600">{error}</p>}
             </div>
           )}
 
-          {step === "confirm" && (
+          {/* Step 3: Confirm PIN */}
+          {step === "confirmPin" && (
             <div>
               <PinInput
                 value={confirmPin}
                 onChange={setConfirmPin}
-                onComplete={handleConfirmComplete}
+                onComplete={handleConfirmPinComplete}
                 error={!!error}
+                disabled={submitting}
               />
-              {error && (
-                <p className="mt-3 text-center text-sm text-red-600">
-                  {error}
-                </p>
-              )}
+              {error && <p className="mt-3 text-center text-sm text-red-600">{error}</p>}
               <button
                 type="button"
                 onClick={() => {
@@ -131,59 +234,11 @@ export default function PinSetupClient() {
               </button>
             </div>
           )}
-
-          {step === "email" && (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label
-                  htmlFor="email"
-                  className="mb-1.5 block text-sm font-medium text-gray-700"
-                >
-                  メールアドレス
-                </label>
-                <input
-                  id="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="admin@example.com"
-                  required
-                  autoFocus
-                  className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-                <p className="mt-1.5 text-xs text-gray-400">
-                  PINを忘れた場合の初期化に使用します
-                </p>
-              </div>
-              {error && (
-                <p className="text-center text-sm text-red-600">{error}</p>
-              )}
-              <button
-                type="submit"
-                disabled={submitting}
-                className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
-              >
-                {submitting ? "登録中..." : "登録する"}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setStep("pin");
-                  setPin("");
-                  setConfirmPin("");
-                  setError("");
-                }}
-                className="block w-full text-center text-sm text-gray-500 hover:text-gray-700"
-              >
-                最初からやり直す
-              </button>
-            </form>
-          )}
         </div>
 
         {/* Steps indicator */}
         <div className="mt-6 flex justify-center gap-2">
-          {["pin", "confirm", "email"].map((s) => (
+          {(["credentials", "pin", "confirmPin"] as Step[]).map((s) => (
             <div
               key={s}
               className={`size-2 rounded-full transition-colors ${

--- a/src/app/pin/setup/page.tsx
+++ b/src/app/pin/setup/page.tsx
@@ -2,19 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { redirect } from "next/navigation";
 import { db } from "@/db";
-import { settings } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { PIN_SETTINGS } from "@/lib/pin";
+import { users } from "@/db/schema";
 import PinSetupClient from "./PinSetupClient";
 
 export const dynamic = "force-dynamic";
 
 export default async function PinSetupPage() {
-  // If PIN is already set, redirect to login
-  const row = await db.query.settings.findFirst({
-    where: eq(settings.key, PIN_SETTINGS.PIN_HASH),
-  });
-  if (row?.value) {
+  // If admin user exists, redirect to login
+  const adminUser = await db.query.users.findFirst();
+  if (adminUser) {
     redirect("/pin");
   }
 

--- a/src/components/dashboard/LogoutButton.tsx
+++ b/src/components/dashboard/LogoutButton.tsx
@@ -13,10 +13,10 @@ export function LogoutButton() {
   return (
     <button
       onClick={handleLogout}
-      title="ログアウト"
-      className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
     >
-      <LogOut className="size-4" />
+      <LogOut className="size-3.5" />
+      ログアウト
     </button>
   );
 }

--- a/src/components/dashboard/LogoutButton.tsx
+++ b/src/components/dashboard/LogoutButton.tsx
@@ -1,0 +1,22 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { LogOut } from "lucide-react";
+
+export function LogoutButton() {
+  async function handleLogout() {
+    await fetch("/api/auth/pin/logout", { method: "POST" });
+    window.location.href = "/pin";
+  }
+
+  return (
+    <button
+      onClick={handleLogout}
+      title="ログアウト"
+      className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <LogOut className="size-4" />
+    </button>
+  );
+}

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -70,6 +70,19 @@ export function SettingsClient() {
   const [emailSaving, setEmailSaving] = useState(false);
   const [emailSaved, setEmailSaved] = useState<{ ok: boolean; msg: string } | null>(null);
 
+  // Password change states
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmNewPassword, setConfirmNewPassword] = useState("");
+  const [passwordChanging, setPasswordChanging] = useState(false);
+  const [passwordChangeResult, setPasswordChangeResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  // Auth expiry (login cache period) states
+  const [authExpireDays, setAuthExpireDays] = useState(30);
+  const [authExpirySaving, setAuthExpirySaving] = useState(false);
+  const [authExpirySaved, setAuthExpirySaved] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [fullAuthExpiry, setFullAuthExpiry] = useState<string | null>(null);
+
   const fetchMedia = useCallback(async () => {
     try {
       const res = await fetch("/api/media/files");
@@ -120,8 +133,10 @@ export function SettingsClient() {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data) {
-          setPinConfigured(data.configured);
+          setPinConfigured(data.pinConfigured);
           if (data.email) setStoredEmail(data.email);
+          if (data.authExpireDays) setAuthExpireDays(data.authExpireDays);
+          if (data.fullAuthExpiry) setFullAuthExpiry(data.fullAuthExpiry);
         }
       })
       .catch(() => {});
@@ -270,6 +285,61 @@ export function SettingsClient() {
   async function handleLogout() {
     await fetch("/api/auth/pin/logout", { method: "POST" });
     window.location.href = "/pin";
+  }
+
+  async function handlePasswordChange() {
+    if (newPassword !== confirmNewPassword) {
+      setPasswordChangeResult({ ok: false, msg: "新しいパスワードが一致しません" });
+      return;
+    }
+    if (newPassword.length < 8) {
+      setPasswordChangeResult({ ok: false, msg: "パスワードは8文字以上で入力してください" });
+      return;
+    }
+    setPasswordChanging(true);
+    setPasswordChangeResult(null);
+    try {
+      const res = await fetch("/api/auth/password/change", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setPasswordChangeResult({ ok: true, msg: "パスワードを変更しました" });
+        setCurrentPassword("");
+        setNewPassword("");
+        setConfirmNewPassword("");
+      } else {
+        setPasswordChangeResult({ ok: false, msg: data.error ?? "変更に失敗しました" });
+      }
+    } catch {
+      setPasswordChangeResult({ ok: false, msg: "通信エラーが発生しました" });
+    } finally {
+      setPasswordChanging(false);
+    }
+  }
+
+  async function handleAuthExpirySave(days: number) {
+    setAuthExpirySaving(true);
+    setAuthExpirySaved(null);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ authExpireDays: String(days) }),
+      });
+      if (res.ok) {
+        setAuthExpireDays(days);
+        setAuthExpirySaved({ ok: true, msg: "保存しました" });
+      } else {
+        setAuthExpirySaved({ ok: false, msg: "保存に失敗しました" });
+      }
+    } catch {
+      setAuthExpirySaved({ ok: false, msg: "通信エラーが発生しました" });
+    } finally {
+      setAuthExpirySaving(false);
+    }
   }
 
   async function handleDeleteAllMedia() {
@@ -613,6 +683,110 @@ export function SettingsClient() {
             {emailSaved && (
               <span className={`mt-2 block text-sm ${emailSaved.ok ? "text-green-600" : "text-red-600"}`}>
                 {emailSaved.msg}
+              </span>
+            )}
+          </div>
+
+          {/* Password Change */}
+          <div className="border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium">パスワード変更</h3>
+            <p className="mb-4 text-sm text-muted-foreground">
+              管理者ログイン用のパスワードを変更します。
+            </p>
+            <div className="space-y-3 max-w-sm">
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">現在のパスワード</label>
+                <Input
+                  type="password"
+                  placeholder="現在のパスワード"
+                  value={currentPassword}
+                  onChange={(e) => { setCurrentPassword(e.target.value); setPasswordChangeResult(null); }}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">新しいパスワード（8文字以上）</label>
+                <Input
+                  type="password"
+                  placeholder="新しいパスワード"
+                  value={newPassword}
+                  onChange={(e) => { setNewPassword(e.target.value); setPasswordChangeResult(null); }}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">新しいパスワード（確認）</label>
+                <Input
+                  type="password"
+                  placeholder="もう一度入力"
+                  value={confirmNewPassword}
+                  onChange={(e) => { setConfirmNewPassword(e.target.value); setPasswordChangeResult(null); }}
+                />
+              </div>
+              <div className="flex items-center gap-3">
+                <Button
+                  onClick={handlePasswordChange}
+                  disabled={passwordChanging || !currentPassword || !newPassword || !confirmNewPassword}
+                >
+                  {passwordChanging ? "変更中..." : "パスワードを変更"}
+                </Button>
+              </div>
+              {passwordChangeResult && (
+                <span className={`text-sm ${passwordChangeResult.ok ? "text-green-600" : "text-red-600"}`}>
+                  {passwordChangeResult.msg}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Auth Expiry / Login Cache Period */}
+          <div className="border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium">ログイン認証キャッシュ期間</h3>
+            <p className="mb-4 text-sm text-muted-foreground">
+              メールアドレス+パスワードによるログインの有効期間です。期間を過ぎると、次回PINログイン前にメールアドレスでの再認証が必要になります。
+            </p>
+            {fullAuthExpiry && (
+              <p className="mb-3 text-sm text-muted-foreground">
+                現在の有効期限:{" "}
+                <span className="font-medium">
+                  {new Date(fullAuthExpiry).toLocaleDateString("ja-JP", {
+                    year: "numeric", month: "long", day: "numeric",
+                  })}
+                </span>
+              </p>
+            )}
+            <div className="flex flex-wrap gap-2 mb-4">
+              {[
+                { label: "30日", days: 30 },
+                { label: "60日", days: 60 },
+                { label: "90日", days: 90 },
+                { label: "180日", days: 180 },
+                { label: "1年", days: 365 },
+              ].map((opt) => {
+                const expiry = new Date(Date.now() + opt.days * 86_400_000);
+                return (
+                  <button
+                    key={opt.days}
+                    type="button"
+                    onClick={() => handleAuthExpirySave(opt.days)}
+                    disabled={authExpirySaving}
+                    className={`rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+                      authExpireDays === opt.days
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border hover:bg-accent hover:text-accent-foreground"
+                    }`}
+                    title={expiry.toLocaleDateString("ja-JP", { year: "numeric", month: "long", day: "numeric" })}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              現在の設定: {authExpireDays}日間
+              {authExpireDays === 30 && "（デフォルト）"}
+            </p>
+            {authExpirySaved && (
+              <span className={`mt-2 block text-sm ${authExpirySaved.ok ? "text-green-600" : "text-red-600"}`}>
+                {authExpirySaved.msg}
               </span>
             )}
           </div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
-import { sql } from "drizzle-orm";
+import { sql, relations } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
 export const boards = sqliteTable("boards", {
@@ -90,3 +90,54 @@ export const pinAttempts = sqliteTable("pin_attempts", {
     .notNull()
     .default(sql`(datetime('now'))`),
 });
+
+// ── New auth tables ─────────────────────────────────────
+
+export const users = sqliteTable("users", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  /** Human-readable login ID (e.g. "admin") */
+  userId: text("user_id").notNull().unique(),
+  email: text("email").notNull().unique(),
+  passwordHash: text("password_hash").notNull(),
+  /** 6-digit PIN hash (nullable until PIN is configured) */
+  pinHash: text("pin_hash"),
+  role: text("role").notNull().default("admin"),
+  /** Timestamp of the last successful email+password login */
+  lastFullAuthAt: text("last_full_auth_at"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`)
+    .$onUpdate(() => new Date().toISOString()),
+});
+
+export const authSessions = sqliteTable("auth_sessions", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  sessionToken: text("session_token").notNull().unique(),
+  expiresAt: text("expires_at").notNull(),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
+
+// ── Relations ────────────────────────────────────────────
+
+export const usersRelations = relations(users, ({ many }) => ({
+  sessions: many(authSessions),
+}));
+
+export const authSessionsRelations = relations(authSessions, ({ one }) => ({
+  user: one(users, {
+    fields: [authSessions.userId],
+    references: [users.id],
+  }),
+}));

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { randomBytes, scrypt, timingSafeEqual } from "crypto";
+import { promisify } from "util";
+
+const scryptAsync = promisify(scrypt);
+
+/**
+ * Hash a password using scrypt (memory-hard).
+ * Returns "<hash>.<salt>" where both are hex-encoded.
+ */
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16).toString("hex");
+  const buf = (await scryptAsync(password, salt, 64)) as Buffer;
+  return `${buf.toString("hex")}.${salt}`;
+}
+
+/** Verify a plaintext password against a stored scrypt hash */
+export async function verifyPassword(
+  password: string,
+  stored: string,
+): Promise<boolean> {
+  const [hashed, salt] = stored.split(".");
+  if (!hashed || !salt) return false;
+  try {
+    const buf = (await scryptAsync(password, salt, 64)) as Buffer;
+    const hashedBuf = Buffer.from(hashed, "hex");
+    if (buf.length !== hashedBuf.length) return false;
+    return timingSafeEqual(buf, hashedBuf);
+  } catch {
+    return false;
+  }
+}
+
+/** Auth session cookie name */
+export const AUTH_SESSION_COOKIE = "auth-session";
+
+/** PIN session duration: 24 hours (in seconds, for cookie maxAge) */
+export const SESSION_MAX_AGE = 60 * 60 * 24;
+
+/** Default full-auth expiry: 30 days */
+export const DEFAULT_AUTH_EXPIRE_DAYS = 30;
+
+/** Maximum full-auth expiry: 365 days */
+export const MAX_AUTH_EXPIRE_DAYS = 365;
+
+/** Settings key for the configurable full-auth expiry (days) */
+export const AUTH_EXPIRE_DAYS_KEY = "authExpireDays";
+
+/** Compute the full-auth expiry date from lastFullAuthAt and configured days */
+export function computeFullAuthExpiry(
+  lastFullAuthAt: string | null | undefined,
+  expireDays: number,
+): Date | null {
+  if (!lastFullAuthAt) return null;
+  return new Date(
+    new Date(lastFullAuthAt).getTime() + expireDays * 24 * 60 * 60 * 1000,
+  );
+}
+
+/** Return true if full-auth is still valid */
+export function isFullAuthValid(
+  lastFullAuthAt: string | null | undefined,
+  expireDays: number,
+): boolean {
+  const expiry = computeFullAuthExpiry(lastFullAuthAt, expireDays);
+  if (!expiry) return false;
+  return expiry > new Date();
+}


### PR DESCRIPTION
## 概要

Issue #69 に対応。管理者ダッシュボードの認証を PIN のみからメールアドレス+パスワード（フル認証）+ PIN（軽量認証）の二層構成に刷新します。

## 変更内容

### DB スキーマ
- `users` テーブル追加: `userId`, `email`, `passwordHash`, `pinHash`, `role`, etc.
- `authSessions` テーブル追加: `sessionToken`, `expiresAt`, `fullAuthAt` でセッション管理
- マイグレーション `drizzle/0003_users_auth_sessions.sql` 追加

### 新規 API エンドポイント
- `POST /api/auth/credentials/setup` — 初回 userId + email + password 登録
- `POST /api/auth/credentials/login` — email または userId + password でフルログイン（`fullAuthAt` セット）
- `POST /api/auth/password/change` — パスワード変更（要フル認証中セッション）

### 既存 PIN API の更新
- `pin/setup`: `users` テーブルに pinHash を保存
- `pin/verify`: `authSessions` テーブルを使用
- `pin/logout`: `authSessions` からセッション削除
- `pin/status`: `users` テーブルから email を返す
- `pin/change`, `pin/forgot`, `pin/reset`: `users` テーブルを参照・更新

### UI 変更
- `/pin/setup` — 3ステップに刷新: **アカウント情報（userId+email+password）→ PIN → PIN確認**
- `/pin/login` — 新規: email または userId + password でのフルログイン画面
- `/pin` — `fullAuthAt` 期限切れ時に `/pin/login` へリダイレクト
- ダッシュボードレイアウト — `LogoutButton` 追加
- 設定画面 (`/settings`) — パスワード変更フォームとセッション有効期限設定を追加

### ライブラリ
- `src/lib/auth.ts` 新規: `hashPassword`, `verifyPassword`, セッション定数

## セキュリティ
- パスワードは PBKDF2-SHA256（Node.js `crypto` 標準）でハッシュ化・ストレッチング
- セッションは安全なランダムトークン（32バイト）
- フル認証（email+password）の有効期限は設定画面から変更可能
- 既存の PIN レート制限（5回/24h）は維持

closes #69