### PR TITLE
feat: 複数アカウント管理 (#72)

### DIFF
--- a/drizzle/0004_user_color_theme.sql
+++ b/drizzle/0004_user_color_theme.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `color_theme` text NOT NULL DEFAULT 'system';

--- a/drizzle/0005_pin_reset_token_user.sql
+++ b/drizzle/0005_pin_reset_token_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pin_reset_tokens` ADD `user_id` text REFERENCES `users`(`id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776700000000,
       "tag": "0003_users_auth_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1776800000000,
+      "tag": "0004_user_color_theme",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776800000000,
       "tag": "0004_user_color_theme",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1776900000000,
+      "tag": "0005_pin_reset_token_user",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -46,7 +46,10 @@ export default async function DashboardLayout({
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
 
+  console.log("[dashboard/layout] Auth check", { hasSessionToken: !!sessionToken });
+
   if (!sessionToken) {
+    console.log("[dashboard/layout] No session token → /pin");
     redirect("/pin");
   }
 
@@ -60,6 +63,7 @@ export default async function DashboardLayout({
   });
 
   if (!session) {
+    console.log("[dashboard/layout] Session not found or expired → /pin");
     redirect("/pin");
   }
 
@@ -71,7 +75,16 @@ export default async function DashboardLayout({
     ? parseInt(expireSetting.value, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  if (!isFullAuthValid(session.user.lastFullAuthAt, expireDays)) {
+  const fullValid = isFullAuthValid(session.user.lastFullAuthAt, expireDays);
+  console.log("[dashboard/layout] Full auth check", {
+    userId: session.user.userId,
+    lastFullAuthAt: session.user.lastFullAuthAt,
+    expireDays,
+    fullValid,
+  });
+
+  if (!fullValid) {
+    console.log("[dashboard/layout] Full auth expired → /pin");
     redirect("/pin");
   }
 

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import Link from "next/link";
-import { LayoutDashboard, MonitorPlay, Settings } from "lucide-react";
+import { LayoutDashboard, MonitorPlay, Settings, Users } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -75,23 +75,42 @@ export default async function DashboardLayout({
     redirect("/pin");
   }
 
+  const { userId, role, colorTheme } = session.user;
+
   return (
-    <ThemeProvider>
+    <ThemeProvider initialTheme={colorTheme as "system" | "light" | "dark"}>
       <div id="dashboard-theme-root" className="flex min-h-dvh bg-background text-foreground">
         {/* Sidebar */}
         <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
-          <div className="flex h-14 items-center justify-between px-4">
-            <Link href="/boards" className="flex items-center gap-2 font-bold">
-              <MonitorPlay className="size-5" />
-              <span>Keinage</span>
-            </Link>
-            <LogoutButton />
+          <div className="flex h-auto min-h-14 flex-col justify-center gap-0.5 px-4 py-3">
+            <div className="flex items-center justify-between">
+              <Link href="/boards" className="flex items-center gap-2 font-bold">
+                <MonitorPlay className="size-5" />
+                <span>Keinage</span>
+              </Link>
+              <LogoutButton />
+            </div>
+            <div className="flex items-center gap-1.5 pl-0.5">
+              <span className="text-xs text-muted-foreground">{userId}</span>
+              <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+                role === "admin"
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                  : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+              }`}>
+                {role === "admin" ? "Admin" : "General"}
+              </span>
+            </div>
           </div>
           <Separator />
           <nav className="flex-1 space-y-1 px-2 py-3">
             <SidebarLink href="/boards" icon={LayoutDashboard}>
               ボード管理
             </SidebarLink>
+            {role === "admin" && (
+              <SidebarLink href="/users" icon={Users}>
+                ユーザー管理
+              </SidebarLink>
+            )}
             <SidebarLink href="/settings" icon={Settings}>
               設定
             </SidebarLink>

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -1,14 +1,14 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
 import { db } from "@/db";
 import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import { AUTH_SESSION_COOKIE } from "@/lib/auth";
-import { SettingsClient } from "@/components/dashboard/SettingsClient";
+import { UserManagement } from "@/components/dashboard/UserManagement";
 
-export default async function SettingsPage() {
+export default async function UsersPage() {
   const cookieStore = await cookies();
   const token = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
   if (!token) redirect("/pin");
@@ -20,12 +20,15 @@ export default async function SettingsPage() {
     ),
     with: { user: true },
   });
-  if (!session) redirect("/pin");
+
+  if (!session || session.user.role !== "admin") {
+    redirect("/boards");
+  }
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold">設定</h1>
-      <SettingsClient role={session.user.role as "admin" | "general"} currentUserId={session.user.userId} />
+      <h1 className="mb-6 text-2xl font-bold">ユーザー管理</h1>
+      <UserManagement />
     </div>
   );
 }

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users, pinAttempts, authSessions } from "@/db/schema";
 import { eq, or, and, gt } from "drizzle-orm";
-import { verifyPassword, AUTH_SESSION_COOKIE, SESSION_MAX_AGE } from "@/lib/auth";
+import { verifyPassword, AUTH_SESSION_COOKIE, SESSION_MAX_AGE, LAST_USER_COOKIE } from "@/lib/auth";
 import {
   MAX_PIN_ATTEMPTS,
   IP_BLOCK_DURATION_MS,
@@ -112,6 +112,13 @@ export async function POST(request: NextRequest) {
     sameSite: "lax",
     path: "/",
     maxAge: SESSION_MAX_AGE,
+  });
+  // Remember which user last authenticated so the PIN screen can target them
+  res.cookies.set(LAST_USER_COOKIE, user.userId, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365, // 1 year
   });
   return res;
 }

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -63,6 +63,12 @@ export async function POST(request: NextRequest) {
     ),
   });
 
+  console.log("[credentials/login] User lookup", {
+    identifier,
+    found: !!user,
+    userId: user?.userId ?? null,
+  });
+
   // Constant-time failure to prevent user enumeration
   if (!user) {
     await db.insert(pinAttempts).values({ ipAddress: ip });
@@ -73,6 +79,11 @@ export async function POST(request: NextRequest) {
   }
 
   const valid = await verifyPassword(password, user.passwordHash);
+  console.log("[credentials/login] Password verify result", {
+    userId: user.userId,
+    valid,
+    pwHashLen: user.passwordHash?.length ?? 0,
+  });
   if (!valid) {
     await db.insert(pinAttempts).values({ ipAddress: ip });
     const remaining = MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
@@ -87,6 +98,8 @@ export async function POST(request: NextRequest) {
 
   // Clear IP attempts on success
   await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
+
+  console.log("[credentials/login] Password verified OK for", user.userId);
 
   const now = new Date().toISOString();
 

--- a/src/app/api/auth/pin/change/route.ts
+++ b/src/app/api/auth/pin/change/route.ts
@@ -26,11 +26,12 @@ export async function PATCH(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { action, currentPin, newPin, newEmail } = body as {
-    action: "verifyCurrentPin" | "changePin" | "changeEmail";
+  const { action, currentPin, newPin, newEmail, newUserId } = body as {
+    action: "verifyCurrentPin" | "changePin" | "changeEmail" | "changeUserId";
     currentPin?: string;
     newPin?: string;
     newEmail?: string;
+    newUserId?: string;
   };
 
   const adminUser = await db.query.users.findFirst({
@@ -96,6 +97,33 @@ export async function PATCH(request: NextRequest) {
     await db
       .update(users)
       .set({ email: newEmail })
+      .where(eq(users.id, adminUser.id));
+
+    return NextResponse.json({ success: true });
+  }
+
+  if (action === "changeUserId") {
+    if (!newUserId || !/^[a-zA-Z0-9_\-]{3,32}$/.test(newUserId)) {
+      return NextResponse.json(
+        { error: "ユーザーIDは3〜32文字の英数字・_・-のみ使用できます" },
+        { status: 400 },
+      );
+    }
+
+    // Check uniqueness
+    const existing = await db.query.users.findFirst({
+      where: eq(users.userId, newUserId),
+    });
+    if (existing && existing.id !== adminUser.id) {
+      return NextResponse.json(
+        { error: "このユーザーIDはすでに使用されています" },
+        { status: 409 },
+      );
+    }
+
+    await db
+      .update(users)
+      .set({ userId: newUserId })
       .where(eq(users.id, adminUser.id));
 
     return NextResponse.json({ success: true });

--- a/src/app/api/auth/pin/change/route.ts
+++ b/src/app/api/auth/pin/change/route.ts
@@ -27,7 +27,7 @@ export async function PATCH(request: NextRequest) {
 
   const body = await request.json();
   const { action, currentPin, newPin, newEmail, newUserId } = body as {
-    action: "verifyCurrentPin" | "changePin" | "changeEmail" | "changeUserId";
+    action: "verifyCurrentPin" | "changePin" | "setupPin" | "changeEmail" | "changeUserId";
     currentPin?: string;
     newPin?: string;
     newEmail?: string;
@@ -39,6 +39,29 @@ export async function PATCH(request: NextRequest) {
   });
   if (!adminUser) {
     return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+
+  // ── setupPin: set initial PIN for a user who has none ──────────────────────
+  if (action === "setupPin") {
+    if (adminUser.pinHash) {
+      return NextResponse.json(
+        { error: "PINは既に設定されています。変更する場合はPIN変更を使用してください" },
+        { status: 400 },
+      );
+    }
+    if (!newPin || !/^\d{6}$/.test(newPin)) {
+      return NextResponse.json(
+        { error: "PINは6桁の数字で入力してください" },
+        { status: 400 },
+      );
+    }
+
+    await db
+      .update(users)
+      .set({ pinHash: hashPin(newPin) })
+      .where(eq(users.id, adminUser.id));
+
+    return NextResponse.json({ success: true });
   }
 
   if (action === "verifyCurrentPin") {

--- a/src/app/api/auth/pin/forgot/route.ts
+++ b/src/app/api/auth/pin/forgot/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
   const token = generateResetToken();
   const expiresAt = new Date(Date.now() + RESET_TOKEN_TTL_MS).toISOString();
 
-  await db.insert(pinResetTokens).values({ token, expiresAt });
+  await db.insert(pinResetTokens).values({ token, expiresAt, userId: adminUser.id });
 
   // Build reset URL
   const requestHost = request.headers.get("host") || "localhost:3000";

--- a/src/app/api/auth/pin/logout/route.ts
+++ b/src/app/api/auth/pin/logout/route.ts
@@ -12,6 +12,8 @@ export async function POST() {
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
 
+  console.log("[logout] Clearing session", { hasToken: !!sessionToken });
+
   if (sessionToken) {
     await db
       .delete(authSessions)

--- a/src/app/api/auth/pin/reset/route.ts
+++ b/src/app/api/auth/pin/reset/route.ts
@@ -48,9 +48,11 @@ export async function POST(request: NextRequest) {
     .set({ usedAt: now })
     .where(eq(pinResetTokens.id, resetToken.id));
 
-  // Update PIN hash on admin user
-  const adminUser = await db.query.users.findFirst();
-  if (!adminUser) {
+  // Find the user linked to this token, else fall back to first admin user
+  let targetUser = resetToken.userId
+    ? await db.query.users.findFirst({ where: eq(users.id, resetToken.userId) })
+    : await db.query.users.findFirst();
+  if (!targetUser) {
     return NextResponse.json(
       { error: "管理者ユーザーが見つかりません" },
       { status: 400 },
@@ -60,7 +62,7 @@ export async function POST(request: NextRequest) {
   await db
     .update(users)
     .set({ pinHash: hashPin(pin) })
-    .where(eq(users.id, adminUser.id));
+    .where(eq(users.id, targetUser.id));
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/auth/pin/status/route.ts
+++ b/src/app/api/auth/pin/status/route.ts
@@ -1,18 +1,49 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { db } from "@/db";
-import { users, settings } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { users, settings, authSessions } from "@/db/schema";
+import { eq, and, gt } from "drizzle-orm";
 import {
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   computeFullAuthExpiry,
+  AUTH_SESSION_COOKIE,
+  LAST_USER_COOKIE,
 } from "@/lib/auth";
 
 /** GET /api/auth/pin/status — check if admin user and PIN are configured */
 export async function GET() {
-  const adminUser = await db.query.users.findFirst();
+  const cookieStore = await cookies();
+
+  // Prefer the logged-in session user; fall back to last-user cookie; then first user
+  let targetUser: typeof users.$inferSelect | null | undefined = null;
+
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  if (sessionToken) {
+    const session = await db.query.authSessions.findFirst({
+      where: and(
+        eq(authSessions.sessionToken, sessionToken),
+        gt(authSessions.expiresAt, new Date().toISOString()),
+      ),
+      with: { user: true },
+    });
+    targetUser = session?.user ?? null;
+  }
+
+  if (!targetUser) {
+    const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
+    if (lastUserId) {
+      targetUser = await db.query.users.findFirst({
+        where: eq(users.userId, lastUserId),
+      });
+    }
+  }
+
+  if (!targetUser) {
+    targetUser = await db.query.users.findFirst();
+  }
 
   const expireSetting = await db.query.settings.findFirst({
     where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
@@ -21,15 +52,15 @@ export async function GET() {
     ? parseInt(expireSetting.value, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  const fullAuthExpiry = adminUser
-    ? computeFullAuthExpiry(adminUser.lastFullAuthAt, expireDays)
+  const fullAuthExpiry = targetUser
+    ? computeFullAuthExpiry(targetUser.lastFullAuthAt, expireDays)
     : null;
 
   return NextResponse.json({
-    userConfigured: !!adminUser,
-    pinConfigured: !!adminUser?.pinHash,
-    email: adminUser?.email ?? null,
-    userId: adminUser?.userId ?? null,
+    userConfigured: !!targetUser,
+    pinConfigured: !!targetUser?.pinHash,
+    email: targetUser?.email ?? null,
+    userId: targetUser?.userId ?? null,
     fullAuthExpiry: fullAuthExpiry?.toISOString() ?? null,
     authExpireDays: expireDays,
   });

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -61,10 +61,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Resolve target user — same logic as pin/page.tsx so they stay in sync:
-  //   1. LAST_USER_COOKIE user (if they have a PIN)
-  //   2. First user WITH a pinHash (fallback when cookie user has no PIN)
-  //   3. First user at all (ultimate fallback)
+  // Resolve target user — same logic as pin/page.tsx:
+  //   - If LAST_USER_COOKIE user exists and has a PIN → that user
+  //   - If cookie user has no PIN or not found → first user with a PIN
   const cookieStore = request.cookies;
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
   let adminUser = lastUserId
@@ -72,12 +71,9 @@ export async function POST(request: NextRequest) {
     : null;
 
   if (!adminUser?.pinHash) {
+    // Cookie user has no PIN (or not found) — fall back to first user with a PIN
     const userWithPin = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
-    if (userWithPin) adminUser = userWithPin;
-  }
-
-  if (!adminUser) {
-    adminUser = await db.query.users.findFirst();
+    adminUser = userWithPin ?? adminUser;
   }
   if (!adminUser?.pinHash) {
     return NextResponse.json(
@@ -134,6 +130,13 @@ export async function POST(request: NextRequest) {
     sameSite: "lax",
     path: "/",
     maxAge: SESSION_MAX_AGE,
+  });
+  // Keep LAST_USER_COOKIE up-to-date so next logout shows the correct PIN screen
+  res.cookies.set(LAST_USER_COOKIE, adminUser.userId, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365, // 1 year
   });
   return res;
 }

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
+  LAST_USER_COOKIE,
 } from "@/lib/auth";
 
 /** POST /api/auth/pin/verify — verify PIN and issue session */
@@ -60,8 +61,13 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Find admin user
-  const adminUser = await db.query.users.findFirst();
+  // Find target user: prefer last-logged-in user, fallback to first admin user
+  const cookieStore = await request.cookies;
+  const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
+  const adminUser = lastUserId
+    ? (await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })) ??
+      (await db.query.users.findFirst())
+    : await db.query.users.findFirst();
   if (!adminUser?.pinHash) {
     return NextResponse.json(
       { error: "PINが設定されていません" },

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -3,7 +3,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users, authSessions, pinAttempts, settings } from "@/db/schema";
-import { eq, and, gt } from "drizzle-orm";
+import { eq, and, gt, isNotNull } from "drizzle-orm";
 import {
   verifyPin,
   generateSessionToken,
@@ -61,13 +61,24 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Find target user: prefer last-logged-in user, fallback to first admin user
-  const cookieStore = await request.cookies;
+  // Resolve target user — same logic as pin/page.tsx so they stay in sync:
+  //   1. LAST_USER_COOKIE user (if they have a PIN)
+  //   2. First user WITH a pinHash (fallback when cookie user has no PIN)
+  //   3. First user at all (ultimate fallback)
+  const cookieStore = request.cookies;
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
-  const adminUser = lastUserId
-    ? (await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })) ??
-      (await db.query.users.findFirst())
-    : await db.query.users.findFirst();
+  let adminUser = lastUserId
+    ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
+    : null;
+
+  if (!adminUser?.pinHash) {
+    const userWithPin = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
+    if (userWithPin) adminUser = userWithPin;
+  }
+
+  if (!adminUser) {
+    adminUser = await db.query.users.findFirst();
+  }
   if (!adminUser?.pinHash) {
     return NextResponse.json(
       { error: "PINが設定されていません" },

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -62,18 +62,37 @@ export async function POST(request: NextRequest) {
   }
 
   // Resolve target user — same logic as pin/page.tsx:
-  //   - If LAST_USER_COOKIE user exists and has a PIN → that user
-  //   - If cookie user has no PIN or not found → first user with a PIN
+  //   Cookie user found + has PIN → that user
+  //   Cookie user found + no PIN → error (should not reach verify)
+  //   Cookie user not found → first user with PIN
   const cookieStore = request.cookies;
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
   let adminUser = lastUserId
     ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
     : null;
 
-  if (!adminUser?.pinHash) {
-    // Cookie user has no PIN (or not found) — fall back to first user with a PIN
-    const userWithPin = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
-    adminUser = userWithPin ?? adminUser;
+  console.log("[pin/verify] User resolution", {
+    lastUserId,
+    cookieUserFound: !!adminUser,
+    cookieUserHasPIN: !!adminUser?.pinHash,
+  });
+
+  if (adminUser) {
+    if (!adminUser.pinHash) {
+      // Cookie user has no PIN — they shouldn't be using PIN verify
+      console.log("[pin/verify] Cookie user has no PIN → error");
+      return NextResponse.json(
+        { error: "PINが設定されていません。メールアドレスでログインしてください。", requiresFullAuth: true },
+        { status: 403 },
+      );
+    }
+  } else {
+    // No cookie or cookie user not found — fall back to first user with a PIN
+    adminUser = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
+    console.log("[pin/verify] Fallback user with PIN", {
+      found: !!adminUser,
+      userId: adminUser?.userId ?? null,
+    });
   }
   if (!adminUser?.pinHash) {
     return NextResponse.json(
@@ -102,6 +121,7 @@ export async function POST(request: NextRequest) {
     await db.insert(pinAttempts).values({ ipAddress: ip });
 
     const remaining = MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
+    console.log("[pin/verify] PIN incorrect for", adminUser.userId, { remaining });
     return NextResponse.json(
       {
         error: `PINが正しくありません${remaining > 0 ? `（残り${remaining}回）` : ""}`,
@@ -113,6 +133,8 @@ export async function POST(request: NextRequest) {
 
   // Success — clear previous attempts for this IP
   await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
+
+  console.log("[pin/verify] PIN verified OK for", adminUser.userId);
 
   // Create session in authSessions table
   const sessionToken = generateSessionToken();

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { eq, ne, and } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
+
+/** PATCH /api/users/[id] — update user role (admin only) */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+  if (session.user.role !== "admin") {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+  const { role } = body as { role?: string };
+
+  if (role !== "admin" && role !== "general") {
+    return NextResponse.json(
+      { error: "role は 'admin' または 'general' を指定してください" },
+      { status: 400 },
+    );
+  }
+
+  const target = await db.query.users.findFirst({ where: eq(users.id, id) });
+  if (!target) {
+    return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+
+  // Prevent removing the last admin
+  if (target.role === "admin" && role === "general") {
+    const otherAdmins = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.role, "admin"), ne(users.id, id)));
+    if (otherAdmins.length === 0) {
+      return NextResponse.json(
+        { error: "管理者ユーザーは最低1人必要です" },
+        { status: 400 },
+      );
+    }
+  }
+
+  await db.update(users).set({ role }).where(eq(users.id, id));
+  return NextResponse.json({ ok: true });
+}
+
+/** DELETE /api/users/[id] — delete user (admin only, cannot delete last admin) */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+  if (session.user.role !== "admin") {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const target = await db.query.users.findFirst({ where: eq(users.id, id) });
+  if (!target) {
+    return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+
+  // Prevent deleting the last admin
+  if (target.role === "admin") {
+    const otherAdmins = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.role, "admin"), ne(users.id, id)));
+    if (otherAdmins.length === 0) {
+      return NextResponse.json(
+        { error: "管理者ユーザーは最低1人必要です。削除できません。" },
+        { status: 400 },
+      );
+    }
+  }
+
+  await db.delete(users).where(eq(users.id, id));
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
+
+/** PATCH /api/users/me — update current user's mutable preferences */
+export async function PATCH(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { colorTheme } = body as { colorTheme?: string };
+
+  if (colorTheme !== undefined) {
+    if (!["system", "light", "dark"].includes(colorTheme)) {
+      return NextResponse.json(
+        { error: "colorTheme は 'system' / 'light' / 'dark' のいずれかを指定してください" },
+        { status: 400 },
+      );
+    }
+    await db
+      .update(users)
+      .set({ colorTheme })
+      .where(eq(users.id, session.userId));
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,105 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
+import { hashPassword } from "@/lib/auth";
+import { randomUUID } from "crypto";
+
+/** GET /api/users — list all users (admin only) */
+export async function GET() {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+  if (session.user.role !== "admin") {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const allUsers = await db
+    .select({
+      id: users.id,
+      userId: users.userId,
+      email: users.email,
+      role: users.role,
+      createdAt: users.createdAt,
+    })
+    .from(users)
+    .orderBy(users.createdAt);
+
+  return NextResponse.json(allUsers);
+}
+
+/** POST /api/users — create a new user (admin only) */
+export async function POST(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+  if (session.user.role !== "admin") {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { userId, email, password, role } = body as {
+    userId?: string;
+    email?: string;
+    password?: string;
+    role?: string;
+  };
+
+  if (!userId || !email || !password) {
+    return NextResponse.json(
+      { error: "ユーザーID・メールアドレス・パスワードは必須です" },
+      { status: 400 },
+    );
+  }
+  if (!/^[a-zA-Z0-9_\-]{3,32}$/.test(userId)) {
+    return NextResponse.json(
+      { error: "ユーザーIDは3〜32文字の英数字・_・-のみ使用できます" },
+      { status: 400 },
+    );
+  }
+  if (password.length < 8) {
+    return NextResponse.json(
+      { error: "パスワードは8文字以上で入力してください" },
+      { status: 400 },
+    );
+  }
+  const normalizedRole = role === "general" ? "general" : "admin";
+
+  // Check uniqueness
+  const existing = await db.query.users.findFirst({
+    where: eq(users.userId, userId),
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "このユーザーIDはすでに使用されています" },
+      { status: 409 },
+    );
+  }
+  const existingEmail = await db.query.users.findFirst({
+    where: eq(users.email, email),
+  });
+  if (existingEmail) {
+    return NextResponse.json(
+      { error: "このメールアドレスはすでに使用されています" },
+      { status: 409 },
+    );
+  }
+
+  const passwordHash = await hashPassword(password);
+  const id = randomUUID();
+
+  await db.insert(users).values({
+    id,
+    userId,
+    email,
+    passwordHash,
+    role: normalizedRole,
+  });
+
+  return NextResponse.json({ id, userId, email, role: normalizedRole }, { status: 201 });
+}

--- a/src/app/pin/PinLoginClient.tsx
+++ b/src/app/pin/PinLoginClient.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import { MonitorPlay, Lock } from "lucide-react";
 import { PinInput } from "@/components/auth/PinInput";
 
-export default function PinLoginClient() {
+export default function PinLoginClient({ userId }: { userId: string }) {
   const router = useRouter();
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
@@ -64,10 +64,10 @@ export default function PinLoginClient() {
           <div className="mb-6 flex flex-col items-center gap-2">
             <Lock className="size-8 text-gray-400" />
             <h2 className="text-lg font-bold text-gray-900">
-              管理者PIN入力
+              PIN入力
             </h2>
             <p className="text-center text-sm text-gray-500">
-              6桁のPINを入力してください
+              <span className="font-medium text-gray-700">{userId}</span> のPINを入力してください
             </p>
           </div>
 

--- a/src/app/pin/PinLoginClient.tsx
+++ b/src/app/pin/PinLoginClient.tsx
@@ -29,6 +29,8 @@ export default function PinLoginClient({ userId }: { userId: string }) {
         });
         const data = await res.json();
 
+        console.log("[PinLoginClient] Verify response", { status: res.status, ok: res.ok, data });
+
         if (!res.ok) {
           if (data.blocked) {
             setBlocked(true);

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -30,6 +30,8 @@ export default function LoginClient() {
         });
         const data = await res.json();
 
+        console.log("[LoginClient] Login response", { status: res.status, ok: res.ok, data });
+
         if (!res.ok) {
           if (data.blocked) setBlocked(true);
           setError(data.error || "認証に失敗しました");

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -11,9 +11,12 @@ import LoginClient from "./LoginClient";
 export const dynamic = "force-dynamic";
 
 export default async function LoginPage() {
+  console.log("[/pin/login] START");
+
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
   if (!adminUser) {
+    console.log("[/pin/login] No users → /pin/setup");
     redirect("/pin/setup");
   }
 
@@ -28,9 +31,12 @@ export default async function LoginPage() {
       ),
     });
     if (sessionRow) {
+      console.log("[/pin/login] Already authenticated → /boards");
       redirect("/boards");
     }
+    console.log("[/pin/login] Session cookie present but invalid/expired");
   }
 
+  console.log("[/pin/login] Rendering LoginClient");
   return <LoginClient />;
 }

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -32,9 +32,9 @@ export default async function PinLoginPage() {
     redirect("/pin/setup");
   }
 
-  // If PIN is not set, redirect to setup
+  // If PIN is not set, send to credentials login (PIN setup is only for first user)
   if (!adminUser.pinHash) {
-    redirect("/pin/setup");
+    redirect("/pin/login");
   }
 
   // If already authenticated, redirect to dashboard

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -20,31 +20,25 @@ export default async function PinLoginPage() {
   const cookieStore = await cookies();
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
 
-  // Step 1: Try the last-logged-in user from cookie
+  // Try the last-logged-in user from cookie
   let targetUser = lastUserId
     ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
     : null;
 
-  // Step 2: If that user has no PIN, fall back to the first user who has one
-  if (!targetUser?.pinHash) {
-    const userWithPin = await db.query.users.findFirst({
-      where: isNotNull(users.pinHash),
-    });
-    if (userWithPin) targetUser = userWithPin;
-  }
-
-  // Step 3: Ultimate fallback — any user at all
-  if (!targetUser) {
-    targetUser = await db.query.users.findFirst();
-  }
-
-  if (!targetUser) {
-    redirect("/pin/setup");
-  }
-
-  // If no user in the system has a PIN, go to credential login
-  if (!targetUser.pinHash) {
-    redirect("/pin/login");
+  if (targetUser) {
+    // Cookie user found. If they have no PIN they must use credentials login.
+    if (!targetUser.pinHash) {
+      redirect("/pin/login");
+    }
+  } else {
+    // No cookie or cookie user not found — find first user with a PIN
+    targetUser = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
+    if (!targetUser) {
+      // No user has a PIN at all
+      const anyUser = await db.query.users.findFirst();
+      if (!anyUser) redirect("/pin/setup");
+      redirect("/pin/login");
+    }
   }
 
   // If already authenticated, redirect to dashboard

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -19,30 +19,11 @@ export const dynamic = "force-dynamic";
 export default async function PinLoginPage() {
   const cookieStore = await cookies();
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
-
-  // Try the last-logged-in user from cookie
-  let targetUser = lastUserId
-    ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
-    : null;
-
-  if (targetUser) {
-    // Cookie user found. If they have no PIN they must use credentials login.
-    if (!targetUser.pinHash) {
-      redirect("/pin/login");
-    }
-  } else {
-    // No cookie or cookie user not found — find first user with a PIN
-    targetUser = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
-    if (!targetUser) {
-      // No user has a PIN at all
-      const anyUser = await db.query.users.findFirst();
-      if (!anyUser) redirect("/pin/setup");
-      redirect("/pin/login");
-    }
-  }
-
-  // If already authenticated, redirect to dashboard
   const sessionCookie = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+
+  console.log("[/pin] START", { lastUserId, hasSessionCookie: !!sessionCookie });
+
+  // ── 1. Already authenticated? → dashboard ─────────────────────────
   if (sessionCookie) {
     const sessionRow = await db.query.authSessions.findFirst({
       where: and(
@@ -51,11 +32,50 @@ export default async function PinLoginPage() {
       ),
     });
     if (sessionRow) {
+      console.log("[/pin] Valid session found → /boards");
       redirect("/boards");
+    }
+    console.log("[/pin] Session cookie present but invalid/expired");
+  }
+
+  // ── 2. Resolve target user ─────────────────────────────────────────
+  let targetUser = lastUserId
+    ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
+    : null;
+
+  console.log("[/pin] Cookie user lookup", {
+    lastUserId,
+    found: !!targetUser,
+    hasPIN: !!targetUser?.pinHash,
+    userId: targetUser?.userId ?? null,
+  });
+
+  if (targetUser) {
+    // Cookie user found. If they have no PIN they must use credentials login.
+    if (!targetUser.pinHash) {
+      console.log("[/pin] Cookie user has no PIN → /pin/login");
+      redirect("/pin/login");
+    }
+  } else {
+    // No cookie or cookie user not found — find first user with a PIN
+    targetUser = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
+    console.log("[/pin] Fallback user with PIN", {
+      found: !!targetUser,
+      userId: targetUser?.userId ?? null,
+    });
+    if (!targetUser) {
+      // No user has a PIN at all
+      const anyUser = await db.query.users.findFirst();
+      if (!anyUser) {
+        console.log("[/pin] No users at all → /pin/setup");
+        redirect("/pin/setup");
+      }
+      console.log("[/pin] No user has PIN → /pin/login");
+      redirect("/pin/login");
     }
   }
 
-  // Check if full auth (email+password) is required for the target user
+  // ── 3. Check full auth validity ────────────────────────────────────
   const expireSetting = await db.query.settings.findFirst({
     where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
   });
@@ -63,9 +83,19 @@ export default async function PinLoginPage() {
     ? parseInt(expireSetting.value, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  if (!isFullAuthValid(targetUser.lastFullAuthAt, expireDays)) {
+  const fullAuthValid = isFullAuthValid(targetUser.lastFullAuthAt, expireDays);
+  console.log("[/pin] Full auth check", {
+    userId: targetUser.userId,
+    lastFullAuthAt: targetUser.lastFullAuthAt,
+    expireDays,
+    fullAuthValid,
+  });
+
+  if (!fullAuthValid) {
+    console.log("[/pin] Full auth expired → /pin/login");
     redirect("/pin/login");
   }
 
+  console.log("[/pin] Showing PIN screen for", targetUser.userId);
   return <PinLoginClient userId={targetUser.userId} />;
 }

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { db } from "@/db";
 import { users, authSessions, settings } from "@/db/schema";
-import { eq, and, gt } from "drizzle-orm";
+import { eq, and, gt, isNotNull } from "drizzle-orm";
 import {
   AUTH_SESSION_COOKIE,
   DEFAULT_AUTH_EXPIRE_DAYS,
@@ -17,23 +17,33 @@ import PinLoginClient from "./PinLoginClient";
 export const dynamic = "force-dynamic";
 
 export default async function PinLoginPage() {
-  // Determine which user's PIN to request:
-  // prefer last-user cookie → fallback to first admin user
   const cookieStore = await cookies();
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
 
-  let adminUser = lastUserId
+  // Step 1: Try the last-logged-in user from cookie
+  let targetUser = lastUserId
     ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
     : null;
-  if (!adminUser) {
-    adminUser = await db.query.users.findFirst();
+
+  // Step 2: If that user has no PIN, fall back to the first user who has one
+  if (!targetUser?.pinHash) {
+    const userWithPin = await db.query.users.findFirst({
+      where: isNotNull(users.pinHash),
+    });
+    if (userWithPin) targetUser = userWithPin;
   }
-  if (!adminUser) {
+
+  // Step 3: Ultimate fallback — any user at all
+  if (!targetUser) {
+    targetUser = await db.query.users.findFirst();
+  }
+
+  if (!targetUser) {
     redirect("/pin/setup");
   }
 
-  // If PIN is not set, send to credentials login (PIN setup is only for first user)
-  if (!adminUser.pinHash) {
+  // If no user in the system has a PIN, go to credential login
+  if (!targetUser.pinHash) {
     redirect("/pin/login");
   }
 
@@ -51,7 +61,7 @@ export default async function PinLoginPage() {
     }
   }
 
-  // Check if full auth (email+password) is required
+  // Check if full auth (email+password) is required for the target user
   const expireSetting = await db.query.settings.findFirst({
     where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
   });
@@ -59,9 +69,9 @@ export default async function PinLoginPage() {
     ? parseInt(expireSetting.value, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {
+  if (!isFullAuthValid(targetUser.lastFullAuthAt, expireDays)) {
     redirect("/pin/login");
   }
 
-  return <PinLoginClient userId={adminUser.userId} />;
+  return <PinLoginClient userId={targetUser.userId} />;
 }

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -10,14 +10,24 @@ import {
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
+  LAST_USER_COOKIE,
 } from "@/lib/auth";
 import PinLoginClient from "./PinLoginClient";
 
 export const dynamic = "force-dynamic";
 
 export default async function PinLoginPage() {
-  // If admin user not configured, redirect to setup
-  const adminUser = await db.query.users.findFirst();
+  // Determine which user's PIN to request:
+  // prefer last-user cookie → fallback to first admin user
+  const cookieStore = await cookies();
+  const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
+
+  let adminUser = lastUserId
+    ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
+    : null;
+  if (!adminUser) {
+    adminUser = await db.query.users.findFirst();
+  }
   if (!adminUser) {
     redirect("/pin/setup");
   }
@@ -28,7 +38,6 @@ export default async function PinLoginPage() {
   }
 
   // If already authenticated, redirect to dashboard
-  const cookieStore = await cookies();
   const sessionCookie = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
   if (sessionCookie) {
     const sessionRow = await db.query.authSessions.findFirst({
@@ -54,5 +63,5 @@ export default async function PinLoginPage() {
     redirect("/pin/login");
   }
 
-  return <PinLoginClient />;
+  return <PinLoginClient userId={adminUser.userId} />;
 }

--- a/src/app/pin/setup/page.tsx
+++ b/src/app/pin/setup/page.tsx
@@ -8,10 +8,10 @@ import PinSetupClient from "./PinSetupClient";
 export const dynamic = "force-dynamic";
 
 export default async function PinSetupPage() {
-  // If admin user exists, redirect to login
+  // If users already exist, direct to credentials login (setup is for first-time only)
   const adminUser = await db.query.users.findFirst();
   if (adminUser) {
-    redirect("/pin");
+    redirect("/pin/login");
   }
 
   return <PinSetupClient />;

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -65,6 +65,12 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
   const [pinStep, setPinStep] = useState<"current" | "new" | "confirm">("current");
   const [pinChanging, setPinChanging] = useState(false);
   const [pinChangeResult, setPinChangeResult] = useState<{ ok: boolean; msg: string } | null>(null);
+  // PIN setup states (for users without a PIN)
+  const [setupPin, setSetupPin] = useState("");
+  const [setupConfirmPin, setSetupConfirmPin] = useState("");
+  const [setupPinStep, setSetupPinStep] = useState<"new" | "confirm">("new");
+  const [setupPinSaving, setSetupPinSaving] = useState(false);
+  const [setupPinResult, setSetupPinResult] = useState<{ ok: boolean; msg: string } | null>(null);
   const [storedEmail, setStoredEmail] = useState("");
   const [newEmail, setNewEmail] = useState("");
   const [emailSaving, setEmailSaving] = useState(false);
@@ -261,6 +267,50 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
     setNewPin("");
     setConfirmPin("");
     setPinStep("current");
+  }
+
+  async function handleSetupPinComplete(completedPin: string) {
+    if (setupPinStep === "new") {
+      setSetupPin(completedPin);
+      setSetupPinStep("confirm");
+      return;
+    }
+    // confirm step
+    if (completedPin !== setupPin) {
+      setSetupPinResult({ ok: false, msg: "PINが一致しません" });
+      setSetupConfirmPin("");
+      return;
+    }
+    setSetupPinSaving(true);
+    setSetupPinResult(null);
+    try {
+      const res = await fetch("/api/auth/pin/change", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "setupPin", newPin: completedPin }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setSetupPinResult({ ok: true, msg: "PINを設定しました" });
+        setPinConfigured(true);
+        setSetupPin("");
+        setSetupConfirmPin("");
+        setSetupPinStep("new");
+      } else {
+        setSetupPinResult({ ok: false, msg: data.error ?? "設定に失敗しました" });
+      }
+    } catch {
+      setSetupPinResult({ ok: false, msg: "設定に失敗しました" });
+    } finally {
+      setSetupPinSaving(false);
+    }
+  }
+
+  function resetSetupPinForm() {
+    setSetupPin("");
+    setSetupConfirmPin("");
+    setSetupPinStep("new");
+    setSetupPinResult(null);
   }
 
   async function handleEmailChange() {
@@ -656,7 +706,7 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
       </div>}
 
       {/* Security / PIN Settings */}
-      {pinConfigured && (
+      {pinConfigured ? (
         <div className="rounded-lg border p-6">
           <h2 className="mb-4 text-lg font-semibold">セキュリティ</h2>
 
@@ -857,6 +907,149 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
               </span>
             )}
           </div>}
+
+          {/* Logout */}
+          <div className="mt-6 border-t pt-4">
+            <Button variant="outline" onClick={handleLogout}>
+              ログアウト
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border p-6">
+          <h2 className="mb-4 text-lg font-semibold">セキュリティ</h2>
+
+          {/* PIN Setup (for users without a PIN) */}
+          <div className="mb-6">
+            <h3 className="mb-2 text-sm font-medium">PIN設定</h3>
+            <p className="mb-4 text-sm text-muted-foreground">
+              PINを設定すると、次回からPINだけでログインできます。
+            </p>
+
+            {setupPinStep === "new" && (
+              <div className="space-y-2">
+                <Label className="text-sm text-muted-foreground">6桁のPINを入力</Label>
+                <PinInput
+                  value={setupPin}
+                  onChange={(v) => { setSetupPin(v); setSetupPinResult(null); }}
+                  onComplete={handleSetupPinComplete}
+                  disabled={setupPinSaving}
+                />
+              </div>
+            )}
+
+            {setupPinStep === "confirm" && (
+              <div className="space-y-2">
+                <Label className="text-sm text-muted-foreground">もう一度入力して確認</Label>
+                <PinInput
+                  value={setupConfirmPin}
+                  onChange={setSetupConfirmPin}
+                  onComplete={handleSetupPinComplete}
+                  disabled={setupPinSaving}
+                  error={setupPinResult?.ok === false}
+                />
+              </div>
+            )}
+
+            <div className="mt-3 flex items-center gap-3">
+              {setupPinStep === "confirm" && (
+                <Button variant="outline" size="sm" onClick={resetSetupPinForm} disabled={setupPinSaving}>
+                  リセット
+                </Button>
+              )}
+              {setupPinResult && (
+                <span className={`text-sm ${setupPinResult.ok ? "text-green-600" : "text-red-600"}`}>
+                  {setupPinResult.msg}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Email Change */}
+          <div className="border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium">リカバリーメールアドレス</h3>
+            <p className="mb-4 text-sm text-muted-foreground">
+              PINを忘れた場合のリセットに使用するメールアドレスです。
+            </p>
+            {storedEmail && (
+              <p className="mb-3 text-sm">
+                現在の設定: <span className="font-mono">{storedEmail}</span>
+              </p>
+            )}
+            <div className="flex items-center gap-3">
+              <Input
+                type="email"
+                placeholder="新しいメールアドレス"
+                value={newEmail}
+                onChange={(e) => {
+                  setNewEmail(e.target.value);
+                  setEmailSaved(null);
+                }}
+                className="max-w-sm"
+              />
+              <Button
+                onClick={handleEmailChange}
+                disabled={emailSaving || !newEmail || !newEmail.includes("@")}
+              >
+                {emailSaving ? "保存中..." : "変更"}
+              </Button>
+            </div>
+            {emailSaved && (
+              <span className={`mt-2 block text-sm ${emailSaved.ok ? "text-green-600" : "text-red-600"}`}>
+                {emailSaved.msg}
+              </span>
+            )}
+          </div>
+
+          {/* Password Change */}
+          <div className="border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium">パスワード変更</h3>
+            <p className="mb-4 text-sm text-muted-foreground">
+              ログイン用のパスワードを変更します。
+            </p>
+            <div className="space-y-3 max-w-sm">
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">現在のパスワード</label>
+                <Input
+                  type="password"
+                  placeholder="現在のパスワード"
+                  value={currentPassword}
+                  onChange={(e) => { setCurrentPassword(e.target.value); setPasswordChangeResult(null); }}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">新しいパスワード（8文字以上）</label>
+                <Input
+                  type="password"
+                  placeholder="新しいパスワード"
+                  value={newPassword}
+                  onChange={(e) => { setNewPassword(e.target.value); setPasswordChangeResult(null); }}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">新しいパスワード（確認）</label>
+                <Input
+                  type="password"
+                  placeholder="もう一度入力"
+                  value={confirmNewPassword}
+                  onChange={(e) => { setConfirmNewPassword(e.target.value); setPasswordChangeResult(null); }}
+                />
+              </div>
+              <div className="flex items-center gap-3">
+                <Button
+                  onClick={handlePasswordChange}
+                  disabled={passwordChanging || !currentPassword || !newPassword || !confirmNewPassword}
+                >
+                  {passwordChanging ? "変更中..." : "パスワードを変更"}
+                </Button>
+              </div>
+              {passwordChangeResult && (
+                <span className={`text-sm ${passwordChangeResult.ok ? "text-green-600" : "text-red-600"}`}>
+                  {passwordChangeResult.msg}
+                </span>
+              )}
+            </div>
+          </div>
 
           {/* Logout */}
           <div className="mt-6 border-t pt-4">

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -37,7 +37,7 @@ interface VersionInfo {
   hasUpdate: boolean;
 }
 
-export function SettingsClient() {
+export function SettingsClient({ role, currentUserId }: { role: "admin" | "general"; currentUserId: string }) {
   const [cityId, setCityId] = useState(DEFAULT_CITY_ID);
   const [selectedPref, setSelectedPref] = useState<WeatherPrefecture | null>(
     null,
@@ -82,6 +82,11 @@ export function SettingsClient() {
   const [authExpirySaving, setAuthExpirySaving] = useState(false);
   const [authExpirySaved, setAuthExpirySaved] = useState<{ ok: boolean; msg: string } | null>(null);
   const [fullAuthExpiry, setFullAuthExpiry] = useState<string | null>(null);
+
+  // UserId change states
+  const [newUserId, setNewUserId] = useState("");
+  const [userIdChanging, setUserIdChanging] = useState(false);
+  const [userIdChangeResult, setUserIdChangeResult] = useState<{ ok: boolean; msg: string } | null>(null);
 
   const fetchMedia = useCallback(async () => {
     try {
@@ -342,6 +347,30 @@ export function SettingsClient() {
     }
   }
 
+  async function handleUserIdChange() {
+    if (!newUserId.trim()) return;
+    setUserIdChanging(true);
+    setUserIdChangeResult(null);
+    try {
+      const res = await fetch("/api/auth/pin/change", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "changeUserId", newUserId: newUserId.trim() }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setUserIdChangeResult({ ok: true, msg: "ユーザーIDを変更しました" });
+        setNewUserId("");
+      } else {
+        setUserIdChangeResult({ ok: false, msg: data.error ?? "変更に失敗しました" });
+      }
+    } catch {
+      setUserIdChangeResult({ ok: false, msg: "通信エラーが発生しました" });
+    } finally {
+      setUserIdChanging(false);
+    }
+  }
+
   async function handleDeleteAllMedia() {
     if (!confirm("すべてのメディアファイルを削除します。この操作は取り消せません。\n本当に実行しますか？")) {
       return;
@@ -448,7 +477,14 @@ export function SettingsClient() {
           ]).map((opt) => (
             <button
               key={opt.value}
-              onClick={() => setTheme(opt.value)}
+              onClick={async () => {
+                setTheme(opt.value);
+                await fetch("/api/users/me", {
+                  method: "PATCH",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ colorTheme: opt.value }),
+                });
+              }}
               className={`rounded-lg border px-4 py-2 text-sm transition-colors ${
                 theme === opt.value
                   ? "border-primary bg-primary text-primary-foreground"
@@ -461,8 +497,39 @@ export function SettingsClient() {
         </div>
       </div>
 
-      {/* Weather Area Selection */}
+      {/* Account Settings */}
       <div className="rounded-lg border p-6">
+        <h2 className="mb-4 text-lg font-semibold">アカウント設定</h2>
+        <div>
+          <h3 className="mb-2 text-sm font-medium">ユーザーID変更</h3>
+          <p className="mb-4 text-sm text-muted-foreground">
+            現在のユーザーID: <span className="font-mono">{currentUserId}</span>
+          </p>
+          <div className="flex items-center gap-3">
+            <Input
+              type="text"
+              placeholder="新しいユーザーID"
+              value={newUserId}
+              onChange={(e) => { setNewUserId(e.target.value); setUserIdChangeResult(null); }}
+              className="max-w-sm"
+            />
+            <Button
+              onClick={handleUserIdChange}
+              disabled={userIdChanging || !newUserId.trim() || newUserId.trim() === currentUserId}
+            >
+              {userIdChanging ? "変更中..." : "変更"}
+            </Button>
+          </div>
+          {userIdChangeResult && (
+            <span className={`mt-2 block text-sm ${userIdChangeResult.ok ? "text-green-600" : "text-red-600"}`}>
+              {userIdChangeResult.msg}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Weather Area Selection */}
+      {role === "admin" && <div className="rounded-lg border p-6">
         <h2 className="mb-4 text-lg font-semibold">天気予報の地域設定</h2>
         <p className="mb-4 text-sm text-muted-foreground">
           フォトクロックテンプレートの天気表示で使用する地域を設定します。
@@ -530,10 +597,10 @@ export function SettingsClient() {
             {cityId}）
           </p>
         )}
-      </div>
+      </div>}
 
       {/* Image Resize Settings */}
-      <div className="rounded-lg border p-6">
+      {role === "admin" && <div className="rounded-lg border p-6">
         <h2 className="mb-4 text-lg font-semibold">画像リサイズ設定</h2>
         <p className="mb-4 text-sm text-muted-foreground">
           アップロード時に画像の長辺を指定ピクセル数以下にリサイズします。
@@ -586,7 +653,7 @@ export function SettingsClient() {
             )}
           </div>
         </div>
-      </div>
+      </div>}
 
       {/* Security / PIN Settings */}
       {pinConfigured && (
@@ -737,8 +804,8 @@ export function SettingsClient() {
             </div>
           </div>
 
-          {/* Auth Expiry / Login Cache Period */}
-          <div className="border-t pt-4">
+          {/* Auth Expiry / Login Cache Period - admin only */}
+          {role === "admin" && <div className="border-t pt-4">
             <h3 className="mb-2 text-sm font-medium">ログイン認証キャッシュ期間</h3>
             <p className="mb-4 text-sm text-muted-foreground">
               メールアドレス+パスワードによるログインの有効期間です。期間を過ぎると、次回PINログイン前にメールアドレスでの再認証が必要になります。
@@ -789,7 +856,7 @@ export function SettingsClient() {
                 {authExpirySaved.msg}
               </span>
             )}
-          </div>
+          </div>}
 
           {/* Logout */}
           <div className="mt-6 border-t pt-4">
@@ -800,8 +867,8 @@ export function SettingsClient() {
         </div>
       )}
 
-      {/* Media Management */}
-      <div className="rounded-lg border border-red-200 p-6">
+      {/* Media Management - admin only */}
+      {role === "admin" && <div className="rounded-lg border border-red-200 p-6">
         <h2 className="mb-4 text-lg font-semibold">メディア管理</h2>
 
         {/* Individual media list */}
@@ -893,7 +960,7 @@ export function SettingsClient() {
             )}
           </div>
         </div>
-      </div>
+      </div>}
     </div>
   );
 }

--- a/src/components/dashboard/ThemeProvider.tsx
+++ b/src/components/dashboard/ThemeProvider.tsx
@@ -12,8 +12,6 @@ import {
 
 export type Theme = "system" | "light" | "dark";
 
-const STORAGE_KEY = "e-web-board-theme";
-
 interface ThemeContextValue {
   theme: Theme;
   setTheme: (t: Theme) => void;
@@ -36,21 +34,28 @@ function getResolvedTheme(theme: Theme): "light" | "dark" {
     : "light";
 }
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>("system");
+export function ThemeProvider({
+  children,
+  initialTheme = "system",
+}: {
+  children: React.ReactNode;
+  initialTheme?: Theme;
+}) {
+  const [theme, setThemeState] = useState<Theme>(initialTheme);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    if (stored === "light" || stored === "dark" || stored === "system") {
-      setThemeState(stored);
-    }
     setMounted(true);
   }, []);
 
   const setTheme = useCallback((t: Theme) => {
     setThemeState(t);
-    localStorage.setItem(STORAGE_KEY, t);
+    // Persist to DB (fire-and-forget)
+    fetch("/api/users/me", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ colorTheme: t }),
+    }).catch(() => {});
   }, []);
 
   // Apply .dark class to the wrapper element

--- a/src/components/dashboard/UserManagement.tsx
+++ b/src/components/dashboard/UserManagement.tsx
@@ -1,0 +1,249 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Trash2, UserPlus } from "lucide-react";
+
+interface UserRow {
+  id: string;
+  userId: string;
+  email: string;
+  role: string;
+  createdAt: string;
+}
+
+export function UserManagement() {
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create user dialog
+  const [showCreate, setShowCreate] = useState(false);
+  const [createUserId, setCreateUserId] = useState("");
+  const [createEmail, setCreateEmail] = useState("");
+  const [createPassword, setCreatePassword] = useState("");
+  const [createRole, setCreateRole] = useState<"admin" | "general">("general");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/users");
+      if (res.ok) setUsers(await res.json());
+      else setError("ユーザー一覧の取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchUsers(); }, [fetchUsers]);
+
+  async function handleRoleChange(id: string, role: string) {
+    const res = await fetch(`/api/users/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setError(data.error ?? "ロール変更に失敗しました");
+      return;
+    }
+    setUsers((prev) => prev.map((u) => u.id === id ? { ...u, role } : u));
+  }
+
+  async function handleDelete(id: string, userId: string) {
+    if (!confirm(`ユーザー「${userId}」を削除しますか？`)) return;
+    const res = await fetch(`/api/users/${id}`, { method: "DELETE" });
+    const data = await res.json();
+    if (!res.ok) {
+      setError(data.error ?? "削除に失敗しました");
+      return;
+    }
+    setUsers((prev) => prev.filter((u) => u.id !== id));
+  }
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const res = await fetch("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId: createUserId.trim(),
+          email: createEmail.trim(),
+          password: createPassword,
+          role: createRole,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setCreateError(data.error ?? "作成に失敗しました");
+        return;
+      }
+      setShowCreate(false);
+      setCreateUserId("");
+      setCreateEmail("");
+      setCreatePassword("");
+      setCreateRole("general");
+      await fetchUsers();
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">ユーザー一覧</h2>
+        <Button size="sm" onClick={() => { setShowCreate(true); setCreateError(null); }}>
+          <UserPlus className="mr-1.5 size-4" />
+          ユーザー追加
+        </Button>
+      </div>
+
+      {error && (
+        <p className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">{error}</p>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/40 text-xs text-muted-foreground">
+                <th className="px-4 py-2 text-left">ユーザーID</th>
+                <th className="px-4 py-2 text-left">メールアドレス</th>
+                <th className="px-4 py-2 text-left">ロール</th>
+                <th className="px-4 py-2 text-right">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr key={user.id} className="border-b last:border-0">
+                  <td className="px-4 py-3 font-medium">{user.userId}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{user.email}</td>
+                  <td className="px-4 py-3">
+                    <Select
+                      value={user.role}
+                      onValueChange={(v) => handleRoleChange(user.id, v ?? "")}
+                    >
+                      <SelectTrigger className="h-7 w-28 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="admin">Admin</SelectItem>
+                        <SelectItem value="general">General</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => handleDelete(user.id, user.userId)}
+                      className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-red-500 transition-colors hover:bg-red-50 hover:text-red-700"
+                      title="削除"
+                    >
+                      <Trash2 className="size-3.5" />
+                      削除
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Create user dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>新しいユーザーを追加</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleCreate} className="space-y-4 pt-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="cu-userId">ユーザーID</Label>
+              <Input
+                id="cu-userId"
+                value={createUserId}
+                onChange={(e) => setCreateUserId(e.target.value)}
+                placeholder="例: john_doe"
+                pattern="[a-zA-Z0-9_\-]{3,32}"
+                title="3〜32文字の英数字・_・-"
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="cu-email">メールアドレス</Label>
+              <Input
+                id="cu-email"
+                type="email"
+                value={createEmail}
+                onChange={(e) => setCreateEmail(e.target.value)}
+                placeholder="user@example.com"
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="cu-password">パスワード</Label>
+              <Input
+                id="cu-password"
+                type="password"
+                value={createPassword}
+                onChange={(e) => setCreatePassword(e.target.value)}
+                placeholder="8文字以上"
+                minLength={8}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="cu-role">ロール</Label>
+              <Select value={createRole} onValueChange={(v) => setCreateRole(v as "admin" | "general")}>
+                <SelectTrigger id="cu-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="admin">Admin（全権限）</SelectItem>
+                  <SelectItem value="general">General（一部制限）</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {createError && (
+              <p className="text-sm text-red-600">{createError}</p>
+            )}
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="outline" onClick={() => setShowCreate(false)}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={creating}>
+                {creating ? "作成中..." : "作成"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -104,6 +104,8 @@ export const users = sqliteTable("users", {
   /** 6-digit PIN hash (nullable until PIN is configured) */
   pinHash: text("pin_hash"),
   role: text("role").notNull().default("admin"),
+  /** Dashboard color theme preference: "system" | "light" | "dark" */
+  colorTheme: text("color_theme").notNull().default("system"),
   /** Timestamp of the last successful email+password login */
   lastFullAuthAt: text("last_full_auth_at"),
   createdAt: text("created_at")

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,6 +74,8 @@ export const pinResetTokens = sqliteTable("pin_reset_tokens", {
     .primaryKey()
     .$defaultFn(() => randomUUID()),
   token: text("token").notNull().unique(),
+  /** User whose PIN this token resets */
+  userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
   expiresAt: text("expires_at").notNull(),
   usedAt: text("used_at"),
   createdAt: text("created_at")
@@ -135,6 +137,14 @@ export const authSessions = sqliteTable("auth_sessions", {
 
 export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(authSessions),
+  pinResetTokens: many(pinResetTokens),
+}));
+
+export const pinResetTokensRelations = relations(pinResetTokens, ({ one }) => ({
+  user: one(users, {
+    fields: [pinResetTokens.userId],
+    references: [users.id],
+  }),
 }));
 
 export const authSessionsRelations = relations(authSessions, ({ one }) => ({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -35,6 +35,13 @@ export async function verifyPassword(
 /** Auth session cookie name */
 export const AUTH_SESSION_COOKIE = "auth-session";
 
+/**
+ * Cookie that stores the userId (human-readable) of the most recently
+ * authenticated user. Used to target the correct account on the PIN screen.
+ * Long-lived (1 year), httpOnly.
+ */
+export const LAST_USER_COOKIE = "last-user-id";
+
 /** PIN session duration: 24 hours (in seconds, for cookie maxAge) */
 export const SESSION_MAX_AGE = 60 * 60 * 24;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -67,3 +67,31 @@ export function isFullAuthValid(
   if (!expiry) return false;
   return expiry > new Date();
 }
+
+// ── Session helper ────────────────────────────────────────────────────────────
+
+import { cookies } from "next/headers";
+import { db } from "@/db";
+import { authSessions } from "@/db/schema";
+import { eq, and, gt } from "drizzle-orm";
+
+/**
+ * Read the current session from the cookie store and return the
+ * associated session row (with user) if it is valid, or null.
+ * Only for use inside Next.js request context (Route Handlers / Server
+ * Components).
+ */
+export async function getSessionUser() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  const session = await db.query.authSessions.findFirst({
+    where: and(
+      eq(authSessions.sessionToken, token),
+      gt(authSessions.expiresAt, new Date().toISOString()),
+    ),
+    with: { user: true },
+  });
+  return session ?? null;
+}


### PR DESCRIPTION
## 概要

Issue #72 の複数アカウント管理機能を実装します。

## 変更内容

### DB
- `users` テーブルに `color_theme` カラムを追加 (`drizzle/0004_user_color_theme.sql`)

### 新規 API
- `GET /api/users` — ユーザー一覧取得（管理者のみ）
- `POST /api/users` — ユーザー作成（管理者のみ）
- `PATCH /api/users/[id]` — ロール変更（管理者のみ）
- `DELETE /api/users/[id]` — ユーザー削除（管理者のみ、最後のadminは削除不可）
- `GET /api/users/me` — 自分の情報取得
- `PATCH /api/users/me` — userId / email / colorTheme 更新

### API 更新
- `PATCH /api/auth/pin/change` に `changeUserId` アクションを追加

### 新規コンポーネント・ページ
- `UserManagement.tsx` — ユーザー管理UI（一覧・ロール変更・削除・新規作成）
- `/users` ページ — 管理者のみアクセス可

### 既存ファイル更新
- `layout.tsx` — サイドバーにログイン中ユーザーID・ロールバッジ表示を追加、管理者のみ「ユーザー管理」リンクを表示
- `settings/page.tsx` — サーバーコンポーネント化し、role / userId を `SettingsClient` に渡す
- `SettingsClient.tsx` — role・currentUserId プロップ対応、管理者専用セクション（天気・画像設定・メディア管理・authExpiry）を一般ユーザーから非表示、ユーザーID変更フォームを追加、テーマ変更を API 経由で保存
- `ThemeProvider.tsx` — `initialTheme` プロップ対応（DB に保存されたテーマを起動時に反映）
- `lib/auth.ts` — `getSessionUser()` ヘルパーを追加

## ロールごとの権限

| 機能 | 管理者 (admin) | 一般 (general) |
|------|:---:|:---:|
| ボード編集 | ✅ | ✅ |
| カラーテーマ変更 | ✅ | ✅ |
| ユーザーID変更 | ✅ | ✅ |
| PIN変更 | ✅ | ✅ |
| メールアドレス変更 | ✅ | ✅ |
| パスワード変更 | ✅ | ✅ |
| 天気予報設定 | ✅ | ❌ |
| 画像リサイズ設定 | ✅ | ❌ |
| メディア管理 | ✅ | ❌ |
| authExpiry設定 | ✅ | ❌ |
| ユーザー管理ページ | ✅ | ❌ |

closes #72