### PR TITLE
feat: 管理者画面のレスポンシブ対応 (#64)

### DIFF
--- a/lp/logos/keinage_logo.svg
+++ b/lp/logos/keinage_logo.svg
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="200 60 200 180">
+  <g transform="translate(200, 60)">
+    <rect x="0" y="0" width="200" height="140" rx="12" fill="#1A1A1A"/>
+    
+    <rect x="12" y="12" width="176" height="116" rx="4" fill="#FFFFFF"/>
+    
+    <rect x="20" y="20" width="28" height="100" fill="#1A1A1A" stroke="#1A1A1A" stroke-width="4" stroke-linejoin="round"/>
+    
+    <polygon points="60,70 180,20 180,120" fill="#1A1A1A" stroke="#1A1A1A" stroke-width="4" stroke-linejoin="round"/>
+    
+    <rect x="92" y="140" width="16" height="24" fill="#1A1A1A"/>
+    <rect x="60" y="164" width="80" height="8" rx="4" fill="#1A1A1A"/>
+  </g>
+
+  </svg>

--- a/src/app/(dashboard)/boards/page.tsx
+++ b/src/app/(dashboard)/boards/page.tsx
@@ -26,10 +26,10 @@ export default async function BoardsPage() {
 
   return (
     <div>
-      <div className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">ボード管理</h1>
-          <p className="text-sm text-muted-foreground">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-xl font-bold sm:text-2xl">ボード管理</h1>
+          <p className="text-xs text-muted-foreground sm:text-sm">
             ボードの作成・編集・削除を行います
           </p>
         </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,12 +1,9 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import Link from "next/link";
-import { LayoutDashboard, MonitorPlay, Settings, Users } from "lucide-react";
-import { Separator } from "@/components/ui/separator";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { db } from "@/db";
-import { users, authSessions, settings } from "@/db/schema";
+import { authSessions, settings } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import {
   AUTH_SESSION_COOKIE,
@@ -15,27 +12,7 @@ import {
   isFullAuthValid,
 } from "@/lib/auth";
 import { ThemeProvider } from "@/components/dashboard/ThemeProvider";
-import { LogoutButton } from "@/components/dashboard/LogoutButton";
-
-function SidebarLink({
-  href,
-  icon: Icon,
-  children,
-}: {
-  href: string;
-  icon: React.ComponentType<{ className?: string }>;
-  children: React.ReactNode;
-}) {
-  return (
-    <Link
-      href={href}
-      className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-    >
-      <Icon className="size-4" />
-      {children}
-    </Link>
-  );
-}
+import { DashboardShell } from "@/components/dashboard/DashboardShell";
 
 export default async function DashboardLayout({
   children,
@@ -92,49 +69,9 @@ export default async function DashboardLayout({
 
   return (
     <ThemeProvider initialTheme={colorTheme as "system" | "light" | "dark"}>
-      <div id="dashboard-theme-root" className="flex min-h-dvh bg-background text-foreground">
-        {/* Sidebar */}
-        <aside className="flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
-          <div className="flex h-auto min-h-14 flex-col justify-center gap-0.5 px-4 py-3">
-            <div className="flex items-center justify-between">
-              <Link href="/boards" className="flex items-center gap-2 font-bold">
-                <MonitorPlay className="size-5" />
-                <span>Keinage</span>
-              </Link>
-              <LogoutButton />
-            </div>
-            <div className="flex items-center gap-1.5 pl-0.5">
-              <span className="text-xs text-muted-foreground">{userId}</span>
-              <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
-                role === "admin"
-                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-                  : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-              }`}>
-                {role === "admin" ? "Admin" : "General"}
-              </span>
-            </div>
-          </div>
-          <Separator />
-          <nav className="flex-1 space-y-1 px-2 py-3">
-            <SidebarLink href="/boards" icon={LayoutDashboard}>
-              ボード管理
-            </SidebarLink>
-            {role === "admin" && (
-              <SidebarLink href="/users" icon={Users}>
-                ユーザー管理
-              </SidebarLink>
-            )}
-            <SidebarLink href="/settings" icon={Settings}>
-              設定
-            </SidebarLink>
-          </nav>
-        </aside>
-
-        {/* Main content */}
-        <main className="flex-1 overflow-y-auto">
-          <div className="mx-auto max-w-5xl px-6 py-8">{children}</div>
-        </main>
-      </div>
+      <DashboardShell userId={userId} role={role}>
+        {children}
+      </DashboardShell>
     </ThemeProvider>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,9 +9,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-heading: var(--font-geist-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -137,3 +137,19 @@
   transition: background-color 300ms ease, color 300ms ease,
     border-color 300ms ease;
 }
+
+/* Sidebar slide animation — avoids Tailwind v4 translate variable issue */
+.sidebar-slide {
+  transform: translateX(-100%);
+  transition: transform 300ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.sidebar-slide[data-open="true"] {
+  transform: translateX(0);
+}
+@media (width >= 48rem) {
+  .sidebar-slide,
+  .sidebar-slide[data-open="true"] {
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,11 +131,11 @@
   }
 }
 
-/* Smooth theme transition for dashboard dark mode */
-#dashboard-theme-root,
-#dashboard-theme-root * {
-  transition: background-color 300ms ease, color 300ms ease,
-    border-color 300ms ease;
+/* Smooth theme transition for dashboard dark mode without overriding local motion */
+:where(#dashboard-theme-root, #dashboard-theme-root *) {
+  transition-property: background-color, color, border-color;
+  transition-duration: 300ms;
+  transition-timing-function: ease;
 }
 
 /* Sidebar slide animation — avoids Tailwind v4 translate variable issue */

--- a/src/app/pin/PinLoginClient.tsx
+++ b/src/app/pin/PinLoginClient.tsx
@@ -5,8 +5,9 @@
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { MonitorPlay, Lock } from "lucide-react";
+import { Lock } from "lucide-react";
 import { PinInput } from "@/components/auth/PinInput";
+import { KeinageLogo } from "@/components/KeinageLogo";
 
 export default function PinLoginClient({ userId }: { userId: string }) {
   const router = useRouter();
@@ -56,9 +57,7 @@ export default function PinLoginClient({ userId }: { userId: string }) {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center gap-3">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-lg">
-            <MonitorPlay className="size-7" />
-          </div>
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
           <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
         </div>
 

--- a/src/app/pin/forgot/page.tsx
+++ b/src/app/pin/forgot/page.tsx
@@ -4,7 +4,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { MonitorPlay, Mail } from "lucide-react";
+import { Mail } from "lucide-react";
+import { KeinageLogo } from "@/components/KeinageLogo";
 
 export default function PinForgotPage() {
   const [email, setEmail] = useState("");
@@ -51,9 +52,7 @@ export default function PinForgotPage() {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center gap-3">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-lg">
-            <MonitorPlay className="size-7" />
-          </div>
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
           <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
         </div>
 

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -5,7 +5,8 @@
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { MonitorPlay, KeyRound } from "lucide-react";
+import { KeyRound } from "lucide-react";
+import { KeinageLogo } from "@/components/KeinageLogo";
 
 export default function LoginClient() {
   const router = useRouter();
@@ -56,9 +57,7 @@ export default function LoginClient() {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center gap-3">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-lg">
-            <MonitorPlay className="size-7" />
-          </div>
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
           <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
         </div>
 

--- a/src/app/pin/reset/[token]/PinResetClient.tsx
+++ b/src/app/pin/reset/[token]/PinResetClient.tsx
@@ -4,8 +4,9 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { MonitorPlay, KeyRound } from "lucide-react";
+import { KeyRound } from "lucide-react";
 import { PinInput } from "@/components/auth/PinInput";
+import { KeinageLogo } from "@/components/KeinageLogo";
 
 interface PinResetClientProps {
   token: string;
@@ -61,9 +62,7 @@ export default function PinResetClient({ token }: PinResetClientProps) {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center gap-3">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-lg">
-            <MonitorPlay className="size-7" />
-          </div>
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
           <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
         </div>
 

--- a/src/app/pin/setup/PinSetupClient.tsx
+++ b/src/app/pin/setup/PinSetupClient.tsx
@@ -4,8 +4,9 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { MonitorPlay, ShieldCheck } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import { PinInput } from "@/components/auth/PinInput";
+import { KeinageLogo } from "@/components/KeinageLogo";
 
 type Step = "credentials" | "pin" | "confirmPin";
 
@@ -104,9 +105,7 @@ export default function PinSetupClient() {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center gap-3">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-lg">
-            <MonitorPlay className="size-7" />
-          </div>
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
           <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
         </div>
 

--- a/src/components/KeinageLogo.tsx
+++ b/src/components/KeinageLogo.tsx
@@ -17,8 +17,15 @@ export function KeinageLogo({ className }: { className?: string }) {
       <g transform="translate(100, 60)">
         {/* Monitor frame */}
         <rect x="0" y="0" width="200" height="140" rx="12" fill="currentColor" />
-        {/* Screen (always white) */}
-        <rect x="12" y="12" width="176" height="116" rx="4" fill="#FFFFFF" />
+        {/* Screen follows the current theme background for dark-mode contrast */}
+        <rect
+          x="12"
+          y="12"
+          width="176"
+          height="116"
+          rx="4"
+          fill="var(--logo-screen, var(--background, #FFFFFF))"
+        />
         {/* K shape: vertical bar */}
         <rect
           x="20"

--- a/src/components/KeinageLogo.tsx
+++ b/src/components/KeinageLogo.tsx
@@ -1,0 +1,48 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Keinage SVG logo component.
+ * In dark mode the strokes/fills switch to a light colour automatically
+ * via `currentColor`.
+ */
+export function KeinageLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 60 400 180"
+      className={className}
+      aria-hidden="true"
+    >
+      <g transform="translate(100, 60)">
+        {/* Monitor frame */}
+        <rect x="0" y="0" width="200" height="140" rx="12" fill="currentColor" />
+        {/* Screen (always white) */}
+        <rect x="12" y="12" width="176" height="116" rx="4" fill="#FFFFFF" />
+        {/* K shape: vertical bar */}
+        <rect
+          x="20"
+          y="20"
+          width="28"
+          height="100"
+          fill="currentColor"
+          stroke="currentColor"
+          strokeWidth="4"
+          strokeLinejoin="round"
+        />
+        {/* K shape: triangle */}
+        <polygon
+          points="60,70 180,20 180,120"
+          fill="currentColor"
+          stroke="currentColor"
+          strokeWidth="4"
+          strokeLinejoin="round"
+        />
+        {/* Stand: neck */}
+        <rect x="92" y="140" width="16" height="24" fill="currentColor" />
+        {/* Stand: base */}
+        <rect x="60" y="164" width="80" height="8" rx="4" fill="currentColor" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -194,32 +194,28 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
   return (
     <div>
       {/* Header */}
-      <div className="mb-6 flex items-center justify-between">
-        <div>
-          <Link
-            href="/boards"
-            className={buttonVariants({ variant: "ghost", size: "sm" })}
-          >
-            <ArrowLeft data-icon="inline-start" />
-            ボード一覧
-          </Link>
-        </div>
-        <div className="flex items-center gap-2">
-          <a
-            href={`/${boardId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonVariants({ variant: "outline", size: "sm" })}
-          >
-            <ExternalLink data-icon="inline-start" />
-            プレビュー
-          </a>
-        </div>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
+        <Link
+          href="/boards"
+          className={buttonVariants({ variant: "ghost", size: "sm" })}
+        >
+          <ArrowLeft data-icon="inline-start" />
+          ボード一覧
+        </Link>
+        <a
+          href={`/${boardId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({ variant: "outline", size: "sm" })}
+        >
+          <ExternalLink data-icon="inline-start" />
+          プレビュー
+        </a>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-3">
+      <div className="grid gap-6 md:grid-cols-3">
         {/* Left: Board settings (2 cols) */}
-        <div className="space-y-6 lg:col-span-2">
+        <div className="space-y-6 md:col-span-2">
           {/* Basic info */}
           <Card>
             <CardHeader>
@@ -292,12 +288,12 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
             </CardHeader>
             <CardContent className="space-y-4">
               {/* Add new message */}
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <Input
                   value={newMsgContent}
                   onChange={(e) => setNewMsgContent(e.target.value)}
                   placeholder={board.templateId === "call-number" ? "番号を入力..." : "メッセージを入力..."}
-                  className="flex-1"
+                  className="min-w-0 flex-1 basis-40"
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !e.nativeEvent.isComposing) {
                       e.preventDefault();

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -87,7 +87,7 @@ export function DashboardShell({
           {role === "admin" ? "Admin" : "General"}
         </span>
       </div>
-      <nav className="flex-1 space-y-1 px-2 py-1">
+      <nav className="flex-1 space-y-1 overflow-y-auto px-2 py-1">
         <SidebarLink href="/boards" icon={LayoutDashboard} onClick={closeSidebar}>
           ボード管理
         </SidebarLink>
@@ -127,7 +127,7 @@ export function DashboardShell({
       {/* Backdrop overlay (mobile) — animated */}
       <div
         className={`
-          fixed inset-0 z-40 bg-black/40 transition-opacity duration-200 ease-in-out md:hidden
+          fixed inset-0 z-40 bg-black/40 transition-opacity duration-300 ease-out md:hidden
           ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}
         `}
         onClick={closeSidebar}
@@ -138,8 +138,8 @@ export function DashboardShell({
       <aside
         className={`
           fixed inset-y-0 left-0 z-50 flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground
-          transition-transform duration-250 ease-[cubic-bezier(0.32,0.72,0,1)]
-          md:static md:translate-x-0 md:transition-none
+          transition-transform duration-300 ease-out
+          md:sticky md:top-0 md:z-auto md:h-dvh md:translate-x-0 md:transition-none
           ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
         `}
       >

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -1,0 +1,155 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  Settings,
+  Users,
+  Menu,
+  X,
+} from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import { LogoutButton } from "@/components/dashboard/LogoutButton";
+import { KeinageLogo } from "@/components/KeinageLogo";
+
+function SidebarLink({
+  href,
+  icon: Icon,
+  children,
+  onClick,
+}: {
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <Icon className="size-4" />
+      {children}
+    </Link>
+  );
+}
+
+export function DashboardShell({
+  userId,
+  role,
+  children,
+}: {
+  userId: string;
+  role: string;
+  children: React.ReactNode;
+}) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close sidebar on route change
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [pathname]);
+
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
+  const sidebarContent = (
+    <>
+      <div className="flex h-auto min-h-14 flex-col justify-center gap-0.5 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <Link href="/boards" className="flex items-center gap-2 font-bold" onClick={closeSidebar}>
+            <KeinageLogo className="h-5 w-auto text-foreground" />
+            <span>Keinage</span>
+          </Link>
+          <div className="flex items-center gap-1">
+            <LogoutButton />
+            {/* Close button: mobile only */}
+            <button
+              onClick={closeSidebar}
+              className="ml-1 rounded-lg p-1.5 text-muted-foreground hover:bg-accent md:hidden"
+              aria-label="メニューを閉じる"
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 pl-0.5">
+          <span className="text-xs text-muted-foreground">{userId}</span>
+          <span
+            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+              role === "admin"
+                ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+            }`}
+          >
+            {role === "admin" ? "Admin" : "General"}
+          </span>
+        </div>
+      </div>
+      <Separator />
+      <nav className="flex-1 space-y-1 px-2 py-3">
+        <SidebarLink href="/boards" icon={LayoutDashboard} onClick={closeSidebar}>
+          ボード管理
+        </SidebarLink>
+        {role === "admin" && (
+          <SidebarLink href="/users" icon={Users} onClick={closeSidebar}>
+            ユーザー管理
+          </SidebarLink>
+        )}
+        <SidebarLink href="/settings" icon={Settings} onClick={closeSidebar}>
+          設定
+        </SidebarLink>
+      </nav>
+    </>
+  );
+
+  return (
+    <div id="dashboard-theme-root" className="flex min-h-dvh bg-background text-foreground">
+      {/* Mobile header bar */}
+      <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center gap-3 border-b bg-background px-4 md:hidden">
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="rounded-lg p-1.5 text-muted-foreground hover:bg-accent"
+          aria-label="メニューを開く"
+        >
+          <Menu className="size-5" />
+        </button>
+        <Link href="/boards" className="flex items-center gap-2 font-bold">
+          <KeinageLogo className="h-4 w-auto text-foreground" />
+          <span className="text-sm">Keinage</span>
+        </Link>
+      </header>
+
+      {/* Backdrop overlay (mobile) */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          onClick={closeSidebar}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Sidebar: always visible on md+, overlay on mobile */}
+      <aside
+        className={`
+          fixed inset-y-0 left-0 z-50 flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground
+          transition-transform duration-200 ease-in-out
+          md:static md:translate-x-0 md:transition-none
+          ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
+        `}
+      >
+        {sidebarContent}
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-y-auto pt-14 md:pt-0">
+        <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -60,39 +60,34 @@ export function DashboardShell({
 
   const sidebarContent = (
     <>
-      <div className="flex h-auto min-h-14 flex-col justify-center gap-0.5 px-4 py-3">
-        <div className="flex items-center justify-between">
-          <Link href="/boards" className="flex items-center gap-2 font-bold" onClick={closeSidebar}>
-            <KeinageLogo className="h-5 w-auto text-foreground" />
-            <span>Keinage</span>
-          </Link>
-          <div className="flex items-center gap-1">
-            <LogoutButton />
-            {/* Close button: mobile only */}
-            <button
-              onClick={closeSidebar}
-              className="ml-1 rounded-lg p-1.5 text-muted-foreground hover:bg-accent md:hidden"
-              aria-label="メニューを閉じる"
-            >
-              <X className="size-5" />
-            </button>
-          </div>
-        </div>
-        <div className="flex items-center gap-1.5 pl-0.5">
-          <span className="text-xs text-muted-foreground">{userId}</span>
-          <span
-            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
-              role === "admin"
-                ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-                : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-            }`}
-          >
-            {role === "admin" ? "Admin" : "General"}
-          </span>
-        </div>
+      <div className="flex min-h-14 items-center gap-2 px-4 py-3">
+        <Link href="/boards" className="flex items-center gap-2 font-bold" onClick={closeSidebar}>
+          <KeinageLogo className="h-5 w-auto text-foreground" />
+          <span>Keinage</span>
+        </Link>
+        {/* Close button: mobile only */}
+        <button
+          onClick={closeSidebar}
+          className="ml-auto rounded-lg p-1.5 text-muted-foreground hover:bg-accent md:hidden"
+          aria-label="メニューを閉じる"
+        >
+          <X className="size-5" />
+        </button>
       </div>
       <Separator />
-      <nav className="flex-1 space-y-1 px-2 py-3">
+      <div className="flex items-center gap-1.5 px-4 py-2">
+        <span className="text-xs text-muted-foreground">{userId}</span>
+        <span
+          className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+            role === "admin"
+              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+              : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+          }`}
+        >
+          {role === "admin" ? "Admin" : "General"}
+        </span>
+      </div>
+      <nav className="flex-1 space-y-1 px-2 py-1">
         <SidebarLink href="/boards" icon={LayoutDashboard} onClick={closeSidebar}>
           ボード管理
         </SidebarLink>
@@ -105,6 +100,10 @@ export function DashboardShell({
           設定
         </SidebarLink>
       </nav>
+      <Separator />
+      <div className="px-2 py-3">
+        <LogoutButton />
+      </div>
     </>
   );
 
@@ -125,20 +124,21 @@ export function DashboardShell({
         </Link>
       </header>
 
-      {/* Backdrop overlay (mobile) */}
-      {sidebarOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-black/40 md:hidden"
-          onClick={closeSidebar}
-          aria-hidden="true"
-        />
-      )}
+      {/* Backdrop overlay (mobile) — animated */}
+      <div
+        className={`
+          fixed inset-0 z-40 bg-black/40 transition-opacity duration-200 ease-in-out md:hidden
+          ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}
+        `}
+        onClick={closeSidebar}
+        aria-hidden="true"
+      />
 
-      {/* Sidebar: always visible on md+, overlay on mobile */}
+      {/* Sidebar: always visible on md+, slide-in overlay on mobile */}
       <aside
         className={`
           fixed inset-y-0 left-0 z-50 flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground
-          transition-transform duration-200 ease-in-out
+          transition-transform duration-250 ease-[cubic-bezier(0.32,0.72,0,1)]
           md:static md:translate-x-0 md:transition-none
           ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
         `}

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -126,22 +126,15 @@ export function DashboardShell({
 
       {/* Backdrop overlay (mobile) — animated */}
       <div
-        className={`
-          fixed inset-0 z-40 bg-black/40 transition-opacity duration-300 ease-out md:hidden
-          ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}
-        `}
+        className={`fixed inset-0 z-40 bg-black/40 md:hidden transition-opacity duration-300 ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
         onClick={closeSidebar}
         aria-hidden="true"
       />
 
       {/* Sidebar: always visible on md+, slide-in overlay on mobile */}
       <aside
-        className={`
-          fixed inset-y-0 left-0 z-50 flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground
-          transition-transform duration-300 ease-out
-          md:sticky md:top-0 md:z-auto md:h-dvh md:translate-x-0 md:transition-none
-          ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
-        `}
+        data-open={sidebarOpen}
+        className="sidebar-slide fixed inset-y-0 left-0 z-50 flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground md:sticky md:top-0 md:z-auto md:h-dvh"
       >
         {sidebarContent}
       </aside>

--- a/src/components/dashboard/LogoutButton.tsx
+++ b/src/components/dashboard/LogoutButton.tsx
@@ -13,9 +13,9 @@ export function LogoutButton() {
   return (
     <button
       onClick={handleLogout}
-      className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
     >
-      <LogOut className="size-3.5" />
+      <LogOut className="size-4" />
       ログアウト
     </button>
   );

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -18,6 +18,7 @@ import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import type { WeatherPrefecture } from "@/lib/weather-areas";
 import { PinInput } from "@/components/auth/PinInput";
 import { useTheme, type Theme } from "@/components/dashboard/ThemeProvider";
+import { QRCodeSVG } from "qrcode.react";
 
 interface UploadedFile {
   filename: string;
@@ -56,6 +57,7 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
   const [imageSaved, setImageSaved] = useState(false);
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const { theme, setTheme } = useTheme();
+  const [dashboardUrl, setDashboardUrl] = useState<string | null>(null);
 
   // PIN/Email change states
   const [pinConfigured, setPinConfigured] = useState(false);
@@ -139,6 +141,24 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => { if (data) setVersionInfo(data); })
       .catch(() => {});
+    // Resolve dashboard URL for QR code
+    (async () => {
+      const origin = window.location.origin;
+      const hostname = window.location.hostname;
+      if (hostname === "localhost" || hostname === "127.0.0.1") {
+        try {
+          const res = await fetch("/api/network");
+          if (res.ok) {
+            const { ip } = await res.json();
+            if (ip) {
+              setDashboardUrl(`${window.location.protocol}//${ip}:${window.location.port}/boards`);
+              return;
+            }
+          }
+        } catch { /* fallback below */ }
+      }
+      setDashboardUrl(`${origin}/boards`);
+    })();
     // Load PIN status and email
     fetch("/api/auth/pin/status")
       .then((r) => (r.ok ? r.json() : null))
@@ -509,6 +529,24 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
                 </a>
               </p>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Dashboard QR Code */}
+      {dashboardUrl && (
+        <div className="rounded-lg border p-6">
+          <h2 className="mb-4 text-lg font-semibold">管理画面 QRコード</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            スマートフォンでこのQRコードを読み取ると、管理画面にアクセスできます。
+          </p>
+          <div className="flex flex-col items-center gap-3">
+            <div className="rounded-lg bg-white p-3">
+              <QRCodeSVG value={dashboardUrl} size={180} />
+            </div>
+            <p className="max-w-xs break-all text-center text-xs text-muted-foreground">
+              {dashboardUrl}
+            </p>
           </div>
         </div>
       )}

--- a/src/components/dashboard/UserManagement.tsx
+++ b/src/components/dashboard/UserManagement.tsx
@@ -130,7 +130,7 @@ export function UserManagement() {
       {loading ? (
         <p className="text-sm text-muted-foreground">読み込み中...</p>
       ) : (
-        <div className="overflow-hidden rounded-lg border">
+        <div className="overflow-x-auto rounded-lg border">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-muted/40 text-xs text-muted-foreground">

--- a/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
@@ -99,7 +99,7 @@ export function CallNumberConfigEditor({
         <div className="space-y-1.5">
           <Label htmlFor="cfg-layout">レーン配置</Label>
           <Select value={layout} onValueChange={(v) => update("layout", v)}>
-            <SelectTrigger id="cfg-layout" className="w-48">
+            <SelectTrigger id="cfg-layout" className="w-full max-w-48">
               <SelectValue>
                 {layout === "horizontal" ? "横レイアウト" : "縦レイアウト"}
               </SelectValue>
@@ -126,9 +126,9 @@ export function CallNumberConfigEditor({
               step={2}
               value={numberFontSize}
               onChange={(e) => update("numberFontSize", Number(e.target.value))}
-              className="w-48"
+              className="w-full max-w-48"
             />
-            <div className="flex w-48 justify-between text-xs text-muted-foreground">
+            <div className="flex w-full max-w-48 justify-between text-xs text-muted-foreground">
               <span>24px</span>
               <span>120px</span>
             </div>

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -107,7 +107,7 @@ export function MessageBoardConfigEditor({
           step={1}
           value={fontSize}
           onChange={(e) => update("fontSize", Number(e.target.value))}
-          className="w-48"
+          className="w-full max-w-48"
         />
       </div>
 
@@ -174,7 +174,7 @@ export function MessageBoardConfigEditor({
           value={fontFamily}
           onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
         >
-          <SelectTrigger id="cfg-font" className="w-64">
+          <SelectTrigger id="cfg-font" className="w-full max-w-64">
             <SelectValue placeholder="フォントを選択">
               {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
             </SelectValue>

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -94,7 +94,7 @@ export function PhotoClockConfigEditor({
       <div className="space-y-1.5">
         <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
         <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
-          <SelectTrigger id="cfg-objectFit" className="w-72">
+          <SelectTrigger id="cfg-objectFit" className="w-full max-w-72">
             <SelectValue>{objectFit === "cover" ? "全面表示（トリミングされる場合あり）" : "全体表示（余白ができる場合あり）"}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -107,7 +107,7 @@ export function PhotoClockConfigEditor({
       <div className="space-y-1.5">
         <Label htmlFor="cfg-clockPos">時計の位置</Label>
         <Select value={clockPosition} onValueChange={(v) => update("clockPosition", v)}>
-          <SelectTrigger id="cfg-clockPos" className="w-48">
+          <SelectTrigger id="cfg-clockPos" className="w-full max-w-48">
             <SelectValue placeholder="位置を選択">{positionLabels[clockPosition] ?? clockPosition}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -123,7 +123,7 @@ export function PhotoClockConfigEditor({
       <div className="space-y-1.5">
         <Label htmlFor="cfg-clockLayout">時計レイアウト</Label>
         <Select value={clockLayout} onValueChange={(v) => update("clockLayout", v)}>
-          <SelectTrigger id="cfg-clockLayout" className="w-64">
+          <SelectTrigger id="cfg-clockLayout" className="w-full max-w-64">
             <SelectValue placeholder="レイアウトを選択">{layoutLabels[clockLayout] ?? clockLayout}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -145,9 +145,9 @@ export function PhotoClockConfigEditor({
           step={4}
           value={clockFontSize}
           onChange={(e) => update("clockFontSize", parseInt(e.target.value, 10))}
-          className="w-64"
+          className="w-full max-w-64"
         />
-        <div className="flex justify-between text-xs text-muted-foreground w-64">
+        <div className="flex w-full max-w-64 justify-between text-xs text-muted-foreground">
           <span>24px</span>
           <span>160px</span>
         </div>
@@ -184,7 +184,7 @@ export function PhotoClockConfigEditor({
           step={0.05}
           value={clockBgOpacity}
           onChange={(e) => update("clockBgOpacity", parseFloat(e.target.value))}
-          className="w-48"
+          className="w-full max-w-48"
         />
       </div>
 
@@ -217,7 +217,7 @@ export function PhotoClockConfigEditor({
           value={fontFamily}
           onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
         >
-          <SelectTrigger id="cfg-font" className="w-64">
+          <SelectTrigger id="cfg-font" className="w-full max-w-64">
             <SelectValue placeholder="フォントを選択">
               {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
             </SelectValue>

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -67,7 +67,7 @@ export function RetroBoardConfigEditor({
       <div className="space-y-1.5">
         <Label htmlFor="cfg-displayColor">表示カラー</Label>
         <Select value={displayColor} onValueChange={(v) => update("displayColor", v)}>
-          <SelectTrigger id="cfg-displayColor" className="w-48">
+          <SelectTrigger id="cfg-displayColor" className="w-full max-w-48">
             <SelectValue placeholder="カラーを選択">{colorLabels[displayColor] ?? displayColor}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -168,7 +168,7 @@ export function RetroBoardConfigEditor({
           value={fontFamily}
           onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
         >
-          <SelectTrigger id="cfg-font" className="w-64">
+          <SelectTrigger id="cfg-font" className="w-full max-w-64">
             <SelectValue placeholder="フォントを選択">
               {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
             </SelectValue>

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -131,7 +131,7 @@ export function SimpleBoardConfigEditor({
           <div className="space-y-1.5">
             <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
             <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
-              <SelectTrigger id="cfg-objectFit" className="w-72">
+              <SelectTrigger id="cfg-objectFit" className="w-full max-w-72">
                 <SelectValue>{objectFit === "cover" ? "全面表示（トリミングされる場合あり）" : "全体表示（余白ができる場合あり）"}</SelectValue>
               </SelectTrigger>
               <SelectContent>
@@ -190,9 +190,9 @@ export function SimpleBoardConfigEditor({
               step={1}
               value={tickerFontSize}
               onChange={(e) => update("tickerFontSize", Number(e.target.value))}
-              className="w-48"
+              className="w-full max-w-48"
             />
-            <div className="flex justify-between text-xs text-muted-foreground w-48">
+            <div className="flex w-full max-w-48 justify-between text-xs text-muted-foreground">
               <span>12px</span>
               <span>64px</span>
             </div>
@@ -201,7 +201,7 @@ export function SimpleBoardConfigEditor({
           <div className="space-y-1.5">
             <Label htmlFor="cfg-tickerPosition">表示位置</Label>
             <Select value={tickerPosition} onValueChange={(v) => update("tickerPosition", v)}>
-              <SelectTrigger id="cfg-tickerPosition" className="w-48">
+              <SelectTrigger id="cfg-tickerPosition" className="w-full max-w-48">
                 <SelectValue>{tickerPosition === "top" ? "上部" : "下部"}</SelectValue>
               </SelectTrigger>
               <SelectContent>
@@ -296,7 +296,7 @@ export function SimpleBoardConfigEditor({
               value={tickerFontFamily}
               onValueChange={(v) => update("tickerFontFamily", v === "__default__" ? "" : v)}
             >
-              <SelectTrigger id="cfg-font" className="w-64">
+              <SelectTrigger id="cfg-font" className="w-full max-w-64">
                 <SelectValue placeholder="フォントを選択">
                   {GOOGLE_FONTS.find((f) => f.value === tickerFontFamily)?.label ?? "デフォルト"}
                 </SelectValue>


### PR DESCRIPTION
## 概要

Closes #64

管理者画面をスマートフォンでも快適に操作できるよう、レスポンシブ対応を行いました。

## 変更内容

### 1. サイドバーの開閉対応 (モバイル)
- `DashboardShell` クライアントコンポーネントを新規作成
- モバイル表示時はハンバーガーメニューで開閉可能なオーバーレイサイドバーに変更
- デスクトップ (md以上) では従来通り常時表示
- ルート変更時に自動でサイドバーを閉じる

### 2. ボード管理画面のレスポンシブ調整
- ページヘッダーのフォントサイズをモバイル向けに調整 (`text-xl` → `sm:text-2xl`)
- メインコンテンツ領域のパディングをモバイル向けに縮小

### 3. 設定画面にQRコード表示
- `qrcode.react` (既存の依存) を使用してダッシュボードURLのQRコードを表示
- `localhost` / `127.0.0.1` の場合は `/api/network` でローカルIP (192.168.x.x) を取得して使用
- ドメインホスティングの場合はそのままのURLを使用

### 4. ロゴのSVG化
- `KeinageLogo` 共通コンポーネントを新規作成 (`/lp/logos/keinage_logo.svg` ベース)
- `currentColor` を使用し、ダークモード時は自動的にライトカラーで表示
- ダッシュボードサイドバー左上のロゴを置き換え
- 全ログイン画面 (PIN入力、ログイン、セットアップ、PIN忘れ、PINリセット) のロゴを置き換え

## 変更ファイル

### 新規作成
- `src/components/KeinageLogo.tsx` — SVGロゴコンポーネント
- `src/components/dashboard/DashboardShell.tsx` — レスポンシブ対応ダッシュボードシェル

### 変更
- `src/app/(dashboard)/layout.tsx` — DashboardShellに移行
- `src/app/(dashboard)/boards/page.tsx` — レスポンシブフォントサイズ
- `src/components/dashboard/SettingsClient.tsx` — QRコードセクション追加
- `src/app/pin/PinLoginClient.tsx` — SVGロゴに置き換え
- `src/app/pin/login/LoginClient.tsx` — SVGロゴに置き換え
- `src/app/pin/setup/PinSetupClient.tsx` — SVGロゴに置き換え
- `src/app/pin/forgot/page.tsx` — SVGロゴに置き換え
- `src/app/pin/reset/[token]/PinResetClient.tsx` — SVGロゴに置き換え