### PR TITLE
fix: sync board slide interval with image durations

### DIFF
--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -7,6 +7,17 @@ import { eq, asc } from "drizzle-orm";
 import { updateBoardSchema } from "@/lib/validators";
 import { emitSSE } from "@/lib/sse";
 
+const LEGACY_IMAGE_DURATION_SECONDS = 5;
+
+function readSlideInterval(config: unknown): number | undefined {
+  if (!config || typeof config !== "object") {
+    return undefined;
+  }
+
+  const raw = (config as Record<string, unknown>).slideInterval;
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 1 ? raw : undefined;
+}
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -68,6 +79,12 @@ export async function PATCH(
   if (result.data.config !== undefined) updates.config = result.data.config;
   if (result.data.isActive !== undefined) updates.isActive = result.data.isActive;
 
+  const previousSlideInterval = readSlideInterval(existing.config);
+  const nextSlideInterval =
+    result.data.config !== undefined
+      ? readSlideInterval(result.data.config)
+      : undefined;
+
   if (Object.keys(updates).length === 0) {
     return NextResponse.json(existing);
   }
@@ -77,6 +94,42 @@ export async function PATCH(
     .set(updates)
     .where(eq(boards.id, id))
     .returning();
+
+  if (
+    nextSlideInterval !== undefined &&
+    nextSlideInterval !== previousSlideInterval
+  ) {
+    const boardMedia = await db
+      .select({
+        id: mediaItems.id,
+        type: mediaItems.type,
+        duration: mediaItems.duration,
+      })
+      .from(mediaItems)
+      .where(eq(mediaItems.boardId, id));
+
+    const fallbackDurations = new Set<number>([LEGACY_IMAGE_DURATION_SECONDS]);
+    if (previousSlideInterval !== undefined) {
+      fallbackDurations.add(previousSlideInterval);
+    }
+
+    const imageIdsToSync = boardMedia
+      .filter(
+        (item) => item.type === "image" && fallbackDurations.has(item.duration),
+      )
+      .map((item) => item.id);
+
+    for (const mediaId of imageIdsToSync) {
+      await db
+        .update(mediaItems)
+        .set({ duration: nextSlideInterval })
+        .where(eq(mediaItems.id, mediaId));
+    }
+
+    if (imageIdsToSync.length > 0) {
+      emitSSE(id, "media-updated");
+    }
+  }
 
   emitSSE(id, "board-updated");
 

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -28,6 +28,15 @@ const ALLOWED_VIDEO_TYPES = ["video/mp4", "video/webm"];
 const ALLOWED_TYPES = [...ALLOWED_IMAGE_TYPES, ...ALLOWED_VIDEO_TYPES];
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
+function readSlideInterval(config: unknown): number | undefined {
+  if (!config || typeof config !== "object") {
+    return undefined;
+  }
+
+  const raw = (config as Record<string, unknown>).slideInterval;
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 1 ? raw : undefined;
+}
+
 export async function GET() {
   const items = await db
     .select({
@@ -142,10 +151,13 @@ export async function POST(request: NextRequest) {
     -1,
   );
 
+  const defaultDuration =
+    mediaType === "image" ? readSlideInterval(board.config) ?? 5 : 5;
+
   const durationValue =
     duration && typeof duration === "string"
-      ? Math.max(1, parseInt(duration, 10) || 5)
-      : 5;
+      ? Math.max(1, parseInt(duration, 10) || defaultDuration)
+      : defaultDuration;
 
   const [created] = await db
     .insert(mediaItems)


### PR DESCRIPTION
## Summary
- sync existing image durations to the updated board slide interval when they still use the previous default value
- default newly uploaded image durations to the board slide interval instead of the legacy 5-second fallback
- preserve explicitly customized media durations by only updating images that still match the prior default

## Verification
- `pnpm build`
- `pnpm lint` currently fails on pre-existing unrelated errors in the repository

Closes #77