### PR TITLE
fix: prevent mobile overflow in board edit screens

### DIFF
--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -215,7 +215,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
 
       <div className="grid gap-6 md:grid-cols-3">
         {/* Left: Board settings (2 cols) */}
-        <div className="space-y-6 md:col-span-2">
+        <div className="min-w-0 space-y-6 md:col-span-2">
           {/* Basic info */}
           <Card>
             <CardHeader>
@@ -426,7 +426,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
         </div>
 
         {/* Right: Actions sidebar */}
-        <div className="space-y-4">
+        <div className="min-w-0 space-y-4">
           <Card>
             <CardHeader>
               <CardTitle className="text-base">アクション</CardTitle>

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -235,7 +235,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                 />
               </div>
 
-              <div className="flex items-center gap-3">
+              <div className="flex flex-wrap items-center gap-3">
                 <Switch
                   id="board-active"
                   checked={isActive}
@@ -332,19 +332,19 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                       editingMsgId === msg.id ? (
                         <div
                           key={msg.id}
-                          className="flex items-center gap-2 rounded-md border border-primary/30 bg-accent/30 px-3 py-2 text-sm"
+                          className="flex flex-col gap-2 rounded-md border border-primary/30 bg-accent/30 px-3 py-2 text-sm sm:flex-row sm:items-center"
                         >
                           <Input
                             value={editMsgPriority}
                             onChange={(e) => setEditMsgPriority(e.target.value)}
                             type="number"
                             min={0}
-                            className="w-16 shrink-0"
+                            className="w-20 shrink-0 sm:w-16"
                           />
                           <Input
                             value={editMsgContent}
                             onChange={(e) => setEditMsgContent(e.target.value)}
-                            className="flex-1"
+                            className="min-w-0 flex-1"
                             onKeyDown={(e) => {
                               if (e.key === "Enter" && !e.nativeEvent.isComposing) {
                                 e.preventDefault();
@@ -356,25 +356,27 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                             }}
                             autoFocus
                           />
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            onClick={() => handleSaveMessage(msg.id)}
-                          >
-                            <Check className="size-3.5 text-green-600" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            onClick={cancelEditMessage}
-                          >
-                            <X className="size-3.5 text-muted-foreground" />
-                          </Button>
+                          <div className="flex items-center gap-2 self-end sm:self-auto">
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              onClick={() => handleSaveMessage(msg.id)}
+                            >
+                              <Check className="size-3.5 text-green-600" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              onClick={cancelEditMessage}
+                            >
+                              <X className="size-3.5 text-muted-foreground" />
+                            </Button>
+                          </div>
                         </div>
                       ) : (
                         <div
                           key={msg.id}
-                          className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                          className="flex flex-wrap items-center gap-2 rounded-md border px-3 py-2 text-sm"
                         >
                           <Badge variant="secondary" className="shrink-0">
                             P{msg.priority}

--- a/src/components/dashboard/CallScreenAdmin.tsx
+++ b/src/components/dashboard/CallScreenAdmin.tsx
@@ -92,8 +92,8 @@ export default function CallScreenAdmin({
         {/* Passcode */}
         <div className="space-y-2">
           <label className="text-sm font-medium">パスコード（6桁）</label>
-          <div className="flex items-center gap-3">
-            <span className="rounded-lg border bg-muted px-4 py-2 font-mono text-2xl tracking-[0.3em]">
+          <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+            <span className="max-w-full overflow-hidden rounded-lg border bg-muted px-4 py-2 font-mono text-lg tracking-[0.18em] break-all sm:text-2xl sm:tracking-[0.3em]">
               {passcode || "------"}
             </span>
             <Button
@@ -114,14 +114,15 @@ export default function CallScreenAdmin({
         {/* URL */}
         <div className="space-y-2">
           <label className="text-sm font-medium">呼び出し画面URL</label>
-          <div className="flex items-center gap-2">
-            <code className="flex-1 truncate rounded-lg border bg-muted px-3 py-2 text-xs">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <code className="block min-w-0 w-full overflow-hidden text-ellipsis rounded-lg border bg-muted px-3 py-2 text-xs sm:flex-1">
               {callUrl}
             </code>
             <Button
               type="button"
               variant="outline"
               size="sm"
+              className="w-full sm:w-auto"
               onClick={handleCopyUrl}
             >
               {copied ? (
@@ -140,7 +141,7 @@ export default function CallScreenAdmin({
             <label className="text-sm font-medium">
               QRコード（パスコード込み）
             </label>
-            <div className="inline-block rounded-xl border bg-white p-4">
+            <div className="inline-block max-w-full overflow-hidden rounded-xl border bg-white p-3 sm:p-4">
               <QRCodeSVG
                 value={callUrlWithPasscode}
                 size={200}

--- a/src/components/dashboard/MediaUploadZone.tsx
+++ b/src/components/dashboard/MediaUploadZone.tsx
@@ -227,10 +227,10 @@ export default function MediaUploadZone({
           {uploading.map((item, idx) => (
             <div
               key={idx}
-              className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm"
+              className="flex flex-col gap-2 rounded-md border px-3 py-2 text-sm sm:flex-row sm:items-center"
             >
               <span className="flex-1 truncate">{item.name}</span>
-              <div className="h-2 w-24 overflow-hidden rounded-full bg-muted">
+              <div className="h-2 w-full overflow-hidden rounded-full bg-muted sm:w-24">
                 <div
                   className="h-full rounded-full bg-primary transition-all"
                   style={{ width: `${item.progress}%` }}
@@ -256,7 +256,7 @@ export default function MediaUploadZone({
               onDragOver={(e) => handleReorderDragOver(e, index)}
               onDrop={(e) => handleReorderDrop(e, index)}
               onDragEnd={handleReorderDragEnd}
-              className={`flex items-center gap-3 rounded-md border px-3 py-2 text-sm transition-colors ${
+              className={`flex flex-wrap items-center gap-3 rounded-md border px-3 py-2 text-sm transition-colors ${
                 draggedIndex === index ? "opacity-50" : ""
               } ${dragOverIndex === index ? "border-primary bg-primary/5" : ""}`}
             >
@@ -282,7 +282,7 @@ export default function MediaUploadZone({
               </div>
 
               {/* Info */}
-              <div className="flex-1 min-w-0">
+              <div className="min-w-0 flex-1 basis-40">
                 <div className="flex items-center gap-2">
                   <Badge variant="outline" className="shrink-0">
                     {item.type === "image" ? (
@@ -299,7 +299,7 @@ export default function MediaUploadZone({
               </div>
 
               {/* Duration */}
-              <div className="flex shrink-0 items-center gap-1">
+              <div className="ml-auto flex shrink-0 items-center gap-1">
                 <Label className="text-xs text-muted-foreground">秒:</Label>
                 <Input
                   type="number"
@@ -317,6 +317,7 @@ export default function MediaUploadZone({
               <Button
                 variant="ghost"
                 size="icon-xs"
+                className="ml-auto sm:ml-0"
                 onClick={() => handleDelete(item.id)}
               >
                 <Trash2 className="size-3.5 text-destructive" />

--- a/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
@@ -83,7 +83,7 @@ export function CallNumberConfigEditor({
       {/* Clock */}
       <div>
         <h4 className="mb-3 text-sm font-semibold">時計</h4>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-start gap-3">
           <Switch
             id="cfg-showClock"
             checked={showClock}
@@ -180,7 +180,7 @@ export function CallNumberConfigEditor({
         <div className="space-y-3">
           <div className="space-y-1.5">
             <Label htmlFor="cfg-bgColor">背景色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-bgColor"
@@ -199,7 +199,7 @@ export function CallNumberConfigEditor({
 
           <div className="space-y-1.5">
             <Label htmlFor="cfg-waitingColor">呼び出し前のテキスト色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-waitingColor"
@@ -218,7 +218,7 @@ export function CallNumberConfigEditor({
 
           <div className="space-y-1.5">
             <Label htmlFor="cfg-calledColor">呼び出し済みのテキスト色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-calledColor"
@@ -237,7 +237,7 @@ export function CallNumberConfigEditor({
 
           <div className="space-y-1.5">
             <Label htmlFor="cfg-highlightColor">直近呼び出しのハイライト色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-highlightColor"

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -59,25 +59,29 @@ export function MessageBoardConfigEditor({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <Switch
           id="cfg-showClock"
           checked={showClock}
           onCheckedChange={(v) => update("showClock", v)}
         />
-        <Label htmlFor="cfg-showClock">現在時刻を表示</Label>
+        <Label htmlFor="cfg-showClock" className="min-w-0 flex-1 leading-snug">
+          現在時刻を表示
+        </Label>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <Switch
           id="cfg-showWeather"
           checked={showWeather}
           onCheckedChange={(v) => update("showWeather", v)}
         />
-        <Label htmlFor="cfg-showWeather">天気予報を表示</Label>
+        <Label htmlFor="cfg-showWeather" className="min-w-0 flex-1 leading-snug">
+          天気予報を表示
+        </Label>
       </div>
       {showWeather && (
-        <p className="text-xs text-muted-foreground">
+        <p className="break-words text-xs text-muted-foreground">
           表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
         </p>
       )}
@@ -93,7 +97,7 @@ export function MessageBoardConfigEditor({
           onChange={(e) =>
             update("maxDisplayCount", Math.max(1, parseInt(e.target.value, 10) || 10))
           }
-          className="w-24"
+          className="w-full sm:w-24"
         />
       </div>
 
@@ -107,13 +111,13 @@ export function MessageBoardConfigEditor({
           step={1}
           value={fontSize}
           onChange={(e) => update("fontSize", Number(e.target.value))}
-          className="w-full max-w-48"
+          className="w-full sm:max-w-48"
         />
       </div>
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-bgColor">背景色</Label>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
           <input
             type="color"
             id="cfg-bgColor"
@@ -124,7 +128,7 @@ export function MessageBoardConfigEditor({
           <Input
             value={backgroundColor}
             onChange={(e) => update("backgroundColor", e.target.value)}
-            className="w-28 font-mono text-sm"
+            className="w-full font-mono text-sm sm:w-28"
             maxLength={7}
           />
         </div>
@@ -132,7 +136,7 @@ export function MessageBoardConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-textColor">文字色</Label>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
           <input
             type="color"
             id="cfg-textColor"
@@ -143,7 +147,7 @@ export function MessageBoardConfigEditor({
           <Input
             value={textColor}
             onChange={(e) => update("textColor", e.target.value)}
-            className="w-28 font-mono text-sm"
+            className="w-full font-mono text-sm sm:w-28"
             maxLength={7}
           />
         </div>
@@ -151,7 +155,7 @@ export function MessageBoardConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-accentColor">アクセントカラー</Label>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
           <input
             type="color"
             id="cfg-accentColor"
@@ -162,7 +166,7 @@ export function MessageBoardConfigEditor({
           <Input
             value={accentColor}
             onChange={(e) => update("accentColor", e.target.value)}
-            className="w-28 font-mono text-sm"
+            className="w-full font-mono text-sm sm:w-28"
             maxLength={7}
           />
         </div>
@@ -174,7 +178,7 @@ export function MessageBoardConfigEditor({
           value={fontFamily}
           onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
         >
-          <SelectTrigger id="cfg-font" className="w-full max-w-64">
+          <SelectTrigger id="cfg-font" className="w-full sm:max-w-64">
             <SelectValue placeholder="フォントを選択">
               {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
             </SelectValue>

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -87,14 +87,14 @@ export function PhotoClockConfigEditor({
           onChange={(e) =>
             update("slideInterval", Math.max(1, parseInt(e.target.value, 10) || 1))
           }
-          className="w-24"
+          className="w-full sm:w-24"
         />
       </div>
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-objectFit">メディア表示モード</Label>
         <Select value={objectFit} onValueChange={(v) => update("objectFit", v)}>
-          <SelectTrigger id="cfg-objectFit" className="w-full max-w-72">
+          <SelectTrigger id="cfg-objectFit" className="w-full sm:max-w-72">
             <SelectValue>{objectFit === "cover" ? "全面表示（トリミングされる場合あり）" : "全体表示（余白ができる場合あり）"}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -107,7 +107,7 @@ export function PhotoClockConfigEditor({
       <div className="space-y-1.5">
         <Label htmlFor="cfg-clockPos">時計の位置</Label>
         <Select value={clockPosition} onValueChange={(v) => update("clockPosition", v)}>
-          <SelectTrigger id="cfg-clockPos" className="w-full max-w-48">
+          <SelectTrigger id="cfg-clockPos" className="w-full sm:max-w-48">
             <SelectValue placeholder="位置を選択">{positionLabels[clockPosition] ?? clockPosition}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -123,7 +123,7 @@ export function PhotoClockConfigEditor({
       <div className="space-y-1.5">
         <Label htmlFor="cfg-clockLayout">時計レイアウト</Label>
         <Select value={clockLayout} onValueChange={(v) => update("clockLayout", v)}>
-          <SelectTrigger id="cfg-clockLayout" className="w-full max-w-64">
+          <SelectTrigger id="cfg-clockLayout" className="w-full sm:max-w-64">
             <SelectValue placeholder="レイアウトを選択">{layoutLabels[clockLayout] ?? clockLayout}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -145,9 +145,9 @@ export function PhotoClockConfigEditor({
           step={4}
           value={clockFontSize}
           onChange={(e) => update("clockFontSize", parseInt(e.target.value, 10))}
-          className="w-full max-w-64"
+          className="w-full sm:max-w-64"
         />
-        <div className="flex w-full max-w-64 justify-between text-xs text-muted-foreground">
+        <div className="flex w-full justify-between text-xs text-muted-foreground sm:max-w-64">
           <span>24px</span>
           <span>160px</span>
         </div>
@@ -155,7 +155,7 @@ export function PhotoClockConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-clockColor">時計の文字色</Label>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
           <input
             type="color"
             id="cfg-clockColor"
@@ -166,7 +166,7 @@ export function PhotoClockConfigEditor({
           <Input
             value={clockColor}
             onChange={(e) => update("clockColor", e.target.value)}
-            className="w-28 font-mono text-sm"
+            className="w-full font-mono text-sm sm:w-28"
             maxLength={7}
           />
         </div>
@@ -184,29 +184,33 @@ export function PhotoClockConfigEditor({
           step={0.05}
           value={clockBgOpacity}
           onChange={(e) => update("clockBgOpacity", parseFloat(e.target.value))}
-          className="w-full max-w-48"
+          className="w-full sm:max-w-48"
         />
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <Switch
           id="cfg-24h"
           checked={is24Hour}
           onCheckedChange={(v) => update("is24Hour", v)}
         />
-        <Label htmlFor="cfg-24h">24時間表示（OFFで12時間+AM/PM表記）</Label>
+        <Label htmlFor="cfg-24h" className="min-w-0 flex-1 leading-snug">
+          24時間表示（OFFで12時間+AM/PM表記）
+        </Label>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <Switch
           id="cfg-weather"
           checked={showWeather}
           onCheckedChange={(v) => update("showWeather", v)}
         />
-        <Label htmlFor="cfg-weather">天気予報を表示</Label>
+        <Label htmlFor="cfg-weather" className="min-w-0 flex-1 leading-snug">
+          天気予報を表示
+        </Label>
       </div>
       {showWeather && (
-        <p className="text-xs text-muted-foreground">
+        <p className="break-words text-xs text-muted-foreground">
           表示地域は<a href="/settings" className="underline">設定ページ</a>で変更できます。
         </p>
       )}
@@ -217,7 +221,7 @@ export function PhotoClockConfigEditor({
           value={fontFamily}
           onValueChange={(v) => update("fontFamily", v === "__default__" ? "" : v)}
         >
-          <SelectTrigger id="cfg-font" className="w-full max-w-64">
+          <SelectTrigger id="cfg-font" className="w-full sm:max-w-64">
             <SelectValue placeholder="フォントを選択">
               {GOOGLE_FONTS.find((f) => f.value === fontFamily)?.label ?? "デフォルト"}
             </SelectValue>

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -139,7 +139,7 @@ export function RetroBoardConfigEditor({
         />
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <Switch
           id="cfg-showClock"
           checked={showClock}
@@ -148,7 +148,7 @@ export function RetroBoardConfigEditor({
         <Label htmlFor="cfg-showClock">現在時刻を表示</Label>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <Switch
           id="cfg-showWeather"
           checked={showWeather}

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -86,7 +86,7 @@ export function SimpleBoardConfigEditor({
       <div>
         <h4 className="mb-3 text-sm font-semibold">時計・天気</h4>
         <div className="space-y-3">
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-start gap-3">
             <Switch
               id="cfg-showClock"
               checked={showClock}
@@ -94,7 +94,7 @@ export function SimpleBoardConfigEditor({
             />
             <Label htmlFor="cfg-showClock">現在時刻を表示</Label>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-start gap-3">
             <Switch
               id="cfg-showWeather"
               checked={showWeather}
@@ -142,7 +142,7 @@ export function SimpleBoardConfigEditor({
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="cfg-bgColor">背景色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-bgColor"
@@ -213,7 +213,7 @@ export function SimpleBoardConfigEditor({
 
           <div className="space-y-1.5">
             <Label htmlFor="cfg-textColor">文字色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-textColor"
@@ -232,7 +232,7 @@ export function SimpleBoardConfigEditor({
 
           <div className="space-y-1.5">
             <Label htmlFor="cfg-tickerBg">背景色</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 type="color"
                 id="cfg-tickerBg"


### PR DESCRIPTION
## Summary
- make board edit controls wrap or stack on small screens to prevent horizontal overflow
- adjust message edit rows and media management rows so they collapse cleanly on smartphones
- tighten the remaining Photo Clock and Message Board config layouts by making long labels wrap and fixed-width inputs stack on mobile

## Scope
- board edit shared UI
- media upload / media list UI
- call number admin UI
- template config editors for simple, photo-clock, retro, message, and call-number

## Verification
- `env CI=1 pnpm build`

Closes #81