### PR TITLE
fix: 管理画面リロード時のダークモードちらつきを防止

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -69,7 +69,11 @@ export default async function DashboardLayout({
 
   return (
     <ThemeProvider initialTheme={colorTheme as "system" | "light" | "dark"}>
-      <DashboardShell userId={userId} role={role}>
+      <DashboardShell
+        userId={userId}
+        role={role}
+        initialTheme={colorTheme as "system" | "light" | "dark"}
+      >
         {children}
       </DashboardShell>
     </ThemeProvider>

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -42,14 +42,17 @@ function SidebarLink({
 export function DashboardShell({
   userId,
   role,
+  initialTheme,
   children,
 }: {
   userId: string;
   role: string;
+  initialTheme: "system" | "light" | "dark";
   children: React.ReactNode;
 }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname();
+  const initialResolvedTheme = initialTheme === "system" ? undefined : initialTheme;
 
   // Close sidebar on route change
   useEffect(() => {
@@ -108,7 +111,11 @@ export function DashboardShell({
   );
 
   return (
-    <div id="dashboard-theme-root" className="flex min-h-dvh bg-background text-foreground">
+    <div
+      id="dashboard-theme-root"
+      className={`flex min-h-dvh bg-background text-foreground ${initialResolvedTheme === "dark" ? "dark" : ""}`}
+      style={initialResolvedTheme ? { colorScheme: initialResolvedTheme } : undefined}
+    >
       {/* Mobile header bar */}
       <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center gap-3 border-b bg-background px-4 md:hidden">
         <button

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -16,6 +16,19 @@ import { Separator } from "@/components/ui/separator";
 import { LogoutButton } from "@/components/dashboard/LogoutButton";
 import { KeinageLogo } from "@/components/KeinageLogo";
 
+function getThemeBootstrapScript(initialTheme: "system" | "light" | "dark") {
+  return `(() => {
+    const root = document.currentScript?.parentElement;
+    if (!root) return;
+    const theme = ${JSON.stringify(initialTheme)};
+    const resolved = theme === "system"
+      ? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+      : theme;
+    root.classList.toggle("dark", resolved === "dark");
+    root.style.colorScheme = resolved;
+  })();`;
+}
+
 function SidebarLink({
   href,
   icon: Icon,
@@ -116,6 +129,7 @@ export function DashboardShell({
       className={`flex min-h-dvh bg-background text-foreground ${initialResolvedTheme === "dark" ? "dark" : ""}`}
       style={initialResolvedTheme ? { colorScheme: initialResolvedTheme } : undefined}
     >
+      <script dangerouslySetInnerHTML={{ __html: getThemeBootstrapScript(initialTheme) }} />
       {/* Mobile header bar */}
       <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center gap-3 border-b bg-background px-4 md:hidden">
         <button

--- a/src/components/dashboard/ThemeProvider.tsx
+++ b/src/components/dashboard/ThemeProvider.tsx
@@ -34,6 +34,13 @@ function getResolvedTheme(theme: Theme): "light" | "dark" {
     : "light";
 }
 
+function applyResolvedTheme(resolved: "light" | "dark") {
+  const el = document.getElementById("dashboard-theme-root");
+  if (!el) return;
+  el.classList.toggle("dark", resolved === "dark");
+  el.style.colorScheme = resolved;
+}
+
 export function ThemeProvider({
   children,
   initialTheme = "system",
@@ -42,11 +49,6 @@ export function ThemeProvider({
   initialTheme?: Theme;
 }) {
   const [theme, setThemeState] = useState<Theme>(initialTheme);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const setTheme = useCallback((t: Theme) => {
     setThemeState(t);
@@ -60,13 +62,9 @@ export function ThemeProvider({
 
   // Apply .dark class to the wrapper element
   useEffect(() => {
-    if (!mounted) return;
-
     function apply() {
       const resolved = getResolvedTheme(theme);
-      const el = document.getElementById("dashboard-theme-root");
-      if (!el) return;
-      el.classList.toggle("dark", resolved === "dark");
+      applyResolvedTheme(resolved);
     }
 
     apply();
@@ -77,7 +75,7 @@ export function ThemeProvider({
       mq.addEventListener("change", apply);
       return () => mq.removeEventListener("change", apply);
     }
-  }, [theme, mounted]);
+  }, [theme]);
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>


### PR DESCRIPTION
## 概要
- 管理画面をダークモードで利用中にリロードすると、一瞬ライトモードで描画される問題を修正しました
- ダーク/ライトの明示設定はサーバー初期描画時点で反映し、初回ペイントのテーマずれを防止します
- クライアント側のテーマ同期処理では `color-scheme` も合わせて更新するようにしました

## 変更内容
- ダッシュボードのテーマルートに初期テーマを SSR で反映
- `ThemeProvider` のテーマ反映処理を簡素化し、不要なマウント待ちを削除
- 初期テーマに応じて `color-scheme` を同期

## 確認内容
- 変更ファイルに対して ESLint を実行
- コード上で、ダークモード明示設定時に初回描画から `.dark` が付与されることを確認

Closes #83