### PR TITLE
feat: owner/shared の所有スコープを導入

### DIFF
--- a/drizzle/0001_marvelous_jackpot.sql
+++ b/drizzle/0001_marvelous_jackpot.sql
@@ -1,0 +1,63 @@
+ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'general';--> statement-breakpoint
+ALTER TABLE "boards" ADD COLUMN "owner_user_id" text;--> statement-breakpoint
+ALTER TABLE "settings" ADD COLUMN "owner_user_id" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "phone_number" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "attribute" text DEFAULT 'shared' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "owner_user_id" text;--> statement-breakpoint
+DO $$
+DECLARE
+    scoped_owner_id text;
+BEGIN
+    SELECT "id"
+    INTO scoped_owner_id
+    FROM "users"
+    ORDER BY
+        CASE WHEN "role" = 'admin' THEN 0 ELSE 1 END,
+        "created_at" ASC,
+        "id" ASC
+    LIMIT 1;
+
+    IF scoped_owner_id IS NULL THEN
+        IF EXISTS (SELECT 1 FROM "boards") OR EXISTS (SELECT 1 FROM "settings") THEN
+            RAISE EXCEPTION 'Cannot backfill owner scope without an existing user';
+        END IF;
+
+        RETURN;
+    END IF;
+
+    UPDATE "users"
+    SET
+        "attribute" = CASE
+            WHEN "id" = scoped_owner_id THEN 'owner'
+            ELSE 'shared'
+        END,
+        "owner_user_id" = CASE
+            WHEN "id" = scoped_owner_id THEN NULL
+            ELSE scoped_owner_id
+        END,
+        "role" = CASE
+            WHEN "id" = scoped_owner_id THEN 'admin'
+            ELSE "role"
+        END,
+        "phone_number" = CASE
+            WHEN "id" = scoped_owner_id AND "phone_number" IS NULL THEN '000-0000-0000'
+            ELSE "phone_number"
+        END;
+
+    UPDATE "boards"
+    SET "owner_user_id" = scoped_owner_id
+    WHERE "owner_user_id" IS NULL;
+
+    UPDATE "settings"
+    SET "owner_user_id" = scoped_owner_id
+    WHERE "owner_user_id" IS NULL;
+END
+$$;--> statement-breakpoint
+ALTER TABLE "boards" ALTER COLUMN "owner_user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "settings" ALTER COLUMN "owner_user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "settings" DROP CONSTRAINT IF EXISTS "settings_pkey";--> statement-breakpoint
+ALTER TABLE "settings" ADD CONSTRAINT "settings_owner_user_id_key_pk" PRIMARY KEY("owner_user_id","key");--> statement-breakpoint
+ALTER TABLE "boards" ADD CONSTRAINT "boards_owner_user_id_users_id_fk" FOREIGN KEY ("owner_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "settings" ADD CONSTRAINT "settings_owner_user_id_users_id_fk" FOREIGN KEY ("owner_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_owner_user_id_users_id_fk" FOREIGN KEY ("owner_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_phone_number_unique" UNIQUE("phone_number");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,611 @@
+{
+  "id": "814e72d6-3d99-467f-a430-d560f60e0c7f",
+  "prevId": "1802b43e-a0d7-4727-bed0-8a05f2770f04",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_unique": {
+          "name": "auth_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_owner_user_id_users_id_fk": {
+          "name": "boards_owner_user_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_attempts": {
+      "name": "pin_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_reset_tokens": {
+      "name": "pin_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pin_reset_tokens_user_id_users_id_fk": {
+          "name": "pin_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "pin_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pin_reset_tokens_token_unique": {
+          "name": "pin_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_owner_user_id_users_id_fk": {
+          "name": "settings_owner_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_owner_user_id_key_pk": {
+          "name": "settings_owner_user_id_key_pk",
+          "columns": [
+            "owner_user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_owner_user_id_users_id_fk": {
+          "name": "users_owner_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776996359314,
       "tag": "0000_large_kate_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777165109520,
+      "tag": "0001_marvelous_jackpot",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -5,8 +5,8 @@
  * Usage: pnpm db:seed
  */
 import { drizzle } from "drizzle-orm/node-postgres";
-import { randomUUID } from "crypto";
 import { Pool } from "pg";
+import { asc, eq } from "drizzle-orm";
 import * as schema from "../src/db/schema";
 
 const DATABASE_URL =
@@ -16,20 +16,56 @@ async function main() {
   const pool = new Pool({ connectionString: DATABASE_URL });
   const db = drizzle(pool, { schema });
 
-  const boardId = randomUUID();
+  let ownerUserId = (
+    await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.attribute, "owner"))
+      .orderBy(asc(schema.users.createdAt))
+      .limit(1)
+  )[0]?.id;
 
-  await db.insert(schema.boards).values({
-    id: boardId,
-    name: "サンプルボード",
-    templateId: "simple",
-    config: JSON.stringify({
-      slideInterval: 5,
-      tickerSpeed: 60,
-      backgroundColor: "#000000",
-      textColor: "#ffffff",
-    }),
-    isActive: true,
-  });
+  if (!ownerUserId) {
+    ownerUserId = (
+      await db
+        .insert(schema.users)
+        .values({
+          userId: "seed-owner",
+          email: "seed-owner@example.com",
+          phoneNumber: "000-0000-0000",
+          passwordHash: "seed-password-hash",
+          attribute: "owner",
+          role: "admin",
+        })
+        .returning({ id: schema.users.id })
+    )[0]?.id;
+  }
+
+  if (!ownerUserId) {
+    throw new Error("Failed to prepare an owner user for seed data");
+  }
+
+  const boardId = (
+    await db
+      .insert(schema.boards)
+      .values({
+        ownerUserId,
+        name: "サンプルボード",
+        templateId: "simple",
+        config: JSON.stringify({
+          slideInterval: 5,
+          tickerSpeed: 60,
+          backgroundColor: "#000000",
+          textColor: "#ffffff",
+        }),
+        isActive: true,
+      })
+      .returning({ id: schema.boards.id })
+  )[0]?.id;
+
+  if (!boardId) {
+    throw new Error("Failed to create the sample board");
+  }
 
   // サンプル画像（プレースホルダー画像を使用）
   const sampleImages = [
@@ -40,7 +76,6 @@ async function main() {
 
   for (const [index, url] of sampleImages.entries()) {
     await db.insert(schema.mediaItems).values({
-      id: randomUUID(),
       boardId,
       type: "image",
       filePath: url,
@@ -58,7 +93,6 @@ async function main() {
 
   for (const [index, content] of sampleMessages.entries()) {
     await db.insert(schema.messages).values({
-      id: randomUUID(),
       boardId,
       content,
       priority: index,
@@ -69,26 +103,32 @@ async function main() {
   console.log(`   Open http://localhost:3000/${boardId}`);
 
   // --- Photo-Clock Board ---
-  const photoClockId = randomUUID();
+  const photoClockId = (
+    await db
+      .insert(schema.boards)
+      .values({
+        ownerUserId,
+        name: "フォトクロック サンプル",
+        templateId: "photo-clock",
+        config: JSON.stringify({
+          slideInterval: 8,
+          clockPosition: "bottom-right",
+          clockFontSize: "text-5xl",
+          clockColor: "#ffffff",
+          clockBgOpacity: 0.5,
+          is24Hour: true,
+        }),
+        isActive: true,
+      })
+      .returning({ id: schema.boards.id })
+  )[0]?.id;
 
-  await db.insert(schema.boards).values({
-    id: photoClockId,
-    name: "フォトクロック サンプル",
-    templateId: "photo-clock",
-    config: JSON.stringify({
-      slideInterval: 8,
-      clockPosition: "bottom-right",
-      clockFontSize: "text-5xl",
-      clockColor: "#ffffff",
-      clockBgOpacity: 0.5,
-      is24Hour: true,
-    }),
-    isActive: true,
-  });
+  if (!photoClockId) {
+    throw new Error("Failed to create the photo-clock sample board");
+  }
 
   for (const [index, url] of sampleImages.entries()) {
     await db.insert(schema.mediaItems).values({
-      id: randomUUID(),
       boardId: photoClockId,
       type: "image",
       filePath: url,
@@ -101,20 +141,27 @@ async function main() {
   console.log(`   Open http://localhost:3000/${photoClockId}`);
 
   // --- Retro Board ---
-  const retroBoardId = randomUUID();
+  const retroBoardId = (
+    await db
+      .insert(schema.boards)
+      .values({
+        ownerUserId,
+        name: "レトロ掲示板 サンプル",
+        templateId: "retro",
+        config: JSON.stringify({
+          displayColor: "green",
+          rows: 5,
+          flipSpeed: 0.08,
+          switchInterval: 5,
+        }),
+        isActive: true,
+      })
+      .returning({ id: schema.boards.id })
+  )[0]?.id;
 
-  await db.insert(schema.boards).values({
-    id: retroBoardId,
-    name: "レトロ掲示板 サンプル",
-    templateId: "retro",
-    config: JSON.stringify({
-      displayColor: "green",
-      rows: 5,
-      flipSpeed: 0.08,
-      switchInterval: 5,
-    }),
-    isActive: true,
-  });
+  if (!retroBoardId) {
+    throw new Error("Failed to create the retro sample board");
+  }
 
   const retroMessages = [
     "1番線  東京行き  10:15 発  定刻",
@@ -128,7 +175,6 @@ async function main() {
 
   for (const [index, content] of retroMessages.entries()) {
     await db.insert(schema.messages).values({
-      id: randomUUID(),
       boardId: retroBoardId,
       content,
       priority: retroMessages.length - index,
@@ -139,21 +185,28 @@ async function main() {
   console.log(`   Open http://localhost:3000/${retroBoardId}`);
 
   // --- Message Board ---
-  const messageBoardId = randomUUID();
+  const messageBoardId = (
+    await db
+      .insert(schema.boards)
+      .values({
+        ownerUserId,
+        name: "メッセージ掲示板 サンプル",
+        templateId: "message",
+        config: JSON.stringify({
+          maxDisplayCount: 10,
+          fontSize: "text-xl",
+          backgroundColor: "#1e293b",
+          textColor: "#f8fafc",
+          accentColor: "#3b82f6",
+        }),
+        isActive: true,
+      })
+      .returning({ id: schema.boards.id })
+  )[0]?.id;
 
-  await db.insert(schema.boards).values({
-    id: messageBoardId,
-    name: "メッセージ掲示板 サンプル",
-    templateId: "message",
-    config: JSON.stringify({
-      maxDisplayCount: 10,
-      fontSize: "text-xl",
-      backgroundColor: "#1e293b",
-      textColor: "#f8fafc",
-      accentColor: "#3b82f6",
-    }),
-    isActive: true,
-  });
+  if (!messageBoardId) {
+    throw new Error("Failed to create the message sample board");
+  }
 
   const msgBoardMessages = [
     { content: "本日 14:00 より全体会議を行います", priority: 5 },
@@ -165,7 +218,6 @@ async function main() {
 
   for (const { content, priority } of msgBoardMessages) {
     await db.insert(schema.messages).values({
-      id: randomUUID(),
       boardId: messageBoardId,
       content,
       priority,

--- a/src/app/(dashboard)/boards/page.tsx
+++ b/src/app/(dashboard)/boards/page.tsx
@@ -3,9 +3,9 @@
 import Link from "next/link";
 import { db } from "@/db";
 import { boards } from "@/db/schema";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { Plus, ExternalLink } from "lucide-react";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -15,13 +15,21 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { templates } from "@/lib/templates";
+import { getSessionUser } from "@/lib/auth";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 export const dynamic = "force-dynamic";
 
 export default async function BoardsPage() {
+  const session = await getSessionUser();
+  if (!session) {
+    return null;
+  }
+
   const allBoards = await db
     .select()
     .from(boards)
+    .where(eq(boards.ownerUserId, resolveOwnerUserId(session.user)))
     .orderBy(desc(boards.createdAt));
 
   return (

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -3,7 +3,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { db } from "@/db";
-import { authSessions, settings } from "@/db/schema";
+import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import {
   AUTH_SESSION_COOKIE,
@@ -11,6 +11,8 @@ import {
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
 } from "@/lib/auth";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import { ThemeProvider } from "@/components/dashboard/ThemeProvider";
 import { DashboardShell } from "@/components/dashboard/DashboardShell";
 
@@ -45,11 +47,10 @@ export default async function DashboardLayout({
   }
 
   // Check full-auth validity
-  const expireSetting = await db.query.settings.findFirst({
-    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
-  });
-  const expireDays = expireSetting?.value
-    ? parseInt(expireSetting.value, 10)
+  const ownerUserId = resolveOwnerUserId(session.user);
+  const expireSetting = await getOwnerSetting(ownerUserId, AUTH_EXPIRE_DAYS_KEY);
+  const expireDays = expireSetting
+    ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
   const fullValid = isFullAuthValid(session.user.lastFullAuthAt, expireDays);

--- a/src/app/api/auth/credentials/setup/route.ts
+++ b/src/app/api/auth/credentials/setup/route.ts
@@ -2,26 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { users } from "@/db/schema";
-import { hashPassword, AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { users, authSessions } from "@/db/schema";
+import { hashPassword, AUTH_SESSION_COOKIE, LAST_USER_COOKIE } from "@/lib/auth";
 import { generateSessionToken } from "@/lib/pin";
+import { eq, or } from "drizzle-orm";
 
-/** POST /api/auth/credentials/setup — initial admin user registration */
-export async function POST(request: NextRequest) {
-  // Ensure no user exists yet
-  const existing = await db.select().from(users).limit(1);
-  if (existing.length > 0) {
-    return NextResponse.json(
-      { error: "管理者は既に登録されています" },
-      { status: 400 },
-    );
+const SETUP_SESSION_MAX_AGE = 60 * 15;
+
+function normalizePhoneNumber(input: string): string | null {
+  const digits = input.replace(/\D/g, "");
+
+  if (digits.length === 10) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
   }
 
+  if (digits.length === 11) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  }
+
+  return null;
+}
+
+/** POST /api/auth/credentials/setup — owner user registration */
+export async function POST(request: NextRequest) {
   const body = await request.json();
-  const { userId, email, password } = body as {
+  const { userId, email, password, phoneNumber } = body as {
     userId?: string;
     email?: string;
     password?: string;
+    phoneNumber?: string;
   };
 
   if (
@@ -42,6 +51,14 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
+  const normalizedPhoneNumber =
+    typeof phoneNumber === "string" ? normalizePhoneNumber(phoneNumber) : null;
+  if (!normalizedPhoneNumber) {
+    return NextResponse.json(
+      { error: "電話番号を正しく入力してください" },
+      { status: 400 },
+    );
+  }
   if (!password || password.length < 8) {
     return NextResponse.json(
       { error: "パスワードは8文字以上で入力してください" },
@@ -49,26 +66,53 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const passwordHash = await hashPassword(password);
+  const existingUser = await db.query.users.findFirst({
+    where: or(
+      eq(users.userId, userId),
+      eq(users.email, email),
+      eq(users.phoneNumber, normalizedPhoneNumber),
+    ),
+  });
+  if (existingUser) {
+    return NextResponse.json(
+      { error: "同じユーザーID・メールアドレス・電話番号では登録できません" },
+      { status: 409 },
+    );
+  }
 
-  await db.insert(users).values({
+  const passwordHash = await hashPassword(password);
+  const now = new Date().toISOString();
+  const sessionToken = generateSessionToken();
+  const expiresAt = new Date(Date.now() + SETUP_SESSION_MAX_AGE * 1000).toISOString();
+
+  const [createdUser] = await db.insert(users).values({
     userId,
     email,
+    phoneNumber: normalizedPhoneNumber,
     passwordHash,
+    attribute: "owner",
     role: "admin",
-    lastFullAuthAt: new Date().toISOString(),
+    lastFullAuthAt: now,
+  }).returning();
+
+  await db.insert(authSessions).values({
+    userId: createdUser.id,
+    sessionToken,
+    expiresAt,
   });
 
-  // Return a setup-complete token for the PIN setup step (short TTL client-side token)
-  const setupToken = generateSessionToken();
-
-  const res = NextResponse.json({ success: true, setupToken });
-  // Provide a temporary setup cookie so PIN setup route can verify continuity
-  res.cookies.set(AUTH_SESSION_COOKIE, setupToken, {
+  const res = NextResponse.json({ success: true });
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
-    maxAge: 60 * 15, // 15 minutes for setup
+    maxAge: SETUP_SESSION_MAX_AGE,
+  });
+  res.cookies.set(LAST_USER_COOKIE, createdUser.userId, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
   });
   return res;
 }

--- a/src/app/api/auth/pin/setup/route.ts
+++ b/src/app/api/auth/pin/setup/route.ts
@@ -2,23 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { users, authSessions, settings } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { users, authSessions } from "@/db/schema";
+import { and, eq, gt } from "drizzle-orm";
 import { hashPin, generateSessionToken } from "@/lib/pin";
 import {
   AUTH_SESSION_COOKIE,
+  LAST_USER_COOKIE,
   SESSION_MAX_AGE,
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
 } from "@/lib/auth";
 import { cookies } from "next/headers";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** POST /api/auth/pin/setup — set initial PIN for the admin user */
 export async function POST(request: NextRequest) {
-  // Verify that at least one user (admin) exists
-  const adminUser = await db.query.users.findFirst();
-  if (!adminUser) {
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+
+  if (!sessionToken) {
+    return NextResponse.json(
+      { error: "サインアップセッションが見つかりません" },
+      { status: 401 },
+    );
+  }
+
+  const session = await db.query.authSessions.findFirst({
+    where: and(
+      eq(authSessions.sessionToken, sessionToken),
+      gt(authSessions.expiresAt, new Date().toISOString()),
+    ),
+    with: { user: true },
+  });
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "サインアップセッションが無効です。再度登録してください" },
+      { status: 401 },
+    );
+  }
+
+  const targetUser = session.user;
+  if (!targetUser) {
     return NextResponse.json(
       { error: "管理者アカウントが未登録です。先にメールアドレスとパスワードを登録してください" },
       { status: 400 },
@@ -26,7 +53,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Check that PIN is not already set
-  if (adminUser.pinHash) {
+  if (targetUser.pinHash) {
     return NextResponse.json(
       { error: "PINは既に設定されています" },
       { status: 400 },
@@ -44,15 +71,14 @@ export async function POST(request: NextRequest) {
   }
 
   // Retrieve configured auth expire days
-  const expireSetting = await db.query.settings.findFirst({
-    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
-  });
-  const expireDays = expireSetting?.value
-    ? parseInt(expireSetting.value, 10)
+  const ownerUserId = resolveOwnerUserId(targetUser);
+  const expireSetting = await getOwnerSetting(ownerUserId, AUTH_EXPIRE_DAYS_KEY);
+  const expireDays = expireSetting
+    ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
   // Verify full-auth is still valid (set during credentials/setup)
-  if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {
+  if (!isFullAuthValid(targetUser.lastFullAuthAt, expireDays)) {
     return NextResponse.json(
       { error: "認証セッションが無効です。再度ログインしてください" },
       { status: 401 },
@@ -63,35 +89,33 @@ export async function POST(request: NextRequest) {
   await db
     .update(users)
     .set({ pinHash: hashPin(pin) })
-    .where(eq(users.id, adminUser.id));
+    .where(eq(users.id, targetUser.id));
 
   // Delete any previous setup cookie session
-  const cookieStore = await cookies();
-  const existingToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
-  if (existingToken) {
-    await db
-      .delete(authSessions)
-      .where(eq(authSessions.sessionToken, existingToken));
-  }
+  await db.delete(authSessions).where(eq(authSessions.sessionToken, sessionToken));
 
   // Create a proper auth session
-  const sessionToken = generateSessionToken();
-  const expiresAt = new Date(
-    Date.now() + SESSION_MAX_AGE * 1000,
-  ).toISOString();
+  const fullSessionToken = generateSessionToken();
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000).toISOString();
 
   await db.insert(authSessions).values({
-    userId: adminUser.id,
-    sessionToken,
+    userId: targetUser.id,
+    sessionToken: fullSessionToken,
     expiresAt,
   });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
+  res.cookies.set(AUTH_SESSION_COOKIE, fullSessionToken, {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
     maxAge: SESSION_MAX_AGE,
+  });
+  res.cookies.set(LAST_USER_COOKIE, targetUser.userId, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
   });
   return res;
 }

--- a/src/app/api/auth/pin/status/route.ts
+++ b/src/app/api/auth/pin/status/route.ts
@@ -3,7 +3,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { db } from "@/db";
-import { users, settings, authSessions } from "@/db/schema";
+import { users, authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import {
   DEFAULT_AUTH_EXPIRE_DAYS,
@@ -12,12 +12,14 @@ import {
   AUTH_SESSION_COOKIE,
   LAST_USER_COOKIE,
 } from "@/lib/auth";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** GET /api/auth/pin/status — check if admin user and PIN are configured */
 export async function GET() {
   const cookieStore = await cookies();
 
-  // Prefer the logged-in session user; fall back to last-user cookie; then first user
+  // Prefer the logged-in session user; fall back to the remembered user only.
   let targetUser: typeof users.$inferSelect | null | undefined = null;
 
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
@@ -41,15 +43,14 @@ export async function GET() {
     }
   }
 
-  if (!targetUser) {
-    targetUser = await db.query.users.findFirst();
-  }
+  const anyUser = targetUser ? targetUser : await db.query.users.findFirst();
 
-  const expireSetting = await db.query.settings.findFirst({
-    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
-  });
-  const expireDays = expireSetting?.value
-    ? parseInt(expireSetting.value, 10)
+  const ownerUserId = targetUser ? resolveOwnerUserId(targetUser) : null;
+  const expireSetting = ownerUserId
+    ? await getOwnerSetting(ownerUserId, AUTH_EXPIRE_DAYS_KEY)
+    : null;
+  const expireDays = expireSetting
+    ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
   const fullAuthExpiry = targetUser
@@ -57,7 +58,7 @@ export async function GET() {
     : null;
 
   return NextResponse.json({
-    userConfigured: !!targetUser,
+    userConfigured: !!anyUser,
     pinConfigured: !!targetUser?.pinHash,
     email: targetUser?.email ?? null,
     userId: targetUser?.userId ?? null,

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { users, authSessions, pinAttempts, settings } from "@/db/schema";
+import { users, authSessions, pinAttempts } from "@/db/schema";
 import { eq, and, gt, isNotNull } from "drizzle-orm";
 import {
   verifyPin,
@@ -18,6 +18,8 @@ import {
   isFullAuthValid,
   LAST_USER_COOKIE,
 } from "@/lib/auth";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** POST /api/auth/pin/verify — verify PIN and issue session */
 export async function POST(request: NextRequest) {
@@ -102,11 +104,12 @@ export async function POST(request: NextRequest) {
   }
 
   // Check full-auth validity
-  const expireSetting = await db.query.settings.findFirst({
-    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
-  });
-  const expireDays = expireSetting?.value
-    ? parseInt(expireSetting.value, 10)
+  const expireSetting = await getOwnerSetting(
+    resolveOwnerUserId(adminUser),
+    AUTH_EXPIRE_DAYS_KEY,
+  );
+  const expireDays = expireSetting
+    ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
   if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {

--- a/src/app/api/boards/[id]/messages/route.ts
+++ b/src/app/api/boards/[id]/messages/route.ts
@@ -2,20 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { boards, messages } from "@/db/schema";
+import { messages } from "@/db/schema";
 import { eq, and, or, isNull, gt } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
+import { findOwnedBoard, resolveOwnerUserId } from "@/lib/ownership";
 import { emitSSE } from "@/lib/sse";
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
   // Verify board exists
-  const board = await db.query.boards.findFirst({
-    where: eq(boards.id, id),
-  });
+  const board = await findOwnedBoard(id, resolveOwnerUserId(session.user));
   if (!board) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }
@@ -39,11 +44,14 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const board = await db.query.boards.findFirst({
-    where: eq(boards.id, id),
-  });
+  const board = await findOwnedBoard(id, resolveOwnerUserId(session.user));
   if (!board) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }

--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -4,8 +4,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { updateBoardSchema } from "@/lib/validators";
 import { emitSSE } from "@/lib/sse";
+import { findOwnedBoard, resolveOwnerUserId } from "@/lib/ownership";
 import { normalizeConfig, parseJsonObject } from "@/lib/utils";
 
 const LEGACY_IMAGE_DURATION_SECONDS = 5;
@@ -19,11 +21,14 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const board = await db.query.boards.findFirst({
-    where: eq(boards.id, id),
-  });
+  const board = await findOwnedBoard(id, resolveOwnerUserId(session.user));
   if (!board) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }
@@ -50,11 +55,14 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const existing = await db.query.boards.findFirst({
-    where: eq(boards.id, id),
-  });
+  const existing = await findOwnedBoard(id, resolveOwnerUserId(session.user));
   if (!existing) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }
@@ -147,11 +155,14 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const existing = await db.query.boards.findFirst({
-    where: eq(boards.id, id),
-  });
+  const existing = await findOwnedBoard(id, resolveOwnerUserId(session.user));
   if (!existing) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }

--- a/src/app/api/boards/route.ts
+++ b/src/app/api/boards/route.ts
@@ -3,16 +3,32 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { boards } from "@/db/schema";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { createBoardSchema } from "@/lib/validators";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import { templates } from "@/lib/templates";
 
 export async function GET() {
-  const allBoards = await db.select().from(boards).orderBy(desc(boards.createdAt));
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const allBoards = await db
+    .select()
+    .from(boards)
+    .where(eq(boards.ownerUserId, resolveOwnerUserId(session.user)))
+    .orderBy(desc(boards.createdAt));
   return NextResponse.json(allBoards);
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -37,6 +53,7 @@ export async function POST(request: NextRequest) {
   const [inserted] = await db
     .insert(boards)
     .values({
+      ownerUserId: resolveOwnerUserId(session.user),
       name,
       templateId,
       config: JSON.stringify(mergedConfig),

--- a/src/app/api/media/[id]/route.ts
+++ b/src/app/api/media/[id]/route.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { mediaItems } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { boards, mediaItems } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { emitSSE } from "@/lib/sse";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import {
   deleteStoredObject,
   storageKeyFromPublicPath,
@@ -15,11 +17,22 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const item = await db.query.mediaItems.findFirst({
-    where: eq(mediaItems.id, id),
-  });
+  const [item] = await db
+    .select({
+      id: mediaItems.id,
+      boardId: mediaItems.boardId,
+      filePath: mediaItems.filePath,
+    })
+    .from(mediaItems)
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(and(eq(mediaItems.id, id), eq(boards.ownerUserId, resolveOwnerUserId(session.user))));
   if (!item) {
     return NextResponse.json(
       { error: "Media item not found" },
@@ -51,11 +64,22 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const item = await db.query.mediaItems.findFirst({
-    where: eq(mediaItems.id, id),
-  });
+  const [item] = await db
+    .select({
+      id: mediaItems.id,
+      boardId: mediaItems.boardId,
+      duration: mediaItems.duration,
+    })
+    .from(mediaItems)
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(and(eq(mediaItems.id, id), eq(boards.ownerUserId, resolveOwnerUserId(session.user))));
   if (!item) {
     return NextResponse.json(
       { error: "Media item not found" },

--- a/src/app/api/media/files/route.ts
+++ b/src/app/api/media/files/route.ts
@@ -3,7 +3,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { mediaItems, boards } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { emitSSE } from "@/lib/sse";
 import {
   deleteStoredObject,
@@ -14,6 +15,7 @@ import {
   publicPathForStorageKey,
   thumbnailStorageKeyFromFilename,
 } from "@/lib/media-storage";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import path from "path";
 
 /**
@@ -22,6 +24,11 @@ import path from "path";
  * For each file, cross-reference the DB to find which boards reference it.
  */
 export async function GET() {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const storedObjects = await listStoredObjects();
   const files = storedObjects.filter((object) => isMediaStorageKey(object.key));
   const thumbnails = new Set(
@@ -39,7 +46,8 @@ export async function GET() {
       boardName: boards.name,
     })
     .from(mediaItems)
-    .leftJoin(boards, eq(mediaItems.boardId, boards.id));
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(eq(boards.ownerUserId, resolveOwnerUserId(session.user)));
 
   // Build a map: filename -> board references
   const fileToBoards = new Map<
@@ -53,7 +61,9 @@ export async function GET() {
     fileToBoards.set(basename, existing);
   }
 
-  const result = files.map((file) => {
+  const result = files
+    .filter((file) => fileToBoards.has(path.basename(file.key)))
+    .map((file) => {
     const filename = path.basename(file.key);
     const type = mediaTypeFromStorageKey(file.key) ?? "image";
     const thumbKey = thumbnailStorageKeyFromFilename(filename);
@@ -70,7 +80,7 @@ export async function GET() {
       modifiedAt: file.modifiedAt,
       boards: fileToBoards.get(filename) ?? [],
     };
-  });
+    });
 
   return NextResponse.json(result);
 }
@@ -81,6 +91,11 @@ export async function GET() {
  * Body: { filename: string }
  */
 export async function DELETE(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   let body: { filename?: string };
   try {
     body = await request.json();
@@ -98,6 +113,25 @@ export async function DELETE(request: NextRequest) {
 
   const sanitized = path.basename(filename);
 
+  const dbPath = publicPathForStorageKey(sanitized);
+  const refs = await db
+    .select({
+      id: mediaItems.id,
+      boardId: mediaItems.boardId,
+    })
+    .from(mediaItems)
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(
+      and(
+        eq(mediaItems.filePath, dbPath),
+        eq(boards.ownerUserId, resolveOwnerUserId(session.user)),
+      ),
+    );
+
+  if (refs.length === 0) {
+    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  }
+
   try {
     await deleteStoredObject(sanitized);
     await deleteStoredObject(thumbnailStorageKeyFromFilename(sanitized));
@@ -108,20 +142,15 @@ export async function DELETE(request: NextRequest) {
     );
   }
 
-  // Delete all DB records that reference this file and notify boards
-  const dbPath = publicPathForStorageKey(sanitized);
-  const refs = await db
-    .select()
-    .from(mediaItems)
-    .where(eq(mediaItems.filePath, dbPath));
-
   const boardIds = new Set<string>();
   for (const ref of refs) {
     boardIds.add(ref.boardId);
   }
 
   if (refs.length > 0) {
-    await db.delete(mediaItems).where(eq(mediaItems.filePath, dbPath));
+    await db
+      .delete(mediaItems)
+      .where(inArray(mediaItems.id, refs.map((ref) => ref.id)));
   }
 
   for (const boardId of boardIds) {

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { mediaItems, boards, settings } from "@/db/schema";
-import { eq, asc } from "drizzle-orm";
+import { mediaItems, boards } from "@/db/schema";
+import { and, eq, asc, inArray } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { updateMediaOrderSchema } from "@/lib/validators";
 import { emitSSE } from "@/lib/sse";
 import {
@@ -13,13 +14,14 @@ import {
 } from "@/lib/image";
 import {
   deleteStoredObject,
-  listStoredObjects,
   publicPathForStorageKey,
   storageKeyFromPublicPath,
   thumbnailStorageKeyFromFilename,
   thumbnailStorageKeyFromPublicPath,
   writeStoredObject,
 } from "@/lib/media-storage";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import { parseJsonObject } from "@/lib/utils";
 import path from "path";
 import { randomUUID } from "crypto";
@@ -40,6 +42,11 @@ function readSlideInterval(config: unknown): number | undefined {
 }
 
 export async function GET() {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const items = await db
     .select({
       id: mediaItems.id,
@@ -53,12 +60,18 @@ export async function GET() {
       boardName: boards.name,
     })
     .from(mediaItems)
-    .leftJoin(boards, eq(mediaItems.boardId, boards.id))
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(eq(boards.ownerUserId, resolveOwnerUserId(session.user)))
     .orderBy(asc(mediaItems.displayOrder));
   return NextResponse.json(items);
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   let formData: FormData;
   try {
     formData = await request.formData();
@@ -88,6 +101,9 @@ export async function POST(request: NextRequest) {
     where: eq(boards.id, boardId),
   });
   if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+  if (board.ownerUserId !== resolveOwnerUserId(session.user)) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }
 
@@ -123,11 +139,9 @@ export async function POST(request: NextRequest) {
 
   if (mediaType === "image") {
     // Read the max long edge setting
-    const maxSetting = await db.query.settings.findFirst({
-      where: eq(settings.key, "imageMaxLongEdge"),
-    });
+    const maxSetting = await getOwnerSetting(board.ownerUserId, "imageMaxLongEdge");
     const maxLongEdge = maxSetting
-      ? parseInt(maxSetting.value, 10)
+      ? parseInt(maxSetting, 10)
       : DEFAULT_IMAGE_MAX_LONG_EDGE;
 
     buffer = Buffer.from(await resizeImage(buffer, sanitizedExt, maxLongEdge));
@@ -180,6 +194,11 @@ export async function POST(request: NextRequest) {
 }
 
 export async function PATCH(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -197,9 +216,24 @@ export async function PATCH(request: NextRequest) {
 
   const updates = result.data;
   const updated: unknown[] = [];
+  const ownerUserId = resolveOwnerUserId(session.user);
 
   const boardIds = new Set<string>();
   for (const item of updates) {
+    const scopedItem = await db
+      .select({
+        id: mediaItems.id,
+        boardId: mediaItems.boardId,
+      })
+      .from(mediaItems)
+      .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+      .where(and(eq(mediaItems.id, item.id), eq(boards.ownerUserId, ownerUserId)))
+      .limit(1);
+
+    if (scopedItem.length === 0) {
+      return NextResponse.json({ error: "Media item not found" }, { status: 404 });
+    }
+
     const [row] = await db
       .update(mediaItems)
       .set({ displayOrder: item.displayOrder })
@@ -219,7 +253,21 @@ export async function PATCH(request: NextRequest) {
 }
 
 export async function DELETE() {
-  const items = await db.select().from(mediaItems);
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const ownerUserId = resolveOwnerUserId(session.user);
+  const items = await db
+    .select({
+      id: mediaItems.id,
+      boardId: mediaItems.boardId,
+      filePath: mediaItems.filePath,
+    })
+    .from(mediaItems)
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(eq(boards.ownerUserId, ownerUserId));
 
   const boardIds = new Set<string>();
   for (const item of items) {
@@ -236,15 +284,10 @@ export async function DELETE() {
     }
   }
 
-  await db.delete(mediaItems);
-
-  const remaining = await listStoredObjects();
-  for (const object of remaining) {
-    try {
-      await deleteStoredObject(object.key);
-    } catch {
-      // ignore orphan cleanup failures
-    }
+  if (items.length > 0) {
+    await db
+      .delete(mediaItems)
+      .where(inArray(mediaItems.id, items.map((item) => item.id)));
   }
 
   for (const boardId of boardIds) {

--- a/src/app/api/messages/[id]/route.ts
+++ b/src/app/api/messages/[id]/route.ts
@@ -2,15 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { messages } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { boards, messages } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { emitSSE } from "@/lib/sse";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import { updateMessageSchema } from "@/lib/validators";
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
   let body: unknown;
@@ -28,9 +35,15 @@ export async function PATCH(
     );
   }
 
-  const existing = await db.query.messages.findFirst({
-    where: eq(messages.id, id),
-  });
+  const [existing] = await db
+    .select({
+      id: messages.id,
+      boardId: messages.boardId,
+      ownerUserId: boards.ownerUserId,
+    })
+    .from(messages)
+    .innerJoin(boards, eq(messages.boardId, boards.id))
+    .where(and(eq(messages.id, id), eq(boards.ownerUserId, resolveOwnerUserId(session.user))));
   if (!existing) {
     return NextResponse.json({ error: "Message not found" }, { status: 404 });
   }
@@ -50,11 +63,22 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const { id } = await params;
 
-  const existing = await db.query.messages.findFirst({
-    where: eq(messages.id, id),
-  });
+  const [existing] = await db
+    .select({
+      id: messages.id,
+      boardId: messages.boardId,
+      ownerUserId: boards.ownerUserId,
+    })
+    .from(messages)
+    .innerJoin(boards, eq(messages.boardId, boards.id))
+    .where(and(eq(messages.id, id), eq(boards.ownerUserId, resolveOwnerUserId(session.user))));
   if (!existing) {
     return NextResponse.json({ error: "Message not found" }, { status: 404 });
   }

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -4,10 +4,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { boards, messages } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { createMessageSchema } from "@/lib/validators";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import { emitSSE } from "@/lib/sse";
 
 export async function POST(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -30,6 +37,9 @@ export async function POST(request: NextRequest) {
     where: eq(boards.id, boardId),
   });
   if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+  if (board.ownerUserId !== resolveOwnerUserId(session.user)) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
   }
 

--- a/src/app/api/public/boards/[id]/messages/route.ts
+++ b/src/app/api/public/boards/[id]/messages/route.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { boards, messages } from "@/db/schema";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, id),
+  });
+  if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  const now = new Date().toISOString();
+  const activeMessages = await db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.boardId, id),
+        or(isNull(messages.expiresAt), gt(messages.expiresAt, now)),
+      ),
+    );
+
+  return NextResponse.json(activeMessages);
+}

--- a/src/app/api/public/boards/[id]/route.ts
+++ b/src/app/api/public/boards/[id]/route.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { boards, mediaItems, messages } from "@/db/schema";
+import { asc, eq } from "drizzle-orm";
+import { normalizeConfig } from "@/lib/utils";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, id),
+  });
+  if (!board) {
+    return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  const media = await db
+    .select()
+    .from(mediaItems)
+    .where(eq(mediaItems.boardId, id))
+    .orderBy(asc(mediaItems.displayOrder));
+
+  const boardMessages = await db
+    .select()
+    .from(messages)
+    .where(eq(messages.boardId, id));
+
+  return NextResponse.json({
+    ...normalizeConfig(board),
+    mediaItems: media,
+    messages: boardMessages,
+  });
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,22 +1,29 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
-import { db } from "@/db";
-import { settings } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
+import { listOwnerSettings, upsertOwnerSettings } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** GET /api/settings — get all settings as key-value object */
 export async function GET() {
-  const rows = await db.select().from(settings);
-  const result: Record<string, string> = {};
-  for (const row of rows) {
-    result[row.key] = row.value;
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
   }
-  return NextResponse.json(result);
+
+  return NextResponse.json(
+    await listOwnerSettings(resolveOwnerUserId(session.user)),
+  );
 }
 
 /** PATCH /api/settings — upsert settings { key: value, ... } */
 export async function PATCH(request: Request) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
   const body = await request.json();
 
   if (!body || typeof body !== "object") {
@@ -24,24 +31,13 @@ export async function PATCH(request: Request) {
   }
 
   const entries = Object.entries(body as Record<string, string>);
+  const updates: Record<string, string> = {};
   for (const [key, value] of entries) {
     if (typeof key !== "string" || typeof value !== "string") continue;
-
-    const existing = await db
-      .select()
-      .from(settings)
-      .where(eq(settings.key, key))
-      .limit(1);
-
-    if (existing.length > 0) {
-      await db
-        .update(settings)
-        .set({ value })
-        .where(eq(settings.key, key));
-    } else {
-      await db.insert(settings).values({ key, value });
-    }
+    updates[key] = value;
   }
+
+  await upsertOwnerSettings(resolveOwnerUserId(session.user), updates);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq, ne, and } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
+import { isSameOwnerScope } from "@/lib/ownership";
 
 /** PATCH /api/users/[id] — update user role (admin only) */
 export async function PATCH(
@@ -33,6 +34,16 @@ export async function PATCH(
   const target = await db.query.users.findFirst({ where: eq(users.id, id) });
   if (!target) {
     return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+  if (!isSameOwnerScope(session.user, target)) {
+    return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+
+  if (target.attribute === "owner" && role !== "admin") {
+    return NextResponse.json(
+      { error: "OwnerユーザーはGeneralへ変更できません" },
+      { status: 400 },
+    );
   }
 
   // Prevent removing the last admin
@@ -71,6 +82,15 @@ export async function DELETE(
   const target = await db.query.users.findFirst({ where: eq(users.id, id) });
   if (!target) {
     return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+  if (!isSameOwnerScope(session.user, target)) {
+    return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+  }
+  if (target.attribute === "owner") {
+    return NextResponse.json(
+      { error: "Ownerユーザーは削除できません" },
+      { status: 400 },
+    );
   }
 
   // Prevent deleting the last admin

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
 import { hashPassword } from "@/lib/auth";
 import { randomUUID } from "crypto";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** GET /api/users — list all users (admin only) */
 export async function GET() {
@@ -23,13 +24,29 @@ export async function GET() {
       id: users.id,
       userId: users.userId,
       email: users.email,
+      attribute: users.attribute,
       role: users.role,
       createdAt: users.createdAt,
     })
     .from(users)
+    .where(eq(users.ownerUserId, resolveOwnerUserId(session.user)))
     .orderBy(users.createdAt);
 
-  return NextResponse.json(allUsers);
+  const ownerUserId = resolveOwnerUserId(session.user);
+  const ownerUser = await db.query.users.findFirst({ where: eq(users.id, ownerUserId) });
+  const scopedUsers = ownerUser ? [
+    {
+      id: ownerUser.id,
+      userId: ownerUser.userId,
+      email: ownerUser.email,
+      attribute: ownerUser.attribute,
+      role: ownerUser.role,
+      createdAt: ownerUser.createdAt,
+    },
+    ...allUsers.filter((user) => user.id !== ownerUser.id),
+  ] : allUsers;
+
+  return NextResponse.json(scopedUsers);
 }
 
 /** POST /api/users — create a new user (admin only) */
@@ -68,7 +85,7 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-  const normalizedRole = role === "general" ? "general" : "admin";
+  const normalizedRole = role === "admin" ? "admin" : "general";
 
   // Check uniqueness
   const existing = await db.query.users.findFirst({
@@ -98,8 +115,16 @@ export async function POST(request: NextRequest) {
     userId,
     email,
     passwordHash,
+    attribute: "shared",
+    ownerUserId: resolveOwnerUserId(session.user),
     role: normalizedRole,
   });
 
-  return NextResponse.json({ id, userId, email, role: normalizedRole }, { status: 201 });
+  return NextResponse.json({
+    id,
+    userId,
+    email,
+    attribute: "shared",
+    role: normalizedRole,
+  }, { status: 201 });
 }

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,10 +1,13 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { settings } from "@/db/schema";
+import { boards } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { DEFAULT_CITY_ID } from "@/lib/weather-areas";
+import { getSessionUser } from "@/lib/auth";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 
 const WEATHER_API_BASE = "https://weather.tsukumijima.net/api/forecast/city";
 
@@ -17,14 +20,32 @@ let weatherCache: { cityId: string; data: unknown; fetchedAt: number } | null =
 const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 /** GET /api/weather — fetch today's weather for the configured city */
-export async function GET() {
-  // Get configured city from settings
-  const row = await db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, "weatherCityId"))
-    .limit(1);
-  const cityId = row[0]?.value ?? DEFAULT_CITY_ID;
+export async function GET(request: NextRequest) {
+  const boardId = request.nextUrl.searchParams.get("boardId");
+
+  let ownerUserId: string | null = null;
+
+  if (boardId) {
+    const board = await db.query.boards.findFirst({
+      where: eq(boards.id, boardId),
+    });
+    if (!board) {
+      return NextResponse.json({ error: "Board not found" }, { status: 404 });
+    }
+    ownerUserId = board.ownerUserId;
+  } else {
+    const session = await getSessionUser();
+    if (session) {
+      ownerUserId = resolveOwnerUserId(session.user);
+    } else {
+      const firstUser = await db.query.users.findFirst();
+      ownerUserId = firstUser ? resolveOwnerUserId(firstUser) : null;
+    }
+  }
+
+  const cityId = ownerUserId
+    ? (await getOwnerSetting(ownerUserId, "weatherCityId")) ?? DEFAULT_CITY_ID
+    : DEFAULT_CITY_ID;
 
   if (!CITY_ID_RE.test(cityId)) {
     return NextResponse.json(

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -64,7 +64,7 @@ export default function LoginClient() {
         <div className="rounded-2xl border bg-white p-8 shadow-sm">
           <div className="mb-6 flex flex-col items-center gap-2">
             <KeyRound className="size-8 text-gray-400" />
-            <h2 className="text-lg font-bold text-gray-900">管理者ログイン</h2>
+            <h2 className="text-lg font-bold text-gray-900">アカウントログイン</h2>
             <p className="text-center text-sm text-gray-500">
               メールアドレスまたはユーザーIDとパスワードを入力してください
             </p>

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -3,7 +3,7 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { db } from "@/db";
-import { users, authSessions } from "@/db/schema";
+import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import { AUTH_SESSION_COOKIE } from "@/lib/auth";
 import LoginClient from "./LoginClient";
@@ -16,8 +16,8 @@ export default async function LoginPage() {
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
   if (!adminUser) {
-    console.log("[/pin/login] No users → /pin/setup");
-    redirect("/pin/setup");
+    console.log("[/pin/login] No users → /signup");
+    redirect("/signup");
   }
 
   // If already authenticated, redirect to dashboard

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -3,7 +3,7 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { db } from "@/db";
-import { users, authSessions, settings } from "@/db/schema";
+import { users, authSessions } from "@/db/schema";
 import { eq, and, gt, isNotNull } from "drizzle-orm";
 import {
   AUTH_SESSION_COOKIE,
@@ -12,6 +12,8 @@ import {
   isFullAuthValid,
   LAST_USER_COOKIE,
 } from "@/lib/auth";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import PinLoginClient from "./PinLoginClient";
 
 export const dynamic = "force-dynamic";
@@ -57,30 +59,21 @@ export default async function PinLoginPage() {
       redirect("/pin/login");
     }
   } else {
-    // No cookie or cookie user not found — find first user with a PIN
-    targetUser = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
-    console.log("[/pin] Fallback user with PIN", {
-      found: !!targetUser,
-      userId: targetUser?.userId ?? null,
-    });
-    if (!targetUser) {
-      // No user has a PIN at all
-      const anyUser = await db.query.users.findFirst();
-      if (!anyUser) {
-        console.log("[/pin] No users at all → /pin/setup");
-        redirect("/pin/setup");
-      }
-      console.log("[/pin] No user has PIN → /pin/login");
-      redirect("/pin/login");
+    // Without a remembered user, require credential login so we don't pick an arbitrary owner.
+    const anyUser = await db.query.users.findFirst();
+    if (!anyUser) {
+      console.log("[/pin] No users at all → /signup");
+      redirect("/signup");
     }
+    console.log("[/pin] No remembered user → /pin/login");
+    redirect("/pin/login");
   }
 
   // ── 3. Check full auth validity ────────────────────────────────────
-  const expireSetting = await db.query.settings.findFirst({
-    where: eq(settings.key, AUTH_EXPIRE_DAYS_KEY),
-  });
-  const expireDays = expireSetting?.value
-    ? parseInt(expireSetting.value, 10)
+  const ownerUserId = resolveOwnerUserId(targetUser);
+  const expireSetting = await getOwnerSetting(ownerUserId, AUTH_EXPIRE_DAYS_KEY);
+  const expireDays = expireSetting
+    ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
   const fullAuthValid = isFullAuthValid(targetUser.lastFullAuthAt, expireDays);

--- a/src/app/pin/setup/PinSetupClient.tsx
+++ b/src/app/pin/setup/PinSetupClient.tsx
@@ -17,6 +17,7 @@ export default function PinSetupClient() {
   // Credentials step
   const [userId, setUserId] = useState("");
   const [email, setEmail] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
@@ -43,7 +44,12 @@ export default function PinSetupClient() {
       const res = await fetch("/api/auth/credentials/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: userId.trim(), email: email.trim(), password }),
+        body: JSON.stringify({
+          userId: userId.trim(),
+          email: email.trim(),
+          phoneNumber: phoneNumber.trim(),
+          password,
+        }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -112,7 +118,7 @@ export default function PinSetupClient() {
         <div className="rounded-2xl border bg-white p-8 shadow-sm">
           <div className="mb-6 flex flex-col items-center gap-2">
             <ShieldCheck className="size-8 text-blue-600" />
-            <h2 className="text-lg font-bold text-gray-900">管理者アカウントの登録</h2>
+            <h2 className="text-lg font-bold text-gray-900">Ownerアカウントの登録</h2>
             <p className="text-center text-sm text-gray-500">{stepLabels[step]}</p>
           </div>
 
@@ -152,6 +158,23 @@ export default function PinSetupClient() {
                   required
                   className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
                 />
+              </div>
+              <div>
+                <label htmlFor="phoneNumber" className="mb-1.5 block text-sm font-medium text-gray-700">
+                  電話番号
+                </label>
+                <input
+                  id="phoneNumber"
+                  type="tel"
+                  value={phoneNumber}
+                  onChange={(e) => setPhoneNumber(e.target.value)}
+                  placeholder="090-1234-5678"
+                  required
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+                <p className="mt-1 text-xs text-gray-400">
+                  Owner登録では電話番号が必須です。同じ電話番号では複数登録できません。
+                </p>
               </div>
               <div>
                 <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-700">

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,9 +1,9 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import { redirect } from "next/navigation";
+import PinSetupClient from "@/app/pin/setup/PinSetupClient";
 
 export const dynamic = "force-dynamic";
 
-export default async function PinSetupPage() {
-  redirect("/signup");
+export default function SignupPage() {
+  return <PinSetupClient />;
 }

--- a/src/components/board/LiveBoard.tsx
+++ b/src/components/board/LiveBoard.tsx
@@ -70,13 +70,14 @@ export default function LiveBoard({
   // --- SSE live updates ---
   const refetchData = useCallback(async () => {
     try {
-      const res = await fetch(`/api/boards/${initialBoard.id}`);
+      const res = await fetch(`/api/public/boards/${initialBoard.id}`);
       if (!res.ok) return;
       const data = await res.json();
 
       setBoard({
         id: data.id,
         name: data.name,
+        ownerUserId: data.ownerUserId,
         templateId: data.templateId,
         config: parseJsonObject(data.config),
         isActive: data.isActive,
@@ -91,7 +92,7 @@ export default function LiveBoard({
   }, [initialBoard.id]);
 
   const handleSSEEvent = useCallback(
-    (_event: string, _data: Record<string, unknown>) => {
+    () => {
       // On any event, refetch the full board data
       refetchData();
     },

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -22,6 +22,7 @@ interface WeatherData {
 }
 
 interface WeatherDisplayProps {
+  boardId?: string;
   color?: string;
   bgOpacity?: number;
   /** Custom font family */
@@ -29,6 +30,7 @@ interface WeatherDisplayProps {
 }
 
 export function WeatherDisplay({
+  boardId,
   color = "#ffffff",
   bgOpacity = 0.5,
   fontFamily,
@@ -37,14 +39,17 @@ export function WeatherDisplay({
 
   const fetchWeather = useCallback(async () => {
     try {
-      const res = await fetch("/api/weather");
+      const search = boardId
+        ? `?boardId=${encodeURIComponent(boardId)}`
+        : "";
+      const res = await fetch(`/api/weather${search}`);
       if (!res.ok) return;
       const data = await res.json();
       setWeather(data);
     } catch {
       // silently ignore
     }
-  }, []);
+  }, [boardId]);
 
   useEffect(() => {
     fetchWeather();

--- a/src/components/board/templates/MessageBoard.tsx
+++ b/src/components/board/templates/MessageBoard.tsx
@@ -83,7 +83,7 @@ export default function MessageBoard({
   // Poll for updated messages from the server
   const fetchMessages = useCallback(async () => {
     try {
-      const res = await fetch(`/api/boards/${board.id}/messages`);
+      const res = await fetch(`/api/public/boards/${board.id}/messages`);
       if (!res.ok) return;
       const data: Message[] = await res.json();
       const sorted = data
@@ -120,8 +120,6 @@ export default function MessageBoard({
     const interval = setInterval(fetchMessages, 3000);
     return () => clearInterval(interval);
   }, [fetchMessages]);
-
-  const now = new Date();
 
   return (
     <div
@@ -225,7 +223,12 @@ export default function MessageBoard({
           className="border-t px-6 py-2"
           style={{ borderColor: config.accentColor + "40" }}
         >
-          <WeatherDisplay color={config.textColor} bgOpacity={0} fontFamily={config.fontFamily || undefined} />
+          <WeatherDisplay
+            boardId={board.id}
+            color={config.textColor}
+            bgOpacity={0}
+            fontFamily={config.fontFamily || undefined}
+          />
         </div>
       )}
 

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -90,6 +90,7 @@ export default function PhotoClockBoard({
         />
         {config.showWeather && (
           <WeatherDisplay
+            boardId={board.id}
             color={config.clockColor}
             bgOpacity={config.clockBgOpacity}
             fontFamily={config.fontFamily || undefined}

--- a/src/components/board/templates/RetroBoard.tsx
+++ b/src/components/board/templates/RetroBoard.tsx
@@ -175,7 +175,12 @@ export default function RetroBoard({
         >
           <div className="flex-1">
             {config.showWeather && (
-              <WeatherDisplay color={color} bgOpacity={0} fontFamily={config.fontFamily || undefined} />
+              <WeatherDisplay
+                boardId={board.id}
+                color={color}
+                bgOpacity={0}
+                fontFamily={config.fontFamily || undefined}
+              />
             )}
           </div>
           {config.showClock && (

--- a/src/components/board/templates/SimpleBoard.tsx
+++ b/src/components/board/templates/SimpleBoard.tsx
@@ -96,7 +96,12 @@ export default function SimpleBoard({
               />
             )}
             {config.showWeather && (
-              <WeatherDisplay color="#ffffff" bgOpacity={0.5} fontFamily={config.tickerFontFamily || undefined} />
+              <WeatherDisplay
+                boardId={board.id}
+                color="#ffffff"
+                bgOpacity={0.5}
+                fontFamily={config.tickerFontFamily || undefined}
+              />
             )}
           </div>
         )}

--- a/src/components/dashboard/UserManagement.tsx
+++ b/src/components/dashboard/UserManagement.tsx
@@ -26,6 +26,7 @@ interface UserRow {
   id: string;
   userId: string;
   email: string;
+  attribute: "owner" | "shared";
   role: string;
   createdAt: string;
 }
@@ -136,6 +137,7 @@ export function UserManagement() {
               <tr className="border-b bg-muted/40 text-xs text-muted-foreground">
                 <th className="px-4 py-2 text-left">ユーザーID</th>
                 <th className="px-4 py-2 text-left">メールアドレス</th>
+                <th className="px-4 py-2 text-left">属性</th>
                 <th className="px-4 py-2 text-left">ロール</th>
                 <th className="px-4 py-2 text-right">操作</th>
               </tr>
@@ -146,8 +148,14 @@ export function UserManagement() {
                   <td className="px-4 py-3 font-medium">{user.userId}</td>
                   <td className="px-4 py-3 text-muted-foreground">{user.email}</td>
                   <td className="px-4 py-3">
+                    <Badge variant={user.attribute === "owner" ? "default" : "secondary"}>
+                      {user.attribute === "owner" ? "Owner" : "Shared"}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3">
                     <Select
                       value={user.role}
+                      disabled={user.attribute === "owner"}
                       onValueChange={(v) => handleRoleChange(user.id, v ?? "")}
                     >
                       <SelectTrigger className="h-7 w-28 text-xs">
@@ -160,14 +168,18 @@ export function UserManagement() {
                     </Select>
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <button
-                      onClick={() => handleDelete(user.id, user.userId)}
-                      className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-red-500 transition-colors hover:bg-red-50 hover:text-red-700"
-                      title="削除"
-                    >
-                      <Trash2 className="size-3.5" />
-                      削除
-                    </button>
+                    {user.attribute === "owner" ? (
+                      <span className="text-xs text-muted-foreground">削除不可</span>
+                    ) : (
+                      <button
+                        onClick={() => handleDelete(user.id, user.userId)}
+                        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-red-500 transition-colors hover:bg-red-50 hover:text-red-700"
+                        title="削除"
+                      >
+                        <Trash2 className="size-3.5" />
+                        削除
+                      </button>
+                    )}
                   </td>
                 </tr>
               ))}
@@ -183,6 +195,9 @@ export function UserManagement() {
             <DialogTitle>新しいユーザーを追加</DialogTitle>
           </DialogHeader>
           <form onSubmit={handleCreate} className="space-y-4 pt-2">
+            <p className="text-sm text-muted-foreground">
+              ここで追加されるユーザーは、現在のOwnerに紐づく Shared ユーザーとして作成されます。
+            </p>
             <div className="space-y-1.5">
               <Label htmlFor="cu-userId">ユーザーID</Label>
               <Input

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import { pgTable, text, integer, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, boolean, primaryKey, AnyPgColumn } from "drizzle-orm/pg-core";
 import { sql, relations } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
@@ -10,6 +10,9 @@ export const boards = pgTable("boards", {
   id: text("id")
     .primaryKey()
     .$defaultFn(() => randomUUID()),
+  ownerUserId: text("owner_user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
   templateId: text("template_id").notNull(), // "simple" | "photo-clock" | "retro" | "message" | "call-number"
   config: text("config").notNull().default("{}"),
@@ -62,14 +65,23 @@ export const messages = pgTable("messages", {
     .$onUpdate(() => new Date().toISOString()),
 });
 
-export const settings = pgTable("settings", {
-  key: text("key").primaryKey(),
-  value: text("value").notNull(),
-  updatedAt: text("updated_at")
-    .notNull()
-    .default(isoNow)
-    .$onUpdate(() => new Date().toISOString()),
-});
+export const settings = pgTable(
+  "settings",
+  {
+    ownerUserId: text("owner_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(isoNow)
+      .$onUpdate(() => new Date().toISOString()),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.ownerUserId, table.key] }),
+  }),
+);
 
 export const pinResetTokens = pgTable("pin_reset_tokens", {
   id: text("id")
@@ -104,10 +116,19 @@ export const users = pgTable("users", {
   /** Human-readable login ID (e.g. "admin") */
   userId: text("user_id").notNull().unique(),
   email: text("email").notNull().unique(),
+  /** Phone number for owner sign-up uniqueness checks */
+  phoneNumber: text("phone_number").unique(),
   passwordHash: text("password_hash").notNull(),
   /** 6-digit PIN hash (nullable until PIN is configured) */
   pinHash: text("pin_hash"),
-  role: text("role").notNull().default("admin"),
+  /** Owner of an isolated workspace, or a shared member under an owner */
+  attribute: text("attribute").notNull().default("shared"),
+  /** Shared users point at their owner user; owner users keep this null */
+  ownerUserId: text("owner_user_id").references(
+    (): AnyPgColumn => users.id,
+    { onDelete: "set null" },
+  ),
+  role: text("role").notNull().default("general"),
   /** Dashboard color theme preference: "system" | "light" | "dark" */
   colorTheme: text("color_theme").notNull().default("system"),
   /** Timestamp of the last successful email+password login */

--- a/src/lib/owner-settings.ts
+++ b/src/lib/owner-settings.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { settings } from "@/db/schema";
+
+export async function getOwnerSetting(
+  ownerUserId: string,
+  key: string,
+): Promise<string | null> {
+  const row = await db.query.settings.findFirst({
+    where: and(
+      eq(settings.ownerUserId, ownerUserId),
+      eq(settings.key, key),
+    ),
+  });
+  return row?.value ?? null;
+}
+
+export async function listOwnerSettings(
+  ownerUserId: string,
+): Promise<Record<string, string>> {
+  const rows = await db
+    .select()
+    .from(settings)
+    .where(eq(settings.ownerUserId, ownerUserId));
+
+  const result: Record<string, string> = {};
+  for (const row of rows) {
+    result[row.key] = row.value;
+  }
+  return result;
+}
+
+export async function upsertOwnerSettings(
+  ownerUserId: string,
+  entries: Record<string, string>,
+): Promise<void> {
+  for (const [key, value] of Object.entries(entries)) {
+    const existing = await db
+      .select()
+      .from(settings)
+      .where(
+        and(
+          eq(settings.ownerUserId, ownerUserId),
+          eq(settings.key, key),
+        ),
+      )
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .update(settings)
+        .set({ value })
+        .where(
+          and(
+            eq(settings.ownerUserId, ownerUserId),
+            eq(settings.key, key),
+          ),
+        );
+    } else {
+      await db.insert(settings).values({ ownerUserId, key, value });
+    }
+  }
+}

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -1,0 +1,32 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import type { users } from "@/db/schema";
+import { boards } from "@/db/schema";
+
+type UserLike = Pick<typeof users.$inferSelect, "id" | "attribute" | "ownerUserId">;
+
+export function resolveOwnerUserId(user: UserLike): string {
+  if (user.attribute === "owner" || !user.ownerUserId) {
+    return user.id;
+  }
+  return user.ownerUserId;
+}
+
+export function isOwnerUser(user: UserLike): boolean {
+  return user.attribute === "owner" && user.ownerUserId === null;
+}
+
+export function isSameOwnerScope(left: UserLike, right: UserLike): boolean {
+  return resolveOwnerUserId(left) === resolveOwnerUserId(right);
+}
+
+export async function findOwnedBoard(boardId: string, ownerUserId: string) {
+  return db.query.boards.findFirst({
+    where: and(
+      eq(boards.id, boardId),
+      eq(boards.ownerUserId, ownerUserId),
+    ),
+  });
+}


### PR DESCRIPTION
## 概要
- issue #100 に対応し、Owner / Shared ユーザーによる所有スコープを導入しました
- ボード・設定・メディア・メッセージを owner 単位で分離しました
- 公開表示面は public read endpoint を追加し、従来どおり匿名表示を維持しています

## 主な変更
- `users` / `boards` / `settings` に owner スコープ用カラムを追加し、既存データを backfill する migration を追加
- `/signup` を追加し、電話番号必須の Owner 登録フローに変更
- 認証 / PIN / 設定 / 天気 / 内部 API を owner スコープで解決するよう変更
- `/api/public/boards/...` を追加し、表示画面の live refresh を内部 API から分離
- ユーザー管理を owner 配下の shared ユーザー管理に変更
- `scripts/seed.ts` を新スキーマに対応

## 確認
- `pnpm build`
- `pnpm db:generate`
- 旧スキーマ相当の一時 PostgreSQL DB に対して `drizzle/0001_marvelous_jackpot.sql` を適用し、owner/shared backfill を確認

## 補足
- `pnpm lint` は既存の React compiler / Next lint 指摘が残っているため未解消です
- 今回差分で発生した未使用 import / unused 変数は除去済みです

Closes #100