### PR TITLE
feat: ボードの公開設定と表示認証を追加

### DIFF
--- a/drizzle/0003_mature_rattler.sql
+++ b/drizzle/0003_mature_rattler.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "boards" ADD COLUMN "visibility" text DEFAULT 'private' NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,695 @@
+{
+  "id": "1daf99c7-0a35-4cb1-94c8-1f645ffafffa",
+  "prevId": "18f9376d-9e89-4e85-86e7-30e4391b7560",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_unique": {
+          "name": "auth_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_owner_user_id_users_id_fk": {
+          "name": "boards_owner_user_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_attempts": {
+      "name": "pin_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_reset_tokens": {
+      "name": "pin_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pin_reset_tokens_user_id_users_id_fk": {
+          "name": "pin_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "pin_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pin_reset_tokens_token_unique": {
+          "name": "pin_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_owner_user_id_users_id_fk": {
+          "name": "settings_owner_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_owner_user_id_key_pk": {
+          "name": "settings_owner_user_id_key_pk",
+          "columns": [
+            "owner_user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_requests": {
+      "name": "signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_requests_token_unique": {
+          "name": "signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_owner_user_id_users_id_fk": {
+          "name": "users_owner_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777207117508,
       "tag": "0002_narrow_the_renegades",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777211409250,
+      "tag": "0003_mature_rattler",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(board)/[boardId]/page.tsx
+++ b/src/app/(board)/[boardId]/page.tsx
@@ -26,8 +26,18 @@ export default async function BoardPage({
     notFound();
   }
 
+  console.log("[board/page] Access", {
+    boardId,
+    visibility: board.visibility,
+    isActive: board.isActive,
+  });
+
   if (board.visibility === "private") {
     const session = await getSessionUser();
+    console.log("[board/page] Private board auth", {
+      boardId,
+      hasSession: !!session,
+    });
     if (!session) {
       redirect(`/pin?redirectTo=${encodeURIComponent(`/${boardId}`)}`);
     }

--- a/src/app/(board)/[boardId]/page.tsx
+++ b/src/app/(board)/[boardId]/page.tsx
@@ -1,9 +1,10 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { eq, asc, and, or, isNull, gt } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { getTemplate } from "@/lib/templates";
 import { normalizeConfig } from "@/lib/utils";
 import LiveBoard from "@/components/board/LiveBoard";
@@ -23,6 +24,13 @@ export default async function BoardPage({
 
   if (!board || !board.isActive) {
     notFound();
+  }
+
+  if (board.visibility === "private") {
+    const session = await getSessionUser();
+    if (!session) {
+      redirect(`/pin?redirectTo=${encodeURIComponent(`/${boardId}`)}`);
+    }
   }
 
   const normalizedBoard = normalizeConfig(board);

--- a/src/app/(dashboard)/boards/new/page.tsx
+++ b/src/app/(dashboard)/boards/new/page.tsx
@@ -5,7 +5,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Globe, Lock } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
@@ -16,6 +16,8 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
 import { templates } from "@/lib/templates";
 import type { TemplateId } from "@/types";
 
@@ -25,6 +27,7 @@ export default function NewBoardPage() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [templateId, setTemplateId] = useState<TemplateId>("simple");
+  const [visibility, setVisibility] = useState<"public" | "private">("private");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -36,7 +39,7 @@ export default function NewBoardPage() {
     const res = await fetch("/api/boards", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, templateId }),
+      body: JSON.stringify({ name, templateId, visibility }),
     });
 
     if (!res.ok) {
@@ -105,6 +108,46 @@ export default function NewBoardPage() {
                     </div>
                   </button>
                 ))}
+              </div>
+            </div>
+
+            <div className="space-y-3 rounded-lg border p-4">
+              <div className="space-y-1">
+                <Label htmlFor="board-visibility">公開設定</Label>
+                <p className="text-xs text-muted-foreground">
+                  Private が初期設定です。Private はログイン済みユーザーのみ表示URLを開けます。
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <div
+                  className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm ${
+                    visibility === "private"
+                      ? "bg-primary/10 text-primary"
+                      : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  <Lock className="size-3.5" />
+                  Private
+                </div>
+                <Switch
+                  id="board-visibility"
+                  checked={visibility === "public"}
+                  onCheckedChange={(checked) => setVisibility(checked ? "public" : "private")}
+                />
+                <div
+                  className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm ${
+                    visibility === "public"
+                      ? "bg-primary/10 text-primary"
+                      : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  <Globe className="size-3.5" />
+                  Public
+                </div>
+                <Badge variant={visibility === "public" ? "default" : "secondary"}>
+                  {visibility === "public" ? "公開中" : "認証必須"}
+                </Badge>
               </div>
             </div>
 

--- a/src/app/(dashboard)/boards/page.tsx
+++ b/src/app/(dashboard)/boards/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { db } from "@/db";
 import { boards } from "@/db/schema";
 import { desc, eq } from "drizzle-orm";
-import { Plus, ExternalLink } from "lucide-react";
+import { Plus, ExternalLink, Globe, Lock, Settings2 } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import {
   Card,
@@ -38,7 +38,7 @@ export default async function BoardsPage() {
         <div className="min-w-0">
           <h1 className="text-xl font-bold sm:text-2xl">ボード管理</h1>
           <p className="text-xs text-muted-foreground sm:text-sm">
-            ボードの作成・編集・削除を行います
+            ボードの作成・編集・削除を行います。表示確認や共有は各カードの「表示」を使用してください。
           </p>
         </div>
         <Link
@@ -70,29 +70,65 @@ export default async function BoardsPage() {
           {allBoards.map((board) => {
             const template = templates[board.templateId as keyof typeof templates];
             return (
-              <Link key={board.id} href={`/boards/${board.id}`}>
-                <Card className="transition-shadow hover:shadow-md">
-                  <CardHeader className="pb-3">
-                    <div className="flex items-start justify-between">
-                      <CardTitle className="text-base">{board.name}</CardTitle>
+              <Card key={board.id} className="transition-shadow hover:shadow-md">
+                <CardHeader className="pb-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <CardTitle className="text-base">{board.name}</CardTitle>
+                    <div className="flex flex-wrap items-center justify-end gap-2">
                       <Badge variant={board.isActive ? "default" : "secondary"}>
                         {board.isActive ? "有効" : "無効"}
                       </Badge>
+                      <Badge variant={board.visibility === "public" ? "default" : "secondary"}>
+                        {board.visibility === "public" ? (
+                          <>
+                            <Globe data-icon="inline-start" />
+                            Public
+                          </>
+                        ) : (
+                          <>
+                            <Lock data-icon="inline-start" />
+                            Private
+                          </>
+                        )}
+                      </Badge>
                     </div>
-                    <CardDescription>
-                      {template?.name ?? board.templateId}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex items-center justify-between text-xs text-muted-foreground">
-                      <span>
-                        作成: {new Date(board.createdAt).toLocaleDateString("ja-JP")}
-                      </span>
-                      <ExternalLink className="size-3.5" />
+                  </div>
+                  <CardDescription>
+                    {template?.name ?? board.templateId}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-1 text-xs text-muted-foreground">
+                    <div>
+                      作成: {new Date(board.createdAt).toLocaleDateString("ja-JP")}
                     </div>
-                  </CardContent>
-                </Card>
-              </Link>
+                    <div>
+                      {board.visibility === "public"
+                        ? "表示URLは非認証でも開けます"
+                        : "表示URLはログイン済みユーザーのみ開けます"}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Link
+                      href={`/boards/${board.id}`}
+                      className={buttonVariants({ variant: "outline", size: "sm" })}
+                    >
+                      <Settings2 data-icon="inline-start" />
+                      管理
+                    </Link>
+                    <a
+                      href={`/${board.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={buttonVariants({ size: "sm" })}
+                    >
+                      <ExternalLink data-icon="inline-start" />
+                      表示
+                    </a>
+                  </div>
+                </CardContent>
+              </Card>
             );
           })}
         </div>

--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -87,6 +87,7 @@ export async function PATCH(
   const updates: Record<string, unknown> = {};
   if (result.data.name !== undefined) updates.name = result.data.name;
   if (result.data.templateId !== undefined) updates.templateId = result.data.templateId;
+  if (result.data.visibility !== undefined) updates.visibility = result.data.visibility;
   if (result.data.config !== undefined) updates.config = result.data.config;
   if (result.data.isActive !== undefined) updates.isActive = result.data.isActive;
 

--- a/src/app/api/boards/route.ts
+++ b/src/app/api/boards/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { name, templateId, config } = result.data;
+  const { name, templateId, visibility, config } = result.data;
 
   // Apply default config from template if no config provided
   const template = templates[templateId as keyof typeof templates];
@@ -55,6 +55,7 @@ export async function POST(request: NextRequest) {
     .values({
       ownerUserId: resolveOwnerUserId(session.user),
       name,
+      visibility,
       templateId,
       config: JSON.stringify(mergedConfig),
     })

--- a/src/app/api/public/boards/[id]/messages/route.ts
+++ b/src/app/api/public/boards/[id]/messages/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { boards, messages } from "@/db/schema";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 
 export async function GET(
   _request: NextRequest,
@@ -14,8 +15,15 @@ export async function GET(
   const board = await db.query.boards.findFirst({
     where: eq(boards.id, id),
   });
-  if (!board) {
+  if (!board || !board.isActive) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  if (board.visibility === "private") {
+    const session = await getSessionUser();
+    if (!session) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
   }
 
   const now = new Date().toISOString();

--- a/src/app/api/public/boards/[id]/route.ts
+++ b/src/app/api/public/boards/[id]/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { asc, eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { normalizeConfig } from "@/lib/utils";
 
 export async function GET(
@@ -15,8 +16,15 @@ export async function GET(
   const board = await db.query.boards.findFirst({
     where: eq(boards.id, id),
   });
-  if (!board) {
+  if (!board || !board.isActive) {
     return NextResponse.json({ error: "Board not found" }, { status: 404 });
+  }
+
+  if (board.visibility === "private") {
+    const session = await getSessionUser();
+    if (!session) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
   }
 
   const media = await db

--- a/src/app/api/sse/[boardId]/route.ts
+++ b/src/app/api/sse/[boardId]/route.ts
@@ -1,6 +1,10 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest } from "next/server";
+import { db } from "@/db";
+import { boards } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getSessionUser } from "@/lib/auth";
 import { addClient, removeClient } from "@/lib/sse";
 
 export const dynamic = "force-dynamic";
@@ -8,10 +12,25 @@ export const dynamic = "force-dynamic";
 const HEARTBEAT_INTERVAL = 30_000; // 30 seconds
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ boardId: string }> },
 ) {
   const { boardId } = await params;
+
+  const board = await db.query.boards.findFirst({
+    where: eq(boards.id, boardId),
+  });
+
+  if (!board || !board.isActive) {
+    return new Response("Board not found", { status: 404 });
+  }
+
+  if (board.visibility === "private") {
+    const session = await getSessionUser();
+    if (!session) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  }
 
   const stream = new ReadableStream({
     start(controller) {
@@ -35,7 +54,7 @@ export async function GET(
       }, HEARTBEAT_INTERVAL);
 
       // Cleanup on close
-      _request.signal.addEventListener("abort", () => {
+      request.signal.addEventListener("abort", () => {
         clearInterval(heartbeat);
         removeClient(boardId, client);
         try {

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -29,9 +29,17 @@ export async function GET(request: NextRequest) {
     const board = await db.query.boards.findFirst({
       where: eq(boards.id, boardId),
     });
-    if (!board) {
+    if (!board || !board.isActive) {
       return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
+
+    if (board.visibility === "private") {
+      const session = await getSessionUser();
+      if (!session) {
+        return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+      }
+    }
+
     ownerUserId = board.ownerUserId;
   } else {
     const session = await getSessionUser();

--- a/src/app/pin/PinLoginClient.tsx
+++ b/src/app/pin/PinLoginClient.tsx
@@ -9,7 +9,13 @@ import { Lock } from "lucide-react";
 import { PinInput } from "@/components/auth/PinInput";
 import { KeinageLogo } from "@/components/KeinageLogo";
 
-export default function PinLoginClient({ userId }: { userId: string }) {
+export default function PinLoginClient({
+  userId,
+  redirectTo,
+}: {
+  userId: string;
+  redirectTo?: string | null;
+}) {
   const router = useRouter();
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
@@ -42,15 +48,19 @@ export default function PinLoginClient({ userId }: { userId: string }) {
           return;
         }
 
-        router.push("/boards");
+        router.push(redirectTo || "/boards");
       } catch {
         setError("通信エラーが発生しました");
         setPin("");
         setVerifying(false);
       }
     },
-    [router, verifying, blocked],
+    [router, redirectTo, verifying, blocked],
   );
+
+  const accountLoginHref = redirectTo
+    ? `/pin/login?redirectTo=${encodeURIComponent(redirectTo)}`
+    : "/pin/login";
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
@@ -92,7 +102,7 @@ export default function PinLoginClient({ userId }: { userId: string }) {
 
           <div className="mt-6 flex flex-col items-center gap-3">
             <Link
-              href="/pin/login"
+              href={accountLoginHref}
               className="text-sm font-medium text-blue-600 hover:text-blue-700"
             >
               メールアドレスまたはIDでログインする

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import { KeyRound } from "lucide-react";
 import { KeinageLogo } from "@/components/KeinageLogo";
 
-export default function LoginClient() {
+export default function LoginClient({ redirectTo }: { redirectTo?: string | null }) {
   const router = useRouter();
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
@@ -41,16 +41,19 @@ export default function LoginClient() {
           return;
         }
 
-        // Full auth succeeded — redirect directly to dashboard
-        router.push("/boards");
+        router.push(redirectTo || "/boards");
       } catch {
         setError("通信エラーが発生しました");
         setPassword("");
         setSubmitting(false);
       }
     },
-    [router, identifier, password, submitting, blocked],
+    [router, redirectTo, identifier, password, submitting, blocked],
   );
+
+  const pinLoginHref = redirectTo
+    ? `/pin?redirectTo=${encodeURIComponent(redirectTo)}`
+    : "/pin";
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
@@ -124,7 +127,7 @@ export default function LoginClient() {
 
           <div className="mt-6 text-center">
             <Link
-              href="/pin"
+              href={pinLoginHref}
               className="text-sm text-gray-500 hover:text-blue-600"
             >
               PINでログインする

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -6,12 +6,21 @@ import { db } from "@/db";
 import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import { AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { sanitizeRedirectTarget } from "@/lib/utils";
 import LoginClient from "./LoginClient";
 
 export const dynamic = "force-dynamic";
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirectTo?: string | string[] }>;
+}) {
   console.log("[/pin/login] START");
+  const params = await searchParams;
+  const redirectTo = sanitizeRedirectTarget(
+    typeof params.redirectTo === "string" ? params.redirectTo : null,
+  );
 
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
@@ -31,12 +40,12 @@ export default async function LoginPage() {
       ),
     });
     if (sessionRow) {
-      console.log("[/pin/login] Already authenticated → /boards");
-      redirect("/boards");
+      console.log("[/pin/login] Already authenticated → target");
+      redirect(redirectTo || "/boards");
     }
     console.log("[/pin/login] Session cookie present but invalid/expired");
   }
 
   console.log("[/pin/login] Rendering LoginClient");
-  return <LoginClient />;
+  return <LoginClient redirectTo={redirectTo} />;
 }

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -14,12 +14,21 @@ import {
 } from "@/lib/auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
+import { sanitizeRedirectTarget } from "@/lib/utils";
 import PinLoginClient from "./PinLoginClient";
 
 export const dynamic = "force-dynamic";
 
-export default async function PinLoginPage() {
+export default async function PinLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirectTo?: string | string[] }>;
+}) {
   const cookieStore = await cookies();
+  const params = await searchParams;
+  const redirectTo = sanitizeRedirectTarget(
+    typeof params.redirectTo === "string" ? params.redirectTo : null,
+  );
   const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
   const sessionCookie = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
 
@@ -34,8 +43,8 @@ export default async function PinLoginPage() {
       ),
     });
     if (sessionRow) {
-      console.log("[/pin] Valid session found → /boards");
-      redirect("/boards");
+      console.log("[/pin] Valid session found → target");
+      redirect(redirectTo || "/boards");
     }
     console.log("[/pin] Session cookie present but invalid/expired");
   }
@@ -56,7 +65,11 @@ export default async function PinLoginPage() {
     // Cookie user found. If they have no PIN they must use credentials login.
     if (!targetUser.pinHash) {
       console.log("[/pin] Cookie user has no PIN → /pin/login");
-      redirect("/pin/login");
+      redirect(
+        redirectTo
+          ? `/pin/login?redirectTo=${encodeURIComponent(redirectTo)}`
+          : "/pin/login",
+      );
     }
   } else {
     // Without a remembered user, require credential login so we don't pick an arbitrary owner.
@@ -66,7 +79,11 @@ export default async function PinLoginPage() {
       redirect("/signup");
     }
     console.log("[/pin] No remembered user → /pin/login");
-    redirect("/pin/login");
+    redirect(
+      redirectTo
+        ? `/pin/login?redirectTo=${encodeURIComponent(redirectTo)}`
+        : "/pin/login",
+    );
   }
 
   // ── 3. Check full auth validity ────────────────────────────────────
@@ -86,9 +103,13 @@ export default async function PinLoginPage() {
 
   if (!fullAuthValid) {
     console.log("[/pin] Full auth expired → /pin/login");
-    redirect("/pin/login");
+    redirect(
+      redirectTo
+        ? `/pin/login?redirectTo=${encodeURIComponent(redirectTo)}`
+        : "/pin/login",
+    );
   }
 
   console.log("[/pin] Showing PIN screen for", targetUser.userId);
-  return <PinLoginClient userId={targetUser.userId} />;
+  return <PinLoginClient userId={targetUser.userId} redirectTo={redirectTo} />;
 }

--- a/src/components/board/LiveBoard.tsx
+++ b/src/components/board/LiveBoard.tsx
@@ -78,6 +78,7 @@ export default function LiveBoard({
         id: data.id,
         name: data.name,
         ownerUserId: data.ownerUserId,
+        visibility: data.visibility,
         templateId: data.templateId,
         config: parseJsonObject(data.config),
         isActive: data.isActive,

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -213,7 +213,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
           className={buttonVariants({ variant: "outline", size: "sm" })}
         >
           <ExternalLink data-icon="inline-start" />
-          プレビュー
+          表示URLを開く
         </a>
       </div>
 
@@ -488,7 +488,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                 className={buttonVariants({ variant: "outline", className: "w-full" })}
               >
                 <ExternalLink data-icon="inline-start" />
-                プレビュー
+                表示URLを開く
               </a>
 
               <Separator />

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -14,6 +14,8 @@ import {
   Pencil,
   Check,
   X,
+  Lock,
+  Globe,
 } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
@@ -59,6 +61,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
   // Edit state
   const [name, setName] = useState("");
   const [isActive, setIsActive] = useState(true);
+  const [visibility, setVisibility] = useState<"public" | "private">("private");
   const [config, setConfig] = useState<Record<string, unknown>>({});
 
   // New message state
@@ -81,6 +84,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
     setBoard(data);
     setName(data.name);
     setIsActive(data.isActive);
+    setVisibility(data.visibility === "public" ? "public" : "private");
     const parsed =
       typeof data.config === "string" ? JSON.parse(data.config) : data.config;
     setConfig(parsed && typeof parsed === "object" ? parsed : {});
@@ -98,7 +102,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
     const res = await fetch(`/api/boards/${boardId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, isActive, config }),
+      body: JSON.stringify({ name, isActive, visibility, config }),
     });
 
     if (!res.ok) {
@@ -247,6 +251,46 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                 <Badge variant={isActive ? "default" : "secondary"}>
                   {isActive ? "有効" : "無効"}
                 </Badge>
+              </div>
+
+              <div className="space-y-3 rounded-lg border p-4">
+                <div className="space-y-1">
+                  <Label htmlFor="board-visibility">公開設定</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Private はログイン済みユーザーのみ表示URLを開けます。Public は誰でも表示URLを閲覧できます。
+                  </p>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <div
+                    className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm ${
+                      visibility === "private"
+                        ? "bg-primary/10 text-primary"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    <Lock className="size-3.5" />
+                    Private
+                  </div>
+                  <Switch
+                    id="board-visibility"
+                    checked={visibility === "public"}
+                    onCheckedChange={(checked) => setVisibility(checked ? "public" : "private")}
+                  />
+                  <div
+                    className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm ${
+                      visibility === "public"
+                        ? "bg-primary/10 text-primary"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    <Globe className="size-3.5" />
+                    Public
+                  </div>
+                  <Badge variant={visibility === "public" ? "default" : "secondary"}>
+                    {visibility === "public" ? "公開中" : "認証必須"}
+                  </Badge>
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,6 +14,7 @@ export const boards = pgTable("boards", {
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
+  visibility: text("visibility").notNull().default("private"),
   templateId: text("template_id").notNull(), // "simple" | "photo-clock" | "retro" | "message" | "call-number"
   config: text("config").notNull().default("{}"),
   isActive: boolean("is_active").notNull().default(true),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,3 +49,15 @@ export function normalizeConfig<T extends { config: unknown }>(record: T): Omit<
     config: parseJsonObject(record.config),
   };
 }
+
+export function sanitizeRedirectTarget(value: string | null | undefined): string | null {
+  if (!value || !value.startsWith("/")) {
+    return null;
+  }
+
+  if (value.startsWith("//")) {
+    return null;
+  }
+
+  return value;
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -12,15 +12,19 @@ export const templateIdSchema = z.enum([
   "call-number",
 ]);
 
+export const boardVisibilitySchema = z.enum(["public", "private"]);
+
 export const createBoardSchema = z.object({
   name: z.string().min(1).max(100),
   templateId: templateIdSchema,
+  visibility: boardVisibilitySchema.optional().default("private"),
   config: z.record(z.unknown()).optional().default({}),
 });
 
 export const updateBoardSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   templateId: templateIdSchema.optional(),
+  visibility: boardVisibilitySchema.optional(),
   config: z.record(z.unknown()).optional(),
   isActive: z.boolean().optional(),
 });


### PR DESCRIPTION
## 概要
- ボードに `public` / `private` の公開設定を追加し、既定値を `private` に変更
- `private` ボードの表示URL、公開API、SSE、天気取得でログイン済みセッションを必須化
- private ボードへ未ログインでアクセスした場合、戻り先付きで PIN / ログイン画面へ遷移
- ボード新規作成・編集画面に公開設定トグル、ロック表示、注釈を追加

## 変更内容
- `boards.visibility` カラムと migration を追加
- ボード作成 / 更新 API で `visibility` を保存できるように変更
- 表示画面と `/api/public/boards/[id]`, `/api/public/boards/[id]/messages`, `/api/sse/[boardId]`, `/api/weather?boardId=...` で visibility を判定
- `/pin` と `/pin/login` に `redirectTo` を追加し、認証後に元の private ボードへ戻れるように変更

## 確認
- `pnpm build`
- `pnpm db:migrate`

Closes #102