### PR TITLE
fix: PIN要求条件を端末単位の認証キャッシュに変更

### DIFF
--- a/drizzle/0004_tough_silk_fever.sql
+++ b/drizzle/0004_tough_silk_fever.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "device_auth_grants" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"device_token_hash" text NOT NULL,
+	"last_full_auth_at" text NOT NULL,
+	"created_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	CONSTRAINT "device_auth_grants_device_token_hash_unique" UNIQUE("device_token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "device_auth_grants" ADD CONSTRAINT "device_auth_grants_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,768 @@
+{
+  "id": "9e9df1e2-fc1f-49d0-8fb4-893fd096d2be",
+  "prevId": "1daf99c7-0a35-4cb1-94c8-1f645ffafffa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_unique": {
+          "name": "auth_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_owner_user_id_users_id_fk": {
+          "name": "boards_owner_user_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_auth_grants": {
+      "name": "device_auth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token_hash": {
+          "name": "device_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_auth_grants_user_id_users_id_fk": {
+          "name": "device_auth_grants_user_id_users_id_fk",
+          "tableFrom": "device_auth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_auth_grants_device_token_hash_unique": {
+          "name": "device_auth_grants_device_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_attempts": {
+      "name": "pin_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_reset_tokens": {
+      "name": "pin_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pin_reset_tokens_user_id_users_id_fk": {
+          "name": "pin_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "pin_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pin_reset_tokens_token_unique": {
+          "name": "pin_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_owner_user_id_users_id_fk": {
+          "name": "settings_owner_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_owner_user_id_key_pk": {
+          "name": "settings_owner_user_id_key_pk",
+          "columns": [
+            "owner_user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_requests": {
+      "name": "signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_requests_token_unique": {
+          "name": "signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_owner_user_id_users_id_fk": {
+          "name": "users_owner_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777211409250,
       "tag": "0003_mature_rattler",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777249886716,
+      "tag": "0004_tough_silk_fever",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -11,6 +11,10 @@ import {
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
 } from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  getDeviceAuthGrantByToken,
+} from "@/lib/device-auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
 import { ThemeProvider } from "@/components/dashboard/ThemeProvider";
@@ -24,6 +28,7 @@ export default async function DashboardLayout({
   // Read cookies first to signal Next.js that this layout is dynamic.
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  const deviceToken = cookieStore.get(DEVICE_AUTH_COOKIE)?.value;
 
   console.log("[dashboard/layout] Auth check", { hasSessionToken: !!sessionToken });
 
@@ -53,17 +58,23 @@ export default async function DashboardLayout({
     ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  const fullValid = isFullAuthValid(session.user.lastFullAuthAt, expireDays);
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
+  const sameUser = deviceAuthGrant?.user.id === session.user.id;
+  const deviceAuthLastFullAuthAt = sameUser
+    ? deviceAuthGrant.lastFullAuthAt
+    : null;
+  const fullValid = isFullAuthValid(deviceAuthLastFullAuthAt, expireDays);
   console.log("[dashboard/layout] Full auth check", {
     userId: session.user.userId,
-    lastFullAuthAt: session.user.lastFullAuthAt,
+    deviceAuthUserId: deviceAuthGrant?.user.userId ?? null,
+    lastFullAuthAt: deviceAuthLastFullAuthAt,
     expireDays,
     fullValid,
   });
 
   if (!fullValid) {
-    console.log("[dashboard/layout] Full auth expired → /pin");
-    redirect("/pin");
+    console.log("[dashboard/layout] Full auth expired for this device → /pin/login");
+    redirect("/pin/login");
   }
 
   const { userId, role, colorTheme } = session.user;

--- a/src/app/api/auth/credentials/complete/route.ts
+++ b/src/app/api/auth/credentials/complete/route.ts
@@ -7,9 +7,14 @@ import { db } from "@/db";
 import { authSessions, signupRequests, users } from "@/db/schema";
 import {
   AUTH_SESSION_COOKIE,
-  LAST_USER_COOKIE,
   hashPassword,
 } from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  clearLegacyLastUserCookie,
+  setDeviceAuthCookie,
+  storeDeviceFullAuth,
+} from "@/lib/device-auth";
 import { generateSessionToken } from "@/lib/pin";
 import {
   SIGNUP_REQUEST_COOKIE,
@@ -95,6 +100,11 @@ export async function POST(request: NextRequest) {
   });
 
   const cookieStore = await cookies();
+  const { deviceToken } = await storeDeviceFullAuth({
+    deviceToken: cookieStore.get(DEVICE_AUTH_COOKIE)?.value,
+    userId: createdUser.id,
+    authenticatedAt: now,
+  });
   const res = NextResponse.json({ success: true, userId: createdUser.userId });
   res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
     httpOnly: true,
@@ -102,12 +112,8 @@ export async function POST(request: NextRequest) {
     path: "/",
     maxAge: SETUP_SESSION_MAX_AGE,
   });
-  res.cookies.set(LAST_USER_COOKIE, createdUser.userId, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 365,
-  });
+  setDeviceAuthCookie(res, deviceToken);
+  clearLegacyLastUserCookie(res);
   if (cookieStore.get(SIGNUP_REQUEST_COOKIE)) {
     res.cookies.set(SIGNUP_REQUEST_COOKIE, "", {
       httpOnly: true,

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -4,7 +4,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users, pinAttempts, authSessions } from "@/db/schema";
 import { eq, or, and, gt } from "drizzle-orm";
-import { verifyPassword, AUTH_SESSION_COOKIE, SESSION_MAX_AGE, LAST_USER_COOKIE } from "@/lib/auth";
+import {
+  verifyPassword,
+  AUTH_SESSION_COOKIE,
+  SESSION_MAX_AGE,
+} from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  clearLegacyLastUserCookie,
+  setDeviceAuthCookie,
+  storeDeviceFullAuth,
+} from "@/lib/device-auth";
 import {
   MAX_PIN_ATTEMPTS,
   IP_BLOCK_DURATION_MS,
@@ -109,6 +119,12 @@ export async function POST(request: NextRequest) {
     .set({ lastFullAuthAt: now })
     .where(eq(users.id, user.id));
 
+  const { deviceToken } = await storeDeviceFullAuth({
+    deviceToken: request.cookies.get(DEVICE_AUTH_COOKIE)?.value,
+    userId: user.id,
+    authenticatedAt: now,
+  });
+
   // Create session
   const sessionToken = generateSessionToken();
   const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000).toISOString();
@@ -126,12 +142,7 @@ export async function POST(request: NextRequest) {
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });
-  // Remember which user last authenticated so the PIN screen can target them
-  res.cookies.set(LAST_USER_COOKIE, user.userId, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 365, // 1 year
-  });
+  setDeviceAuthCookie(res, deviceToken);
+  clearLegacyLastUserCookie(res);
   return res;
 }

--- a/src/app/api/auth/pin/logout/route.ts
+++ b/src/app/api/auth/pin/logout/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { authSessions } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { clearLegacyLastUserCookie } from "@/lib/device-auth";
 import { cookies } from "next/headers";
 
 /** POST /api/auth/pin/logout — clear session */
@@ -20,6 +21,14 @@ export async function POST() {
       .where(eq(authSessions.sessionToken, sessionToken));
   }
 
-  cookieStore.delete(AUTH_SESSION_COOKIE);
-  return NextResponse.json({ success: true });
+  const res = NextResponse.json({ success: true });
+  res.cookies.set(AUTH_SESSION_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+    expires: new Date(0),
+  });
+  clearLegacyLastUserCookie(res);
+  return res;
 }

--- a/src/app/api/auth/pin/setup/route.ts
+++ b/src/app/api/auth/pin/setup/route.ts
@@ -7,12 +7,17 @@ import { and, eq, gt } from "drizzle-orm";
 import { hashPin, generateSessionToken } from "@/lib/pin";
 import {
   AUTH_SESSION_COOKIE,
-  LAST_USER_COOKIE,
   SESSION_MAX_AGE,
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
 } from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  clearLegacyLastUserCookie,
+  getDeviceAuthGrantByToken,
+  setDeviceAuthCookie,
+} from "@/lib/device-auth";
 import { cookies } from "next/headers";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
@@ -21,6 +26,7 @@ import { resolveOwnerUserId } from "@/lib/ownership";
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  const deviceToken = cookieStore.get(DEVICE_AUTH_COOKIE)?.value;
 
   if (!sessionToken) {
     return NextResponse.json(
@@ -76,9 +82,13 @@ export async function POST(request: NextRequest) {
   const expireDays = expireSetting
     ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
+  const deviceAuthLastFullAuthAt = deviceAuthGrant?.user.id === targetUser.id
+    ? deviceAuthGrant.lastFullAuthAt
+    : null;
 
   // Verify full-auth is still valid (set during credentials/setup)
-  if (!isFullAuthValid(targetUser.lastFullAuthAt, expireDays)) {
+  if (!isFullAuthValid(deviceAuthLastFullAuthAt, expireDays)) {
     return NextResponse.json(
       { error: "認証セッションが無効です。再度ログインしてください" },
       { status: 401 },
@@ -111,12 +121,10 @@ export async function POST(request: NextRequest) {
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });
-  res.cookies.set(LAST_USER_COOKIE, targetUser.userId, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 365,
-  });
+  if (deviceToken) {
+    setDeviceAuthCookie(res, deviceToken);
+  }
+  clearLegacyLastUserCookie(res);
   return res;
 }
 

--- a/src/app/api/auth/pin/status/route.ts
+++ b/src/app/api/auth/pin/status/route.ts
@@ -10,16 +10,21 @@ import {
   AUTH_EXPIRE_DAYS_KEY,
   computeFullAuthExpiry,
   AUTH_SESSION_COOKIE,
-  LAST_USER_COOKIE,
 } from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  getDeviceAuthGrantByToken,
+} from "@/lib/device-auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** GET /api/auth/pin/status — check if admin user and PIN are configured */
 export async function GET() {
   const cookieStore = await cookies();
+  const deviceToken = cookieStore.get(DEVICE_AUTH_COOKIE)?.value;
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
 
-  // Prefer the logged-in session user; fall back to the remembered user only.
+  // Prefer the logged-in session user; fall back to the remembered device-auth user.
   let targetUser: typeof users.$inferSelect | null | undefined = null;
 
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
@@ -35,12 +40,7 @@ export async function GET() {
   }
 
   if (!targetUser) {
-    const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
-    if (lastUserId) {
-      targetUser = await db.query.users.findFirst({
-        where: eq(users.userId, lastUserId),
-      });
-    }
+    targetUser = deviceAuthGrant?.user ?? null;
   }
 
   const anyUser = targetUser ? targetUser : await db.query.users.findFirst();
@@ -53,8 +53,11 @@ export async function GET() {
     ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
+  const fullAuthAt = targetUser && deviceAuthGrant?.user.id === targetUser.id
+    ? deviceAuthGrant.lastFullAuthAt
+    : null;
   const fullAuthExpiry = targetUser
-    ? computeFullAuthExpiry(targetUser.lastFullAuthAt, expireDays)
+    ? computeFullAuthExpiry(fullAuthAt, expireDays)
     : null;
 
   return NextResponse.json({

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { users, authSessions, pinAttempts } from "@/db/schema";
-import { eq, and, gt, isNotNull } from "drizzle-orm";
+import { authSessions, pinAttempts } from "@/db/schema";
+import { eq, and, gt } from "drizzle-orm";
 import {
   verifyPin,
   generateSessionToken,
@@ -16,8 +16,13 @@ import {
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
-  LAST_USER_COOKIE,
 } from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  clearLegacyLastUserCookie,
+  getDeviceAuthGrantByToken,
+  setDeviceAuthCookie,
+} from "@/lib/device-auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
 
@@ -63,43 +68,27 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Resolve target user — same logic as pin/page.tsx:
-  //   Cookie user found + has PIN → that user
-  //   Cookie user found + no PIN → error (should not reach verify)
-  //   Cookie user not found → first user with PIN
-  const cookieStore = request.cookies;
-  const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
-  let adminUser = lastUserId
-    ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
-    : null;
+  const deviceToken = request.cookies.get(DEVICE_AUTH_COOKIE)?.value;
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
+  const adminUser = deviceAuthGrant?.user ?? null;
 
-  console.log("[pin/verify] User resolution", {
-    lastUserId,
-    cookieUserFound: !!adminUser,
-    cookieUserHasPIN: !!adminUser?.pinHash,
+  console.log("[pin/verify] Device auth lookup", {
+    hasDeviceAuthGrant: !!deviceAuthGrant,
+    userId: adminUser?.userId ?? null,
+    hasPIN: !!adminUser?.pinHash,
   });
 
-  if (adminUser) {
-    if (!adminUser.pinHash) {
-      // Cookie user has no PIN — they shouldn't be using PIN verify
-      console.log("[pin/verify] Cookie user has no PIN → error");
-      return NextResponse.json(
-        { error: "PINが設定されていません。メールアドレスでログインしてください。", requiresFullAuth: true },
-        { status: 403 },
-      );
-    }
-  } else {
-    // No cookie or cookie user not found — fall back to first user with a PIN
-    adminUser = await db.query.users.findFirst({ where: isNotNull(users.pinHash) });
-    console.log("[pin/verify] Fallback user with PIN", {
-      found: !!adminUser,
-      userId: adminUser?.userId ?? null,
-    });
-  }
-  if (!adminUser?.pinHash) {
+  if (!deviceAuthGrant || !adminUser) {
     return NextResponse.json(
-      { error: "PINが設定されていません" },
-      { status: 400 },
+      { error: "メールアドレスとパスワードによる認証が必要です", requiresFullAuth: true },
+      { status: 403 },
+    );
+  }
+
+  if (!adminUser.pinHash) {
+    return NextResponse.json(
+      { error: "PINが設定されていません。メールアドレスでログインしてください。", requiresFullAuth: true },
+      { status: 403 },
     );
   }
 
@@ -112,7 +101,7 @@ export async function POST(request: NextRequest) {
     ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  if (!isFullAuthValid(adminUser.lastFullAuthAt, expireDays)) {
+  if (!isFullAuthValid(deviceAuthGrant.lastFullAuthAt, expireDays)) {
     return NextResponse.json(
       { error: "メールアドレスとパスワードによる認証が必要です", requiresFullAuth: true },
       { status: 403 },
@@ -156,12 +145,9 @@ export async function POST(request: NextRequest) {
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });
-  // Keep LAST_USER_COOKIE up-to-date so next logout shows the correct PIN screen
-  res.cookies.set(LAST_USER_COOKIE, adminUser.userId, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 365, // 1 year
-  });
+  if (deviceToken) {
+    setDeviceAuthCookie(res, deviceToken);
+  }
+  clearLegacyLastUserCookie(res);
   return res;
 }

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -5,7 +5,18 @@ import { cookies } from "next/headers";
 import { db } from "@/db";
 import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
-import { AUTH_SESSION_COOKIE } from "@/lib/auth";
+import {
+  AUTH_SESSION_COOKIE,
+  DEFAULT_AUTH_EXPIRE_DAYS,
+  AUTH_EXPIRE_DAYS_KEY,
+  isFullAuthValid,
+} from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  getDeviceAuthGrantByToken,
+} from "@/lib/device-auth";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { resolveOwnerUserId } from "@/lib/ownership";
 import { sanitizeRedirectTarget } from "@/lib/utils";
 import LoginClient from "./LoginClient";
 
@@ -32,16 +43,49 @@ export default async function LoginPage({
   // If already authenticated, redirect to dashboard
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  const deviceToken = cookieStore.get(DEVICE_AUTH_COOKIE)?.value;
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
   if (sessionCookie) {
     const sessionRow = await db.query.authSessions.findFirst({
       where: and(
         eq(authSessions.sessionToken, sessionCookie),
         gt(authSessions.expiresAt, new Date().toISOString()),
       ),
+      with: { user: true },
     });
     if (sessionRow) {
-      console.log("[/pin/login] Already authenticated → target");
-      redirect(redirectTo || "/boards");
+      const sameUser = deviceAuthGrant?.user.id === sessionRow.user.id;
+      const expireSetting = sameUser
+        ? await getOwnerSetting(
+            resolveOwnerUserId(sessionRow.user),
+            AUTH_EXPIRE_DAYS_KEY,
+          )
+        : null;
+      const expireDays = expireSetting
+        ? parseInt(expireSetting, 10)
+        : DEFAULT_AUTH_EXPIRE_DAYS;
+      const deviceAuthLastFullAuthAt = sameUser
+        ? deviceAuthGrant.lastFullAuthAt
+        : null;
+      const fullAuthValid = isFullAuthValid(
+        deviceAuthLastFullAuthAt,
+        expireDays,
+      );
+
+      console.log("[/pin/login] Existing session full-auth check", {
+        sessionUserId: sessionRow.user.userId,
+        deviceAuthUserId: deviceAuthGrant?.user.userId ?? null,
+        deviceAuthLastFullAuthAt,
+        expireDays,
+        fullAuthValid,
+      });
+
+      if (fullAuthValid) {
+        console.log("[/pin/login] Already authenticated → target");
+        redirect(redirectTo || "/boards");
+      }
+
+      console.log("[/pin/login] Session exists but device full-auth is not valid");
     }
     console.log("[/pin/login] Session cookie present but invalid/expired");
   }

--- a/src/app/pin/page.tsx
+++ b/src/app/pin/page.tsx
@@ -4,14 +4,17 @@ import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { db } from "@/db";
 import { users, authSessions } from "@/db/schema";
-import { eq, and, gt, isNotNull } from "drizzle-orm";
+import { eq, and, gt } from "drizzle-orm";
 import {
   AUTH_SESSION_COOKIE,
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
   isFullAuthValid,
-  LAST_USER_COOKIE,
 } from "@/lib/auth";
+import {
+  DEVICE_AUTH_COOKIE,
+  getDeviceAuthGrantByToken,
+} from "@/lib/device-auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
 import { sanitizeRedirectTarget } from "@/lib/utils";
@@ -29,10 +32,15 @@ export default async function PinLoginPage({
   const redirectTo = sanitizeRedirectTarget(
     typeof params.redirectTo === "string" ? params.redirectTo : null,
   );
-  const lastUserId = cookieStore.get(LAST_USER_COOKIE)?.value;
   const sessionCookie = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
+  const deviceToken = cookieStore.get(DEVICE_AUTH_COOKIE)?.value;
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
 
-  console.log("[/pin] START", { lastUserId, hasSessionCookie: !!sessionCookie });
+  console.log("[/pin] START", {
+    hasSessionCookie: !!sessionCookie,
+    hasDeviceAuthGrant: !!deviceAuthGrant,
+    deviceAuthUserId: deviceAuthGrant?.user.userId ?? null,
+  });
 
   // ── 1. Already authenticated? → dashboard ─────────────────────────
   if (sessionCookie) {
@@ -41,21 +49,49 @@ export default async function PinLoginPage({
         eq(authSessions.sessionToken, sessionCookie),
         gt(authSessions.expiresAt, new Date().toISOString()),
       ),
+      with: { user: true },
     });
     if (sessionRow) {
-      console.log("[/pin] Valid session found → target");
-      redirect(redirectTo || "/boards");
+      const sameUser = deviceAuthGrant?.user.id === sessionRow.user.id;
+      const expireSetting = sameUser
+        ? await getOwnerSetting(
+            resolveOwnerUserId(sessionRow.user),
+            AUTH_EXPIRE_DAYS_KEY,
+          )
+        : null;
+      const expireDays = expireSetting
+        ? parseInt(expireSetting, 10)
+        : DEFAULT_AUTH_EXPIRE_DAYS;
+      const deviceAuthLastFullAuthAt = sameUser
+        ? deviceAuthGrant.lastFullAuthAt
+        : null;
+      const fullSessionValid = isFullAuthValid(
+        deviceAuthLastFullAuthAt,
+        expireDays,
+      );
+
+      console.log("[/pin] Existing session full-auth check", {
+        sessionUserId: sessionRow.user.userId,
+        deviceAuthUserId: deviceAuthGrant?.user.userId ?? null,
+        deviceAuthLastFullAuthAt,
+        expireDays,
+        fullSessionValid,
+      });
+
+      if (fullSessionValid) {
+        console.log("[/pin] Valid session found → target");
+        redirect(redirectTo || "/boards");
+      }
+
+      console.log("[/pin] Session cookie present but device full-auth is not valid");
     }
     console.log("[/pin] Session cookie present but invalid/expired");
   }
 
   // ── 2. Resolve target user ─────────────────────────────────────────
-  let targetUser = lastUserId
-    ? await db.query.users.findFirst({ where: eq(users.userId, lastUserId) })
-    : null;
+  const targetUser = deviceAuthGrant?.user ?? null;
 
-  console.log("[/pin] Cookie user lookup", {
-    lastUserId,
+  console.log("[/pin] Device auth lookup", {
     found: !!targetUser,
     hasPIN: !!targetUser?.pinHash,
     userId: targetUser?.userId ?? null,
@@ -86,6 +122,14 @@ export default async function PinLoginPage({
     );
   }
 
+  if (!deviceAuthGrant) {
+    redirect(
+      redirectTo
+        ? `/pin/login?redirectTo=${encodeURIComponent(redirectTo)}`
+        : "/pin/login",
+    );
+  }
+
   // ── 3. Check full auth validity ────────────────────────────────────
   const ownerUserId = resolveOwnerUserId(targetUser);
   const expireSetting = await getOwnerSetting(ownerUserId, AUTH_EXPIRE_DAYS_KEY);
@@ -93,10 +137,10 @@ export default async function PinLoginPage({
     ? parseInt(expireSetting, 10)
     : DEFAULT_AUTH_EXPIRE_DAYS;
 
-  const fullAuthValid = isFullAuthValid(targetUser.lastFullAuthAt, expireDays);
+  const fullAuthValid = isFullAuthValid(deviceAuthGrant.lastFullAuthAt, expireDays);
   console.log("[/pin] Full auth check", {
     userId: targetUser.userId,
-    lastFullAuthAt: targetUser.lastFullAuthAt,
+    lastFullAuthAt: deviceAuthGrant.lastFullAuthAt,
     expireDays,
     fullAuthValid,
   });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -176,10 +176,29 @@ export const authSessions = pgTable("auth_sessions", {
     .default(isoNow),
 });
 
+export const deviceAuthGrants = pgTable("device_auth_grants", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  deviceTokenHash: text("device_token_hash").notNull().unique(),
+  lastFullAuthAt: text("last_full_auth_at").notNull(),
+  createdAt: text("created_at")
+    .notNull()
+    .default(isoNow),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(isoNow)
+    .$onUpdate(() => new Date().toISOString()),
+});
+
 // ── Relations ────────────────────────────────────────────
 
 export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(authSessions),
+  deviceAuthGrants: many(deviceAuthGrants),
   pinResetTokens: many(pinResetTokens),
 }));
 
@@ -193,6 +212,13 @@ export const pinResetTokensRelations = relations(pinResetTokens, ({ one }) => ({
 export const authSessionsRelations = relations(authSessions, ({ one }) => ({
   user: one(users, {
     fields: [authSessions.userId],
+    references: [users.id],
+  }),
+}));
+
+export const deviceAuthGrantsRelations = relations(deviceAuthGrants, ({ one }) => ({
+  user: one(users, {
+    fields: [deviceAuthGrants.userId],
     references: [users.id],
   }),
 }));

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -36,9 +36,8 @@ export async function verifyPassword(
 export const AUTH_SESSION_COOKIE = "auth-session";
 
 /**
- * Cookie that stores the userId (human-readable) of the most recently
- * authenticated user. Used to target the correct account on the PIN screen.
- * Long-lived (1 year), httpOnly.
+ * Legacy cookie that stored the last authenticated userId.
+ * Kept only so newer auth flows can explicitly clear it during migration.
  */
 export const LAST_USER_COOKIE = "last-user-id";
 

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { createHash, randomBytes } from "crypto";
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { deviceAuthGrants } from "@/db/schema";
+import { LAST_USER_COOKIE } from "@/lib/auth";
+
+export const DEVICE_AUTH_COOKIE = "device-auth";
+export const DEVICE_AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+function hashDeviceAuthToken(deviceToken: string): string {
+  return createHash("sha256")
+    .update(`keinage-device-auth:${deviceToken}`)
+    .digest("hex");
+}
+
+export function generateDeviceAuthToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export async function getDeviceAuthGrantByToken(deviceToken?: string | null) {
+  if (!deviceToken) {
+    return null;
+  }
+
+  return db.query.deviceAuthGrants.findFirst({
+    where: eq(deviceAuthGrants.deviceTokenHash, hashDeviceAuthToken(deviceToken)),
+    with: { user: true },
+  });
+}
+
+export async function storeDeviceFullAuth(params: {
+  deviceToken?: string | null;
+  userId: string;
+  authenticatedAt?: string;
+}) {
+  const deviceToken = params.deviceToken ?? generateDeviceAuthToken();
+  const lastFullAuthAt = params.authenticatedAt ?? new Date().toISOString();
+  const deviceTokenHash = hashDeviceAuthToken(deviceToken);
+
+  const existingGrant = await db.query.deviceAuthGrants.findFirst({
+    where: eq(deviceAuthGrants.deviceTokenHash, deviceTokenHash),
+  });
+
+  if (existingGrant) {
+    await db
+      .update(deviceAuthGrants)
+      .set({ userId: params.userId, lastFullAuthAt })
+      .where(eq(deviceAuthGrants.id, existingGrant.id));
+  } else {
+    await db.insert(deviceAuthGrants).values({
+      userId: params.userId,
+      deviceTokenHash,
+      lastFullAuthAt,
+    });
+  }
+
+  return { deviceToken, lastFullAuthAt };
+}
+
+export function setDeviceAuthCookie(response: NextResponse, deviceToken: string) {
+  response.cookies.set(DEVICE_AUTH_COOKIE, deviceToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: DEVICE_AUTH_COOKIE_MAX_AGE,
+  });
+}
+
+export function clearLegacyLastUserCookie(response: NextResponse) {
+  response.cookies.set(LAST_USER_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+    expires: new Date(0),
+  });
+}


### PR DESCRIPTION
## 概要
- PINログインの対象ユーザー決定を `last-user-id` cookie 依存から、端末単位の不透明トークン (`device-auth`) + サーバー側 `device_auth_grants` に変更
- メールアドレス+パスワードによる完全認証の有効期限判定を、ユーザー全体ではなく端末ごとの記録で参照するよう修正
- 旧 `last-user-id` cookie は新フローで明示的に削除するよう変更

## 変更内容
- `device_auth_grants` テーブルを追加し、端末ごとの `last_full_auth_at` を保持
- 認証完了時 (`credentials/login`, `credentials/complete`) に端末 grant を発行/更新
- PIN画面、PIN verify、ダッシュボード保護、PIN status、PIN setup を端末 grant ベースに統一
- `/pin/login` の既存セッション自動通過も端末 grant の有効性を確認するよう修正
- Drizzle migration (`0004_tough_silk_fever`) を追加

## 影響
- 既存ユーザーは、初回のみメールアドレス+パスワードで再ログインして端末 grant を再作成する必要があります
- 他ユーザーが同じ端末で最後に認証していたとしても、任意ユーザーの PIN 入力を求められないようになります

## 確認
- `pnpm db:generate`
- `pnpm build`

Closes #103