### PR TITLE
fix: ログイン試行制限の IP 判定を trusted proxy 前提に修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/keinage
 
+# Trust reverse-proxy IP headers only when every request passes through
+# infrastructure that overwrites them, such as ALB / CloudFront / Nginx.
+TRUST_PROXY_HEADERS=false
+
 # Optional S3-compatible media storage
 # 既定ではローカル uploads/ に保存します。利用する場合のみ設定してください。
 # 例: rustfs (alpha) を使う場合

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,13 @@ API は大きく 3 種類に分かれます。
 - `boards`、`media`、`messages`、`settings` など一部の内部 API は、現状レイアウト側の認証ゲート利用を前提にしており、Route Handler 単体では厳密な認可チェックを入れていないものがあります。
 - `POST /api/messages` は外部連携向けです。
 
+### 2.3 ログイン試行制限の IP 解決
+
+- `POST /api/auth/credentials/login` と `POST /api/auth/pin/verify` は `pin_attempts` を使って試行制限します。
+- `TRUST_PROXY_HEADERS=true` のときだけ `x-forwarded-for` / `x-real-ip` を client IP として利用します。
+- `TRUST_PROXY_HEADERS=false` のときは proxy header を信用せず、`client + auth subject` 単位の bucket で試行回数を管理します。
+- 公開運用で ALB / CloudFront / Nginx などが header を上書きする場合のみ `TRUST_PROXY_HEADERS=true` を設定してください。
+
 ## 3. 認証 API
 
 ### 3.1 Owner サインアップ / 初期 PIN 設定
@@ -141,7 +148,7 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、`last-user-i
 
 - `identifier` はメールアドレスまたは `userId`
 - 成功時に `auth-session` と `last-user-id` Cookie を設定
-- 失敗回数は IP ベースで制限
+- 失敗回数は `client + identifier` bucket ベースで制限
 
 #### `POST /api/auth/pin/verify`
 
@@ -158,6 +165,7 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、`last-user-i
 - `last-user-id` があればそのユーザーの PIN を優先検証
 - 対象ユーザーに PIN がない場合は `requiresFullAuth: true` を返す
 - フル認証期限切れでも `requiresFullAuth: true` を返す
+- 失敗回数は `client + target user` bucket ベースで制限
 
 #### `GET /api/auth/pin/status`
 

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -20,15 +20,29 @@ import {
   IP_BLOCK_DURATION_MS,
   generateSessionToken,
 } from "@/lib/pin";
+import {
+  buildRateLimitKey,
+  resolveRateLimitClientIp,
+} from "@/lib/rate-limit";
 
 /** POST /api/auth/credentials/login — email/userId + password login */
 export async function POST(request: NextRequest) {
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "unknown";
+  const clientIp = resolveRateLimitClientIp(request);
 
-  // IP rate-limit (shared with PIN attempts)
+  const body = await request.json();
+  const { identifier, password } = body as {
+    identifier?: string;
+    password?: string;
+  };
+
+  const normalizedIdentifier = identifier?.trim() ?? "";
+  const rateLimitKey = buildRateLimitKey({
+    flow: "credentials",
+    clientIp,
+    subject: normalizedIdentifier || "missing-identifier",
+  });
+
+  // Rate-limit per client/subject bucket. Proxy headers are trusted only when configured.
   const blockThreshold = new Date(
     Date.now() - IP_BLOCK_DURATION_MS,
   ).toISOString();
@@ -37,7 +51,7 @@ export async function POST(request: NextRequest) {
     .from(pinAttempts)
     .where(
       and(
-        eq(pinAttempts.ipAddress, ip),
+        eq(pinAttempts.ipAddress, rateLimitKey),
         gt(pinAttempts.attemptedAt, blockThreshold),
       ),
     );
@@ -53,13 +67,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const body = await request.json();
-  const { identifier, password } = body as {
-    identifier?: string;
-    password?: string;
-  };
-
-  if (!identifier || !password) {
+  if (!normalizedIdentifier || !password) {
     return NextResponse.json(
       { error: "ユーザーIDまたはメールアドレスとパスワードを入力してください" },
       { status: 400 },
@@ -68,20 +76,20 @@ export async function POST(request: NextRequest) {
 
   const user = await db.query.users.findFirst({
     where: or(
-      eq(users.email, identifier),
-      eq(users.userId, identifier),
+      eq(users.email, normalizedIdentifier),
+      eq(users.userId, normalizedIdentifier),
     ),
   });
 
   console.log("[credentials/login] User lookup", {
-    identifier,
+    identifier: normalizedIdentifier,
     found: !!user,
     userId: user?.userId ?? null,
   });
 
   // Constant-time failure to prevent user enumeration
   if (!user) {
-    await db.insert(pinAttempts).values({ ipAddress: ip });
+    await db.insert(pinAttempts).values({ ipAddress: rateLimitKey });
     return NextResponse.json(
       { error: "ユーザーIDまたはパスワードが正しくありません" },
       { status: 401 },
@@ -95,7 +103,7 @@ export async function POST(request: NextRequest) {
     pwHashLen: user.passwordHash?.length ?? 0,
   });
   if (!valid) {
-    await db.insert(pinAttempts).values({ ipAddress: ip });
+    await db.insert(pinAttempts).values({ ipAddress: rateLimitKey });
     const remaining = MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
     return NextResponse.json(
       {
@@ -106,8 +114,8 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Clear IP attempts on success
-  await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
+  // Clear attempts for the successfully authenticated subject bucket.
+  await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, rateLimitKey));
 
   console.log("[credentials/login] Password verified OK for", user.userId);
 

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -25,38 +25,14 @@ import {
 } from "@/lib/device-auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
+import {
+  buildRateLimitKey,
+  resolveRateLimitClientIp,
+} from "@/lib/rate-limit";
 
 /** POST /api/auth/pin/verify — verify PIN and issue session */
 export async function POST(request: NextRequest) {
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "unknown";
-
-  // Check IP block
-  const blockThreshold = new Date(
-    Date.now() - IP_BLOCK_DURATION_MS,
-  ).toISOString();
-  const recentAttempts = await db
-    .select()
-    .from(pinAttempts)
-    .where(
-      and(
-        eq(pinAttempts.ipAddress, ip),
-        gt(pinAttempts.attemptedAt, blockThreshold),
-      ),
-    );
-
-  if (recentAttempts.length >= MAX_PIN_ATTEMPTS) {
-    return NextResponse.json(
-      {
-        error:
-          "試行回数の上限に達しました。24時間後に再度お試しください。",
-        blocked: true,
-      },
-      { status: 429 },
-    );
-  }
+  const clientIp = resolveRateLimitClientIp(request);
 
   const body = await request.json();
   const { pin } = body as { pin?: string };
@@ -77,6 +53,36 @@ export async function POST(request: NextRequest) {
     userId: adminUser?.userId ?? null,
     hasPIN: !!adminUser?.pinHash,
   });
+
+  const rateLimitKey = buildRateLimitKey({
+    flow: "pin",
+    clientIp,
+    subject: adminUser?.userId ?? "no-device-auth",
+  });
+
+  const blockThreshold = new Date(
+    Date.now() - IP_BLOCK_DURATION_MS,
+  ).toISOString();
+  const recentAttempts = await db
+    .select()
+    .from(pinAttempts)
+    .where(
+      and(
+        eq(pinAttempts.ipAddress, rateLimitKey),
+        gt(pinAttempts.attemptedAt, blockThreshold),
+      ),
+    );
+
+  if (recentAttempts.length >= MAX_PIN_ATTEMPTS) {
+    return NextResponse.json(
+      {
+        error:
+          "試行回数の上限に達しました。24時間後に再度お試しください。",
+        blocked: true,
+      },
+      { status: 429 },
+    );
+  }
 
   if (!deviceAuthGrant || !adminUser) {
     return NextResponse.json(
@@ -110,7 +116,7 @@ export async function POST(request: NextRequest) {
 
   if (!verifyPin(pin, adminUser.pinHash)) {
     // Record failed attempt
-    await db.insert(pinAttempts).values({ ipAddress: ip });
+    await db.insert(pinAttempts).values({ ipAddress: rateLimitKey });
 
     const remaining = MAX_PIN_ATTEMPTS - (recentAttempts.length + 1);
     console.log("[pin/verify] PIN incorrect for", adminUser.userId, { remaining });
@@ -123,8 +129,8 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Success — clear previous attempts for this IP
-  await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, ip));
+  // Success — clear attempts for the verified subject bucket.
+  await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, rateLimitKey));
 
   console.log("[pin/verify] PIN verified OK for", adminUser.userId);
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest } from "next/server";
+
+export const TRUST_PROXY_HEADERS = process.env.TRUST_PROXY_HEADERS === "true";
+
+function normalizeRateLimitSegment(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return "unknown";
+  }
+
+  return normalized.replace(/[^a-z0-9._:-]/g, "_");
+}
+
+/**
+ * Route Handlers do not expose the socket remote address.
+ * Proxy headers are therefore trusted only when the deployment explicitly
+ * guarantees that every request passes through a trusted reverse proxy.
+ */
+export function resolveRateLimitClientIp(request: NextRequest): string {
+  if (TRUST_PROXY_HEADERS) {
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    const firstForwardedIp = forwardedFor
+      ?.split(",")
+      .map((value) => value.trim())
+      .find(Boolean);
+    if (firstForwardedIp) {
+      return normalizeRateLimitSegment(firstForwardedIp);
+    }
+
+    const realIp = request.headers.get("x-real-ip")?.trim();
+    if (realIp) {
+      return normalizeRateLimitSegment(realIp);
+    }
+  }
+
+  return "direct";
+}
+
+export function buildRateLimitKey(params: {
+  flow: "credentials" | "pin";
+  clientIp: string;
+  subject: string;
+}): string {
+  return [
+    params.flow,
+    normalizeRateLimitSegment(params.clientIp),
+    normalizeRateLimitSegment(params.subject),
+  ].join(":");
+}


### PR DESCRIPTION
## 概要
- issue #97 に対応し、`x-forwarded-for` / `x-real-ip` を無条件に信用しないよう修正
- login / PIN verify の試行制限を `client + auth subject` bucket に変更し、header 偽装での回避を抑止
- trusted proxy 利用有無を `TRUST_PROXY_HEADERS` で設定できるように変更

## 変更内容
- `src/lib/rate-limit.ts` を追加
  - `TRUST_PROXY_HEADERS=true` のときだけ proxy header を client IP として利用
  - それ以外は `direct` bucket を使い、subject と組み合わせて試行制限キーを生成
- `POST /api/auth/credentials/login`
  - rate-limit キーを `credentials:<client>:<identifier>` に変更
- `POST /api/auth/pin/verify`
  - rate-limit キーを `pin:<client>:<target-user>` に変更
- `.env.example` に `TRUST_PROXY_HEADERS` を追加
- `docs/API.md` に運用ルールを追記

## 確認
- `pnpm build`

Closes #97