### PR TITLE
fix: ダッシュボード変更 API にサーバー側認可を追加

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -302,11 +302,11 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、`last-user-i
 | `GET` | `/api/media` | メディア一覧取得 | 内部向け |
 | `POST` | `/api/media` | メディアアップロード | 内部向け |
 | `PATCH` | `/api/media` | 表示順更新 | 内部向け |
-| `DELETE` | `/api/media` | 全メディア削除 | 内部向け |
+| `DELETE` | `/api/media` | 全メディア削除 | `admin` |
 | `DELETE` | `/api/media/[id]` | 1 件削除 | 内部向け |
 | `PATCH` | `/api/media/[id]` | 1 件の設定更新 | 内部向け |
-| `GET` | `/api/media/files` | ストレージ上ファイル一覧取得 | 内部向け |
-| `DELETE` | `/api/media/files` | ストレージ上ファイルと参照レコード削除 | 内部向け |
+| `GET` | `/api/media/files` | ストレージ上ファイル一覧取得 | `admin` |
+| `DELETE` | `/api/media/files` | ストレージ上ファイルと参照レコード削除 | `admin` |
 
 #### `POST /api/media`
 
@@ -351,7 +351,7 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、`last-user-i
 
 | Method | Path | 説明 | 認証 |
 | --- | --- | --- | --- |
-| `POST` | `/api/messages` | メッセージ作成 | 外部連携可 |
+| `POST` | `/api/messages` | メッセージ作成 | 内部向け |
 | `PATCH` | `/api/messages/[id]` | メッセージ更新 | 内部向け |
 | `DELETE` | `/api/messages/[id]` | メッセージ削除 | 内部向け |
 
@@ -375,12 +375,17 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、`last-user-i
 
 成功時は `message-updated` を発行します。
 
+注記:
+
+- 現在の `POST /api/messages` は認証済みセッションを前提とする内部 API です。
+- 外部連携として公開する場合は、別 endpoint と別認証方式で切り出す前提です。
+
 ## 8. 設定 API
 
 | Method | Path | 説明 | 認証 |
 | --- | --- | --- | --- |
-| `GET` | `/api/settings` | KV 設定をまとめて取得 | 内部向け |
-| `PATCH` | `/api/settings` | KV 設定を upsert | 内部向け |
+| `GET` | `/api/settings` | KV 設定をまとめて取得 | `admin` |
+| `PATCH` | `/api/settings` | KV 設定を upsert | `admin` |
 
 #### `PATCH /api/settings`
 
@@ -393,6 +398,8 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、`last-user-i
 ```
 
 現在の実装では value は文字列として保存します。
+
+設定 API は owner 全体に影響するため、管理者ユーザーのみ利用できます。
 
 ## 9. SSE / 補助 API
 

--- a/src/app/api/media/files/route.ts
+++ b/src/app/api/media/files/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { mediaItems, boards } from "@/db/schema";
 import { and, eq, inArray } from "drizzle-orm";
-import { getSessionUser } from "@/lib/auth";
+import { getAdminSessionUser } from "@/lib/auth";
 import { emitSSE } from "@/lib/sse";
 import {
   deleteStoredObject,
@@ -24,9 +24,9 @@ import path from "path";
  * For each file, cross-reference the DB to find which boards reference it.
  */
 export async function GET() {
-  const session = await getSessionUser();
+  const session = await getAdminSessionUser();
   if (!session) {
-    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
   }
 
   const storedObjects = await listStoredObjects();
@@ -91,9 +91,9 @@ export async function GET() {
  * Body: { filename: string }
  */
 export async function DELETE(request: NextRequest) {
-  const session = await getSessionUser();
+  const session = await getAdminSessionUser();
   if (!session) {
-    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
   }
 
   let body: { filename?: string };

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { mediaItems, boards } from "@/db/schema";
 import { and, eq, asc, inArray } from "drizzle-orm";
-import { getSessionUser } from "@/lib/auth";
+import { getAdminSessionUser, getSessionUser } from "@/lib/auth";
 import { updateMediaOrderSchema } from "@/lib/validators";
 import { emitSSE } from "@/lib/sse";
 import {
@@ -253,9 +253,9 @@ export async function PATCH(request: NextRequest) {
 }
 
 export async function DELETE() {
-  const session = await getSessionUser();
+  const session = await getAdminSessionUser();
   if (!session) {
-    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
   }
 
   const ownerUserId = resolveOwnerUserId(session.user);

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,15 +1,15 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
-import { getSessionUser } from "@/lib/auth";
+import { getAdminSessionUser } from "@/lib/auth";
 import { listOwnerSettings, upsertOwnerSettings } from "@/lib/owner-settings";
 import { resolveOwnerUserId } from "@/lib/ownership";
 
 /** GET /api/settings — get all settings as key-value object */
 export async function GET() {
-  const session = await getSessionUser();
+  const session = await getAdminSessionUser();
   if (!session) {
-    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
   }
 
   return NextResponse.json(
@@ -19,9 +19,9 @@ export async function GET() {
 
 /** PATCH /api/settings — upsert settings { key: value, ... } */
 export async function PATCH(request: Request) {
-  const session = await getSessionUser();
+  const session = await getAdminSessionUser();
   if (!session) {
-    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
   }
 
   const body = await request.json();

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -97,6 +97,11 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
   const [userIdChangeResult, setUserIdChangeResult] = useState<{ ok: boolean; msg: string } | null>(null);
 
   const fetchMedia = useCallback(async () => {
+    if (role !== "admin") {
+      setMediaLoading(false);
+      return;
+    }
+
     try {
       const res = await fetch("/api/media/files");
       if (res.ok) {
@@ -110,6 +115,11 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
   // Load current settings
   useEffect(() => {
     (async () => {
+      if (role !== "admin") {
+        setLoading(false);
+        return;
+      }
+
       try {
         const res = await fetch("/api/settings");
         if (!res.ok) return;
@@ -171,7 +181,7 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
         }
       })
       .catch(() => {});
-  }, [fetchMedia]);
+  }, [fetchMedia, role]);
 
   function handlePrefChange(prefName: string | null) {
     if (!prefName) return;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -101,3 +101,13 @@ export async function getSessionUser() {
   });
   return session ?? null;
 }
+
+/** Return the current session only when the authenticated user is an admin. */
+export async function getAdminSessionUser() {
+  const session = await getSessionUser();
+  if (!session || session.user.role !== "admin") {
+    return null;
+  }
+
+  return session;
+}


### PR DESCRIPTION
## 概要
- issue #98 に対応し、UI では admin のみに見せていた設定変更・グローバルメディア管理 API をサーバー側でも admin 限定に変更
- `messages` 系の現行仕様もドキュメント上で内部 API として整理

## 変更内容
- `src/lib/auth.ts`
  - admin ユーザー専用の `getAdminSessionUser()` helper を追加
- `src/app/api/settings/route.ts`
  - `GET` / `PATCH` ともに admin セッション必須に変更
- `src/app/api/media/files/route.ts`
  - `GET` / `DELETE` ともに admin セッション必須に変更
- `src/app/api/media/route.ts`
  - 一括削除の `DELETE` を admin セッション必須に変更
  - 通常の `GET` / `POST` / `PATCH` は既存どおり owner scope の session 必須のまま維持
- `src/components/dashboard/SettingsClient.tsx`
  - general ユーザーでは admin 限定 API を fetch しないよう調整
- `docs/API.md`
  - admin 限定 endpoint を明記
  - `POST /api/messages` は現状は内部 API であり、外部公開時は別 endpoint / 別認証が必要である旨を追記

## 確認
- `pnpm build`

Closes #98