### PR TITLE
fix: /api/network を管理者限定にする

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -441,7 +441,7 @@ PIN 設定後、正式な 24 時間セッションへ切り替え、端末単位
 | `GET` | `/api/sse/[boardId]` | ボード単位の SSE ストリーム | 表示画面 |
 | `GET` | `/api/sse` | 誤アクセス時の案内 | なし |
 | `GET` | `/api/weather` | 設定地域の天気取得 | 内部向け / 表示向け |
-| `GET` | `/api/network` | ローカル IPv4 を返す | 内部向け |
+| `GET` | `/api/network` | ローカル IPv4 を返す | `admin` |
 | `GET` | `/api/version` | 現在/最新バージョン情報 | 内部向け |
 
 #### `GET /api/sse/[boardId]`
@@ -458,6 +458,11 @@ data: {}
 - `settings.weatherCityId` を参照します。
 - 30 分のインメモリキャッシュを使います。
 - 返却内容は外部 API レスポンス互換の JSON です。
+
+#### `GET /api/network`
+
+- 管理者セッションがある場合のみ、最初に見つかった非 internal IPv4 を返します。
+- 権限がない場合は `403` を返します。
 
 #### `GET /api/version`
 

--- a/src/app/api/network/route.ts
+++ b/src/app/api/network/route.ts
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 import { networkInterfaces } from "os";
+import { getAdminSessionUser } from "@/lib/auth";
 
 /** GET /api/network — return the first non-internal IPv4 address */
 export async function GET() {
+  const session = await getAdminSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
   const nets = networkInterfaces();
   for (const name of Object.keys(nets)) {
     for (const net of nets[name] ?? []) {

--- a/src/components/dashboard/CallScreenAdmin.tsx
+++ b/src/components/dashboard/CallScreenAdmin.tsx
@@ -41,7 +41,10 @@ export default function CallScreenAdmin({
     (async () => {
       try {
         const res = await fetch("/api/network");
-        if (!res.ok) return;
+        if (!res.ok) {
+          setNetworkOrigin(window.location.origin);
+          return;
+        }
         const data = await res.json();
         if (data.ip) {
           const port = window.location.port;


### PR DESCRIPTION
## 概要
- Issue #96 に対応し、`/api/network` を未認証公開しないようにしました

## 変更内容
- `src/app/api/network/route.ts` で管理者セッション必須に変更
- 権限がない場合は `403` を返すように変更
- `CallScreenAdmin` で `403` / 取得失敗時に `window.location.origin` へフォールバック
- `docs/API.md` に `/api/network` の認証条件を追記

## 確認
- `pnpm build`