### PR TITLE
fix: production では認証 Cookie に Secure を付与する

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,11 @@
 | `device-auth` | 端末単位の完全認証キャッシュ識別 |
 | `signup-request-id` | `/signingup` で仮登録状態を識別 |
 
+補足:
+
+- `auth-session`、`device-auth`、`signup-request-id` は `NODE_ENV=production` のとき `Secure` 属性付きで発行されます。
+- ローカル開発では HTTP 動作を維持するため `Secure` を付与しません。
+
 ### 2.2 認証の考え方
 
 API は大きく 3 種類に分かれます。

--- a/src/app/api/auth/credentials/complete/route.ts
+++ b/src/app/api/auth/credentials/complete/route.ts
@@ -7,6 +7,8 @@ import { db } from "@/db";
 import { authSessions, signupRequests, users } from "@/db/schema";
 import {
   AUTH_SESSION_COOKIE,
+  buildAuthCookieOptions,
+  buildExpiredAuthCookieOptions,
   hashPassword,
 } from "@/lib/auth";
 import {
@@ -106,22 +108,11 @@ export async function POST(request: NextRequest) {
     authenticatedAt: now,
   });
   const res = NextResponse.json({ success: true, userId: createdUser.userId });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: SETUP_SESSION_MAX_AGE,
-  });
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SETUP_SESSION_MAX_AGE));
   setDeviceAuthCookie(res, deviceToken);
   clearLegacyLastUserCookie(res);
   if (cookieStore.get(SIGNUP_REQUEST_COOKIE)) {
-    res.cookies.set(SIGNUP_REQUEST_COOKIE, "", {
-      httpOnly: true,
-      sameSite: "lax",
-      path: "/",
-      maxAge: 0,
-      expires: new Date(0),
-    });
+    res.cookies.set(SIGNUP_REQUEST_COOKIE, "", buildExpiredAuthCookieOptions());
   }
 
   return res;

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -8,6 +8,7 @@ import {
   verifyPassword,
   AUTH_SESSION_COOKIE,
   SESSION_MAX_AGE,
+  buildAuthCookieOptions,
 } from "@/lib/auth";
 import {
   DEVICE_AUTH_COOKIE,
@@ -144,12 +145,7 @@ export async function POST(request: NextRequest) {
   });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: SESSION_MAX_AGE,
-  });
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
   setDeviceAuthCookie(res, deviceToken);
   clearLegacyLastUserCookie(res);
   return res;

--- a/src/app/api/auth/credentials/setup/route.ts
+++ b/src/app/api/auth/credentials/setup/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { signupRequests, users } from "@/db/schema";
 import { eq, or } from "drizzle-orm";
 import { sendOwnerSignupEmail, isSmtpConfigured } from "@/lib/mail";
+import { buildAuthCookieOptions } from "@/lib/auth";
 import {
   SIGNUP_REQUEST_COOKIE,
   SIGNUP_REQUEST_COOKIE_MAX_AGE,
@@ -120,11 +121,10 @@ export async function POST(request: NextRequest) {
     success: true,
     previewUrl: !mailSent ? signupUrl : null,
   });
-  res.cookies.set(SIGNUP_REQUEST_COOKIE, signupRequest.id, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: SIGNUP_REQUEST_COOKIE_MAX_AGE,
-  });
+  res.cookies.set(
+    SIGNUP_REQUEST_COOKIE,
+    signupRequest.id,
+    buildAuthCookieOptions(SIGNUP_REQUEST_COOKIE_MAX_AGE),
+  );
   return res;
 }

--- a/src/app/api/auth/pin/logout/route.ts
+++ b/src/app/api/auth/pin/logout/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { authSessions } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { AUTH_SESSION_COOKIE, buildExpiredAuthCookieOptions } from "@/lib/auth";
 import { clearLegacyLastUserCookie } from "@/lib/device-auth";
 import { cookies } from "next/headers";
 
@@ -22,13 +22,7 @@ export async function POST() {
   }
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 0,
-    expires: new Date(0),
-  });
+  res.cookies.set(AUTH_SESSION_COOKIE, "", buildExpiredAuthCookieOptions());
   clearLegacyLastUserCookie(res);
   return res;
 }

--- a/src/app/api/auth/pin/setup/route.ts
+++ b/src/app/api/auth/pin/setup/route.ts
@@ -10,6 +10,7 @@ import {
   SESSION_MAX_AGE,
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
+  buildAuthCookieOptions,
   isFullAuthValid,
 } from "@/lib/auth";
 import {
@@ -115,12 +116,7 @@ export async function POST(request: NextRequest) {
   });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, fullSessionToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: SESSION_MAX_AGE,
-  });
+  res.cookies.set(AUTH_SESSION_COOKIE, fullSessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
   if (deviceToken) {
     setDeviceAuthCookie(res, deviceToken);
   }

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -15,6 +15,7 @@ import {
   SESSION_MAX_AGE,
   DEFAULT_AUTH_EXPIRE_DAYS,
   AUTH_EXPIRE_DAYS_KEY,
+  buildAuthCookieOptions,
   isFullAuthValid,
 } from "@/lib/auth";
 import {
@@ -145,12 +146,7 @@ export async function POST(request: NextRequest) {
   });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: SESSION_MAX_AGE,
-  });
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
   if (deviceToken) {
     setDeviceAuthCookie(res, deviceToken);
   }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -34,6 +34,7 @@ export async function verifyPassword(
 
 /** Auth session cookie name */
 export const AUTH_SESSION_COOKIE = "auth-session";
+export const AUTH_COOKIE_SECURE = process.env.NODE_ENV === "production";
 
 /**
  * Legacy cookie that stored the last authenticated userId.
@@ -43,6 +44,23 @@ export const LAST_USER_COOKIE = "last-user-id";
 
 /** PIN session duration: 24 hours (in seconds, for cookie maxAge) */
 export const SESSION_MAX_AGE = 60 * 60 * 24;
+
+export function buildAuthCookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge,
+    secure: AUTH_COOKIE_SECURE,
+  };
+}
+
+export function buildExpiredAuthCookieOptions() {
+  return {
+    ...buildAuthCookieOptions(0),
+    expires: new Date(0),
+  };
+}
 
 /** Default full-auth expiry: 30 days */
 export const DEFAULT_AUTH_EXPIRE_DAYS = 30;

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -5,7 +5,11 @@ import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { deviceAuthGrants } from "@/db/schema";
-import { LAST_USER_COOKIE } from "@/lib/auth";
+import {
+  LAST_USER_COOKIE,
+  buildAuthCookieOptions,
+  buildExpiredAuthCookieOptions,
+} from "@/lib/auth";
 
 export const DEVICE_AUTH_COOKIE = "device-auth";
 export const DEVICE_AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
@@ -61,20 +65,13 @@ export async function storeDeviceFullAuth(params: {
 }
 
 export function setDeviceAuthCookie(response: NextResponse, deviceToken: string) {
-  response.cookies.set(DEVICE_AUTH_COOKIE, deviceToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: DEVICE_AUTH_COOKIE_MAX_AGE,
-  });
+  response.cookies.set(
+    DEVICE_AUTH_COOKIE,
+    deviceToken,
+    buildAuthCookieOptions(DEVICE_AUTH_COOKIE_MAX_AGE),
+  );
 }
 
 export function clearLegacyLastUserCookie(response: NextResponse) {
-  response.cookies.set(LAST_USER_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 0,
-    expires: new Date(0),
-  });
+  response.cookies.set(LAST_USER_COOKIE, "", buildExpiredAuthCookieOptions());
 }


### PR DESCRIPTION
## 概要
- Issue #99 に対応し、production 環境では認証系 Cookie に `Secure` を付けるようにしました

## 変更内容
- `src/lib/auth.ts` に auth cookie option helper を追加
- `auth-session` 発行/削除処理を helper ベースに統一
- `device-auth` と legacy cookie クリア処理も同じ helper を利用
- `signup-request-id` も auth フローの一部として production では `Secure` 付きで発行/削除
- `docs/API.md` に production / local の切り替え条件を追記

## 確認
- `pnpm build`