### PR TITLE
feat: Owner退会フローを追加

### DIFF
--- a/drizzle/0005_harsh_monster_badoon.sql
+++ b/drizzle/0005_harsh_monster_badoon.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "account_deletion_requests" (
+	"id" text PRIMARY KEY NOT NULL,
+	"owner_user_id" text NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"completed_at" text,
+	"created_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	CONSTRAINT "account_deletion_requests_owner_user_id_unique" UNIQUE("owner_user_id"),
+	CONSTRAINT "account_deletion_requests_token_unique" UNIQUE("token")
+);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,840 @@
+{
+  "id": "403aefe8-2675-4ee0-ae09-5f76e71d4f20",
+  "prevId": "9e9df1e2-fc1f-49d0-8fb4-893fd096d2be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_deletion_requests": {
+      "name": "account_deletion_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_deletion_requests_owner_user_id_unique": {
+          "name": "account_deletion_requests_owner_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_user_id"
+          ]
+        },
+        "account_deletion_requests_token_unique": {
+          "name": "account_deletion_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_unique": {
+          "name": "auth_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_owner_user_id_users_id_fk": {
+          "name": "boards_owner_user_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_auth_grants": {
+      "name": "device_auth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token_hash": {
+          "name": "device_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_auth_grants_user_id_users_id_fk": {
+          "name": "device_auth_grants_user_id_users_id_fk",
+          "tableFrom": "device_auth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_auth_grants_device_token_hash_unique": {
+          "name": "device_auth_grants_device_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_attempts": {
+      "name": "pin_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_reset_tokens": {
+      "name": "pin_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pin_reset_tokens_user_id_users_id_fk": {
+          "name": "pin_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "pin_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pin_reset_tokens_token_unique": {
+          "name": "pin_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_owner_user_id_users_id_fk": {
+          "name": "settings_owner_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_owner_user_id_key_pk": {
+          "name": "settings_owner_user_id_key_pk",
+          "columns": [
+            "owner_user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_requests": {
+      "name": "signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_requests_token_unique": {
+          "name": "signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_owner_user_id_users_id_fk": {
+          "name": "users_owner_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777249886716,
       "tag": "0004_tough_silk_fever",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777298550561,
+      "tag": "0005_harsh_monster_badoon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/delete-account/DeleteAccountRequestClient.tsx
+++ b/src/app/(dashboard)/delete-account/DeleteAccountRequestClient.tsx
@@ -1,0 +1,146 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { AlertTriangle, MailWarning } from "lucide-react";
+import type { AccountDeletionSummary } from "@/lib/account-deletion";
+
+type DeleteAccountRequestClientProps = {
+  email: string;
+  summary: AccountDeletionSummary;
+};
+
+export default function DeleteAccountRequestClient({
+  email,
+  summary,
+}: DeleteAccountRequestClientProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  async function handleRequest() {
+    const confirmed = window.confirm(
+      "登録済みメールアドレス宛に退会リンクを送信します。\nメール内のリンクを開くと、アカウントと関連データが削除されます。\n続行しますか？",
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+    setPreviewUrl(null);
+
+    try {
+      const response = await fetch("/api/auth/account-deletion/request", {
+        method: "POST",
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error ?? "退会リンクの送信に失敗しました");
+        return;
+      }
+
+      setSuccess(`退会リンクを ${email} に送信しました。10分以内にメールのリンクを開いてください。`);
+      setPreviewUrl(typeof data.previewUrl === "string" ? data.previewUrl : null);
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const items = [
+    { label: "Ownerアカウント", value: "1件" },
+    { label: "Sharedユーザー", value: `${summary.sharedUserCount}件` },
+    { label: "ボード", value: `${summary.boardCount}件` },
+    { label: "メディア", value: `${summary.mediaCount}件` },
+    { label: "メッセージ", value: `${summary.messageCount}件` },
+    { label: "設定", value: `${summary.settingCount}件` },
+    { label: "Preferences", value: `${summary.preferenceCount}件` },
+  ];
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div>
+        <p className="text-sm text-muted-foreground">Dangerous settings</p>
+        <h1 className="mt-2 text-2xl font-bold text-foreground">Ownerアカウントの退会</h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          普段使わない設定です。退会が完了すると、Ownerアカウントと関連する不揮発データは復元できません。
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-red-200 bg-red-50/70 p-6">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 size-5 text-red-600" />
+          <div className="space-y-2 text-sm text-red-950">
+            <p className="font-semibold">この操作は取り消せません。</p>
+            <p>
+              退会リンクは <span className="font-mono">{email}</span> 宛に送信されます。
+              リンクを開くと、Owner配下の Shared ユーザー、ボード、メディア、設定、Preferences が削除されます。
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border bg-background p-6">
+        <h2 className="text-lg font-semibold">削除される情報</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          現在のOwnerスコープで削除対象になるデータです。
+        </p>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          {items.map((item) => (
+            <div key={item.label} className="rounded-xl border bg-muted/30 px-4 py-3">
+              <p className="text-sm font-medium text-foreground">{item.label}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{item.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 rounded-xl border border-dashed border-muted-foreground/30 px-4 py-3 text-sm text-muted-foreground">
+          ログインセッションとこの端末の認証情報も無効化されます。退会後は 10 秒後にサインアップ画面へ移動します。
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleRequest}
+          disabled={submitting}
+          className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-300"
+        >
+          <MailWarning className="size-4" />
+          {submitting ? "退会リンクを送信中..." : "退会リンクをメールで送る"}
+        </button>
+        <Link
+          href="/settings"
+          className="inline-flex rounded-lg border px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          設定へ戻る
+        </Link>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          <p>{success}</p>
+          {previewUrl && (
+            <p className="mt-2">
+              開発用プレビュー: <a href={previewUrl} className="underline">{previewUrl}</a>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/delete-account/page.tsx
+++ b/src/app/(dashboard)/delete-account/page.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { redirect } from "next/navigation";
+import { getSessionUser } from "@/lib/auth";
+import {
+  getOwnerAccountDeletionSummary,
+  type AccountDeletionSummary,
+} from "@/lib/account-deletion";
+import { isOwnerUser } from "@/lib/ownership";
+import DeleteAccountRequestClient from "./DeleteAccountRequestClient";
+
+export default async function DeleteAccountPage() {
+  const session = await getSessionUser();
+  if (!session) {
+    redirect("/pin");
+  }
+
+  if (!isOwnerUser(session.user)) {
+    redirect("/settings");
+  }
+
+  const summary: AccountDeletionSummary = await getOwnerAccountDeletionSummary(
+    session.user.id,
+  );
+
+  return (
+    <DeleteAccountRequestClient
+      email={session.user.email}
+      summary={summary}
+    />
+  );
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -7,6 +7,7 @@ import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
 import { AUTH_SESSION_COOKIE } from "@/lib/auth";
 import { SettingsClient } from "@/components/dashboard/SettingsClient";
+import { isOwnerUser } from "@/lib/ownership";
 
 export default async function SettingsPage() {
   const cookieStore = await cookies();
@@ -25,7 +26,11 @@ export default async function SettingsPage() {
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold">設定</h1>
-      <SettingsClient role={session.user.role as "admin" | "general"} currentUserId={session.user.userId} />
+      <SettingsClient
+        role={session.user.role as "admin" | "general"}
+        currentUserId={session.user.userId}
+        isOwner={isOwnerUser(session.user)}
+      />
     </div>
   );
 }

--- a/src/app/api/auth/account-deletion/complete/route.ts
+++ b/src/app/api/auth/account-deletion/complete/route.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq, gt, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import { accountDeletionRequests, users } from "@/db/schema";
+import { buildExpiredAuthCookieOptions, AUTH_SESSION_COOKIE } from "@/lib/auth";
+import { deleteOwnerAccount } from "@/lib/account-deletion";
+import {
+  clearDeviceAuthCookie,
+  clearLegacyLastUserCookie,
+} from "@/lib/device-auth";
+import { isOwnerUser } from "@/lib/ownership";
+
+/** POST /api/auth/account-deletion/complete — delete an owner account by email token */
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => null)) as { token?: string } | null;
+  const token = body?.token?.trim();
+
+  if (!token) {
+    return NextResponse.json({ error: "token is required" }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const deletionRequest = await db.query.accountDeletionRequests.findFirst({
+    where: and(
+      eq(accountDeletionRequests.token, token),
+      isNull(accountDeletionRequests.completedAt),
+      gt(accountDeletionRequests.expiresAt, now),
+    ),
+  });
+
+  if (!deletionRequest) {
+    return NextResponse.json(
+      { error: "リンクが無効か、有効期限が切れています" },
+      { status: 404 },
+    );
+  }
+
+  const ownerUser = await db.query.users.findFirst({
+    where: eq(users.id, deletionRequest.ownerUserId),
+  });
+
+  if (!ownerUser || !isOwnerUser(ownerUser)) {
+    await db
+      .delete(accountDeletionRequests)
+      .where(eq(accountDeletionRequests.id, deletionRequest.id));
+
+    return NextResponse.json(
+      { error: "削除対象のOwnerアカウントが見つかりません" },
+      { status: 404 },
+    );
+  }
+
+  const summary = await deleteOwnerAccount({
+    ownerUserId: ownerUser.id,
+    deletionRequestId: deletionRequest.id,
+  });
+
+  const response = NextResponse.json({ success: true, summary });
+  response.cookies.set(AUTH_SESSION_COOKIE, "", buildExpiredAuthCookieOptions());
+  clearDeviceAuthCookie(response);
+  clearLegacyLastUserCookie(response);
+  return response;
+}

--- a/src/app/api/auth/account-deletion/request/route.ts
+++ b/src/app/api/auth/account-deletion/request/route.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { accountDeletionRequests } from "@/db/schema";
+import {
+  AUTH_EXPIRE_DAYS_KEY,
+  DEFAULT_AUTH_EXPIRE_DAYS,
+  getSessionUser,
+  isFullAuthValid,
+} from "@/lib/auth";
+import {
+  computeAccountDeletionExpiry,
+  generateAccountDeletionToken,
+} from "@/lib/account-deletion";
+import { DEVICE_AUTH_COOKIE, getDeviceAuthGrantByToken } from "@/lib/device-auth";
+import { sendAccountDeletionEmail, isSmtpConfigured } from "@/lib/mail";
+import { getOwnerSetting } from "@/lib/owner-settings";
+import { isOwnerUser } from "@/lib/ownership";
+import {
+  buildPublicAppUrl,
+  isUnauthenticatedSignupPreviewEnabled,
+} from "@/lib/public-origin";
+
+/** POST /api/auth/account-deletion/request — send owner account deletion link */
+export async function POST(request: NextRequest) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  if (!isOwnerUser(session.user)) {
+    return NextResponse.json(
+      { error: "Ownerアカウントのみ退会できます" },
+      { status: 403 },
+    );
+  }
+
+  const deviceToken = request.cookies.get(DEVICE_AUTH_COOKIE)?.value;
+  const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
+  const expireSetting = await getOwnerSetting(session.user.id, AUTH_EXPIRE_DAYS_KEY);
+  const expireDays = expireSetting
+    ? parseInt(expireSetting, 10)
+    : DEFAULT_AUTH_EXPIRE_DAYS;
+  const deviceAuthLastFullAuthAt = deviceAuthGrant?.user.id === session.user.id
+    ? deviceAuthGrant.lastFullAuthAt
+    : null;
+
+  if (!isFullAuthValid(deviceAuthLastFullAuthAt, expireDays)) {
+    return NextResponse.json(
+      { error: "メールアドレスとパスワードによる再認証が必要です" },
+      { status: 403 },
+    );
+  }
+
+  const smtpConfigured = isSmtpConfigured();
+  const previewEnabled = isUnauthenticatedSignupPreviewEnabled();
+  if (!smtpConfigured && !previewEnabled) {
+    return NextResponse.json(
+      { error: "この環境では削除リンクを発行できません。SMTP を設定してください" },
+      { status: 503 },
+    );
+  }
+
+  const token = generateAccountDeletionToken();
+  const expiresAt = computeAccountDeletionExpiry();
+  const deletionUrl = buildPublicAppUrl(`/deleting-account/${token}`);
+  if (!deletionUrl) {
+    return NextResponse.json(
+      { error: "APP_PUBLIC_ORIGIN が未設定、または不正です" },
+      { status: 503 },
+    );
+  }
+
+  const existingRequest = await db.query.accountDeletionRequests.findFirst({
+    where: eq(accountDeletionRequests.ownerUserId, session.user.id),
+  });
+
+  if (existingRequest) {
+    await db
+      .update(accountDeletionRequests)
+      .set({ token, expiresAt, completedAt: null })
+      .where(eq(accountDeletionRequests.id, existingRequest.id));
+  } else {
+    await db.insert(accountDeletionRequests).values({
+      ownerUserId: session.user.id,
+      token,
+      expiresAt,
+    });
+  }
+
+  const mailSent = smtpConfigured
+    ? await sendAccountDeletionEmail(session.user.email, deletionUrl)
+    : false;
+
+  if (!mailSent && smtpConfigured) {
+    return NextResponse.json(
+      { error: "削除確認メールの送信に失敗しました。時間を置いて再度お試しください" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    previewUrl: previewEnabled ? deletionUrl : null,
+  });
+}

--- a/src/app/deleted-account/DeletedAccountClient.tsx
+++ b/src/app/deleted-account/DeletedAccountClient.tsx
@@ -1,0 +1,58 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { CheckCircle2 } from "lucide-react";
+import { KeinageLogo } from "@/components/KeinageLogo";
+
+const REDIRECT_SECONDS = 10;
+
+export default function DeletedAccountClient() {
+  const router = useRouter();
+  const [secondsLeft, setSecondsLeft] = useState(REDIRECT_SECONDS);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setSecondsLeft((current) => {
+        if (current <= 1) {
+          window.clearInterval(intervalId);
+          router.replace("/signup");
+          return 0;
+        }
+        return current - 1;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-emerald-50 to-slate-100 p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 flex flex-col items-center gap-3">
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
+          <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
+        </div>
+
+        <div className="rounded-2xl border bg-white p-8 text-center shadow-sm">
+          <div className="flex flex-col items-center gap-3">
+            <CheckCircle2 className="size-10 text-emerald-600" />
+            <h2 className="text-lg font-bold text-gray-900">アカウント削除が完了しました</h2>
+            <p className="text-sm leading-6 text-gray-500">
+              Ownerアカウントと関連データを削除しました。{secondsLeft} 秒後にサインアップ画面へ移動します。
+            </p>
+            <Link
+              href="/signup"
+              className="mt-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+            >
+              今すぐサインアップへ移動
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deleted-account/page.tsx
+++ b/src/app/deleted-account/page.tsx
@@ -1,0 +1,7 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import DeletedAccountClient from "./DeletedAccountClient";
+
+export default function DeletedAccountPage() {
+  return <DeletedAccountClient />;
+}

--- a/src/app/deleting-account/[token]/DeletingAccountClient.tsx
+++ b/src/app/deleting-account/[token]/DeletingAccountClient.tsx
@@ -1,0 +1,90 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, LoaderCircle } from "lucide-react";
+import { KeinageLogo } from "@/components/KeinageLogo";
+
+type DeletingAccountClientProps = {
+  token: string;
+};
+
+export default function DeletingAccountClient({ token }: DeletingAccountClientProps) {
+  const router = useRouter();
+  const startedRef = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+
+    void (async () => {
+      try {
+        const response = await fetch("/api/auth/account-deletion/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token }),
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+          setError(data.error ?? "アカウント削除に失敗しました");
+          return;
+        }
+
+        router.replace("/deleted-account");
+      } catch {
+        setError("通信エラーが発生しました");
+      }
+    })();
+  }, [router, token]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-red-50 to-slate-100 p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 flex flex-col items-center gap-3">
+          <KeinageLogo className="h-12 w-auto text-gray-900" />
+          <h1 className="text-xl font-bold text-gray-900">Keinage</h1>
+        </div>
+
+        <div className="rounded-2xl border bg-white p-8 shadow-sm">
+          {error ? (
+            <div className="flex flex-col items-center gap-3 text-center">
+              <AlertTriangle className="size-9 text-red-600" />
+              <h2 className="text-lg font-bold text-gray-900">アカウントを削除できませんでした</h2>
+              <p className="text-sm text-gray-500">{error}</p>
+              <div className="flex flex-wrap justify-center gap-3 pt-2">
+                <Link
+                  href="/signup"
+                  className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+                >
+                  サインアップへ
+                </Link>
+                <Link
+                  href="/pin"
+                  className="rounded-lg border px-4 py-2 text-sm font-semibold text-gray-700"
+                >
+                  ログインへ
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-3 text-center">
+              <LoaderCircle className="size-9 animate-spin text-red-600" />
+              <h2 className="text-lg font-bold text-gray-900">アカウントを削除しています</h2>
+              <p className="text-sm leading-6 text-gray-500">
+                Ownerアカウント、Shared ユーザー、ボード、メディア、設定、Preferences を削除しています。
+                完了後、自動で完了画面へ移動します。
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deleting-account/[token]/page.tsx
+++ b/src/app/deleting-account/[token]/page.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { notFound } from "next/navigation";
+import { and, eq, gt, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import { accountDeletionRequests } from "@/db/schema";
+import DeletingAccountClient from "./DeletingAccountClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function DeletingAccountPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const now = new Date().toISOString();
+
+  const deletionRequest = await db.query.accountDeletionRequests.findFirst({
+    where: and(
+      eq(accountDeletionRequests.token, token),
+      isNull(accountDeletionRequests.completedAt),
+      gt(accountDeletionRequests.expiresAt, now),
+    ),
+  });
+
+  if (!deletionRequest) {
+    notFound();
+  }
+
+  return <DeletingAccountClient token={token} />;
+}

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { Label } from "@/components/ui/label";
 import {
@@ -38,7 +39,15 @@ interface VersionInfo {
   hasUpdate: boolean;
 }
 
-export function SettingsClient({ role, currentUserId }: { role: "admin" | "general"; currentUserId: string }) {
+export function SettingsClient({
+  role,
+  currentUserId,
+  isOwner,
+}: {
+  role: "admin" | "general";
+  currentUserId: string;
+  isOwner: boolean;
+}) {
   const [cityId, setCityId] = useState(DEFAULT_CITY_ID);
   const [selectedPref, setSelectedPref] = useState<WeatherPrefecture | null>(
     null,
@@ -1202,6 +1211,24 @@ export function SettingsClient({ role, currentUserId }: { role: "admin" | "gener
           </div>
         </div>
       </div>}
+
+      {isOwner && (
+        <div className="rounded-lg border border-red-300 bg-red-50/60 p-6">
+          <p className="text-sm font-medium text-red-700">Dangerous settings</p>
+          <h2 className="mt-2 text-lg font-semibold text-red-950">Ownerアカウントの退会</h2>
+          <p className="mt-3 text-sm leading-6 text-red-900/80">
+            普段使わない設定です。メールで送られる退会リンクを開くと、Owner配下の Shared ユーザー、ボード、メディア、設定、Preferences が削除されます。
+          </p>
+          <div className="mt-4">
+            <Link
+              href="/delete-account"
+              className="inline-flex rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700"
+            >
+              退会設定を開く
+            </Link>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -127,6 +127,23 @@ export const signupRequests = pgTable("signup_requests", {
     .$onUpdate(() => new Date().toISOString()),
 });
 
+export const accountDeletionRequests = pgTable("account_deletion_requests", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => randomUUID()),
+  ownerUserId: text("owner_user_id").notNull().unique(),
+  token: text("token").notNull().unique(),
+  expiresAt: text("expires_at").notNull(),
+  completedAt: text("completed_at"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(isoNow),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(isoNow)
+    .$onUpdate(() => new Date().toISOString()),
+});
+
 // ── New auth tables ─────────────────────────────────────
 
 export const users = pgTable("users", {

--- a/src/lib/account-deletion.ts
+++ b/src/lib/account-deletion.ts
@@ -1,0 +1,144 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { randomUUID } from "crypto";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  accountDeletionRequests,
+  boards,
+  mediaItems,
+  messages,
+  settings,
+  users,
+} from "@/db/schema";
+import {
+  deleteStoredObject,
+  storageKeyFromPublicPath,
+  thumbnailStorageKeyFromPublicPath,
+} from "@/lib/media-storage";
+
+export const ACCOUNT_DELETION_TOKEN_TTL_MS = 10 * 60 * 1000;
+
+export type AccountDeletionSummary = {
+  userCount: number;
+  sharedUserCount: number;
+  boardCount: number;
+  mediaCount: number;
+  messageCount: number;
+  settingCount: number;
+  preferenceCount: number;
+};
+
+type OwnerDeletionData = {
+  sharedUserIds: string[];
+  boardIds: string[];
+  mediaFilePaths: string[];
+  summary: AccountDeletionSummary;
+};
+
+export function generateAccountDeletionToken(): string {
+  return randomUUID();
+}
+
+export function computeAccountDeletionExpiry(): string {
+  return new Date(Date.now() + ACCOUNT_DELETION_TOKEN_TTL_MS).toISOString();
+}
+
+async function collectOwnerDeletionData(ownerUserId: string): Promise<OwnerDeletionData> {
+  const [sharedUsers, ownedBoards, ownerSettings] = await Promise.all([
+    db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.ownerUserId, ownerUserId)),
+    db
+      .select({ id: boards.id })
+      .from(boards)
+      .where(eq(boards.ownerUserId, ownerUserId)),
+    db
+      .select({ key: settings.key })
+      .from(settings)
+      .where(eq(settings.ownerUserId, ownerUserId)),
+  ]);
+
+  const boardIds = ownedBoards.map((board) => board.id);
+
+  const [ownedMedia, ownedMessages] = await Promise.all([
+    boardIds.length > 0
+      ? db
+          .select({ filePath: mediaItems.filePath })
+          .from(mediaItems)
+          .where(inArray(mediaItems.boardId, boardIds))
+      : Promise.resolve([]),
+    boardIds.length > 0
+      ? db
+          .select({ id: messages.id })
+          .from(messages)
+          .where(inArray(messages.boardId, boardIds))
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    sharedUserIds: sharedUsers.map((user) => user.id),
+    boardIds,
+    mediaFilePaths: ownedMedia.map((item) => item.filePath),
+    summary: {
+      userCount: sharedUsers.length + 1,
+      sharedUserCount: sharedUsers.length,
+      boardCount: boardIds.length,
+      mediaCount: ownedMedia.length,
+      messageCount: ownedMessages.length,
+      settingCount: ownerSettings.length,
+      preferenceCount: sharedUsers.length + 1,
+    },
+  };
+}
+
+export async function getOwnerAccountDeletionSummary(
+  ownerUserId: string,
+): Promise<AccountDeletionSummary> {
+  const { summary } = await collectOwnerDeletionData(ownerUserId);
+  return summary;
+}
+
+export async function deleteOwnerAccount(params: {
+  ownerUserId: string;
+  deletionRequestId: string;
+}) {
+  const deletionData = await collectOwnerDeletionData(params.ownerUserId);
+
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(accountDeletionRequests)
+      .where(eq(accountDeletionRequests.id, params.deletionRequestId));
+
+    if (deletionData.sharedUserIds.length > 0) {
+      await tx
+        .delete(users)
+        .where(inArray(users.id, deletionData.sharedUserIds));
+    }
+
+    await tx.delete(users).where(eq(users.id, params.ownerUserId));
+  });
+
+  for (const filePath of deletionData.mediaFilePaths) {
+    try {
+      await deleteStoredObject(storageKeyFromPublicPath(filePath));
+    } catch (error) {
+      console.error("[account-deletion] Failed to delete media file", {
+        filePath,
+        error,
+      });
+    }
+
+    try {
+      await deleteStoredObject(thumbnailStorageKeyFromPublicPath(filePath));
+    } catch (error) {
+      console.error("[account-deletion] Failed to delete thumbnail", {
+        filePath,
+        error,
+      });
+    }
+  }
+
+  return deletionData.summary;
+}

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -72,6 +72,10 @@ export function setDeviceAuthCookie(response: NextResponse, deviceToken: string)
   );
 }
 
+export function clearDeviceAuthCookie(response: NextResponse) {
+  response.cookies.set(DEVICE_AUTH_COOKIE, "", buildExpiredAuthCookieOptions());
+}
+
 export function clearLegacyLastUserCookie(response: NextResponse) {
   response.cookies.set(LAST_USER_COOKIE, "", buildExpiredAuthCookieOptions());
 }

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -96,3 +96,23 @@ export async function sendOwnerSignupEmail(
     ],
   });
 }
+
+/** Send an owner account deletion confirmation email */
+export async function sendAccountDeletionEmail(
+  to: string,
+  deletionUrl: string,
+): Promise<boolean> {
+  return sendTextMail({
+    to,
+    subject: "[Keinage] アカウント削除確認リンク",
+    lines: [
+      "Keinage のOwnerアカウント削除リクエストを受け付けました。",
+      "",
+      "以下のリンクを開くと、Ownerアカウントと紐づくデータが削除されます：",
+      deletionUrl,
+      "",
+      "このリンクは10分間有効です。",
+      "心当たりがない場合は、このメールを無視してください。",
+    ],
+  });
+}


### PR DESCRIPTION
## 概要
- Owner向けの退会フローを追加しました。
- 設定画面の最下部から退会導線を開き、メールリンクで削除を確定できるようにしました。

## 変更内容
- `delete-account`、`deleting-account/[token]`、`deleted-account` を追加
- Owner限定の退会リンク送信 API と、メールリンクから実削除を行う completion API を追加
- Shared ユーザー、ボード、メディア実ファイル、メッセージ、設定、Preferences をまとめて削除する helper を追加
- `account_deletion_requests` テーブル用の migration を追加
- 設定画面の最下部に `Dangerous settings` セクションを追加

## 確認
- `pnpm build`

Closes #117