### PR TITLE
fix: 画像スライドショーの初回停止を修正

### DIFF
--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -21,6 +21,7 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
   const [currentIndex, setCurrentIndex] = useState(0);
   const [imageLoaded, setImageLoaded] = useState(false);
   const preloadedRef = useRef<Set<string>>(new Set());
+  const currentImageRef = useRef<HTMLImageElement | null>(null);
 
   const advance = useCallback(() => {
     setImageLoaded(false);
@@ -41,6 +42,19 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
       }
     }
   }, [currentIndex, mediaItems]);
+
+  const current = mediaItems[currentIndex];
+
+  useEffect(() => {
+    if (!current) return;
+
+    if (current.type !== "image") {
+      setImageLoaded(true);
+      return;
+    }
+
+    setImageLoaded(Boolean(currentImageRef.current?.complete));
+  }, [current?.id, current?.filePath, current?.type]);
 
   // --- Auto-advance timer (starts only after the current image has loaded) ---
   useEffect(() => {
@@ -84,8 +98,6 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
       </div>
     );
   }
-
-  const current = mediaItems[currentIndex];
   const fitClass = objectFit === "cover" ? "object-cover" : "object-contain";
 
   return (
@@ -110,10 +122,12 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
             />
           ) : (
             <img
+              ref={currentImageRef}
               src={current.filePath}
               alt=""
               className={`h-full w-full ${fitClass}`}
               onLoad={() => setImageLoaded(true)}
+              onError={() => setImageLoaded(true)}
             />
           )}
         </motion.div>


### PR DESCRIPTION
## 概要
- フォトクロックやシンプル掲示板で、複数画像を設定していても初回表示時にスライドショーが進まない不具合を修正しました。
- 原因は `MediaSlider` が画像の `onLoad` だけを頼りにタイマー開始しており、ブラウザキャッシュ済み画像では loaded 状態が立たず停止し続けることでした。

## 変更内容
- `src/components/board/MediaSlider.tsx` を修正
- 現在画像がすでに `complete` な場合でも loaded 扱いにするよう変更
- 画像読み込みエラー時にもスライドショー全体が停止しないようにフォールバックを追加

## 確認
- `pnpm build`

Closes #118