### PR TITLE
security: privateボードのOwnerスコープチェックを追加

### DIFF
--- a/src/app/(board)/[boardId]/page.tsx
+++ b/src/app/(board)/[boardId]/page.tsx
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { eq, asc, and, or, isNull, gt } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
+import { isInOwnerScope } from "@/lib/ownership";
 import { getTemplate } from "@/lib/templates";
 import { normalizeConfig } from "@/lib/utils";
 import LiveBoard from "@/components/board/LiveBoard";
@@ -40,6 +41,10 @@ export default async function BoardPage({
     });
     if (!session) {
       redirect(`/pin?redirectTo=${encodeURIComponent(`/${boardId}`)}`);
+    }
+
+    if (!isInOwnerScope(session.user, board.ownerUserId)) {
+      notFound();
     }
   }
 

--- a/src/app/api/public/boards/[id]/messages/route.ts
+++ b/src/app/api/public/boards/[id]/messages/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { boards, messages } from "@/db/schema";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
+import { isInOwnerScope } from "@/lib/ownership";
 
 export async function GET(
   _request: NextRequest,
@@ -23,6 +24,10 @@ export async function GET(
     const session = await getSessionUser();
     if (!session) {
       return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    if (!isInOwnerScope(session.user, board.ownerUserId)) {
+      return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
   }
 

--- a/src/app/api/public/boards/[id]/route.ts
+++ b/src/app/api/public/boards/[id]/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { asc, eq } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
+import { isInOwnerScope } from "@/lib/ownership";
 import { normalizeConfig } from "@/lib/utils";
 
 export async function GET(
@@ -24,6 +25,10 @@ export async function GET(
     const session = await getSessionUser();
     if (!session) {
       return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    if (!isInOwnerScope(session.user, board.ownerUserId)) {
+      return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
   }
 

--- a/src/app/api/sse/[boardId]/route.ts
+++ b/src/app/api/sse/[boardId]/route.ts
@@ -6,6 +6,7 @@ import { boards } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
 import { addClient, removeClient } from "@/lib/sse";
+import { isInOwnerScope } from "@/lib/ownership";
 
 export const dynamic = "force-dynamic";
 
@@ -29,6 +30,10 @@ export async function GET(
     const session = await getSessionUser();
     if (!session) {
       return new Response("Unauthorized", { status: 401 });
+    }
+
+    if (!isInOwnerScope(session.user, board.ownerUserId)) {
+      return new Response("Board not found", { status: 404 });
     }
   }
 

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -7,7 +7,7 @@ import { eq } from "drizzle-orm";
 import { DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import { getSessionUser } from "@/lib/auth";
 import { getOwnerSetting } from "@/lib/owner-settings";
-import { resolveOwnerUserId } from "@/lib/ownership";
+import { isInOwnerScope, resolveOwnerUserId } from "@/lib/ownership";
 
 const WEATHER_API_BASE = "https://weather.tsukumijima.net/api/forecast/city";
 
@@ -37,6 +37,10 @@ export async function GET(request: NextRequest) {
       const session = await getSessionUser();
       if (!session) {
         return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+      }
+
+      if (!isInOwnerScope(session.user, board.ownerUserId)) {
+        return NextResponse.json({ error: "Board not found" }, { status: 404 });
       }
     }
 

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -22,6 +22,10 @@ export function isSameOwnerScope(left: UserLike, right: UserLike): boolean {
   return resolveOwnerUserId(left) === resolveOwnerUserId(right);
 }
 
+export function isInOwnerScope(user: UserLike, ownerUserId: string): boolean {
+  return resolveOwnerUserId(user) === ownerUserId;
+}
+
 export async function findOwnedBoard(boardId: string, ownerUserId: string) {
   return db.query.boards.findFirst({
     where: and(


### PR DESCRIPTION
## 概要
- private ボードが「ログイン済みなら誰でも見える」状態になっていたため、Owner スコープでのアクセス制御を追加しました。
- 別 Owner が private ボード URL を知っていても閲覧できないように修正しています。

## 原因
- private ボード関連の表示画面 / 公開 API / SSE / weather 取得で、セッションの有無だけを確認しており、`board.ownerUserId` とログインユーザーの Owner スコープ一致を確認していませんでした。

## 変更内容
- `src/lib/ownership.ts`
  - `isInOwnerScope()` helper を追加
- `src/app/(board)/[boardId]/page.tsx`
  - private ボード表示時に Owner スコープ一致を確認し、不一致なら `notFound()` に変更
- `src/app/api/public/boards/[id]/route.ts`
- `src/app/api/public/boards/[id]/messages/route.ts`
- `src/app/api/sse/[boardId]/route.ts`
- `src/app/api/weather/route.ts`
  - private ボード関連の各経路で Owner スコープ不一致時は 404 を返すよう変更

## 確認
- `pnpm build`

Closes #126