### PR TITLE
security: privateボード画像の直リンクに認証を要求する

### DIFF
--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -1,10 +1,35 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import { eq, or } from "drizzle-orm";
+import { db } from "@/db";
+import { boards, mediaItems } from "@/db/schema";
+import { getSessionUser } from "@/lib/auth";
+import { isInOwnerScope } from "@/lib/ownership";
 import { readStoredObject } from "@/lib/media-storage";
 
 /** Disable static caching so newly uploaded files are served immediately. */
 export const dynamic = "force-dynamic";
+
+function buildCandidateMediaPaths(filename: string): string[] {
+  const publicPath = `/uploads/${filename}`;
+  if (!filename.startsWith("thumbs/")) {
+    return [publicPath];
+  }
+
+  const thumbName = path.posix.basename(filename);
+  const ext = path.posix.extname(thumbName).toLowerCase();
+  const base = thumbName.slice(0, thumbName.length - ext.length);
+  const candidates = [`/uploads/${base}${ext}`];
+
+  // GIF thumbnails are generated as JPG files.
+  if (ext === ".jpg") {
+    candidates.push(`/uploads/${base}.gif`);
+  }
+
+  return [...new Set(candidates)];
+}
 
 /**
  * GET /uploads/[...path] — serve uploaded media files.
@@ -20,6 +45,37 @@ export async function GET(
   const segments = await params;
   const filename = segments.path.join("/");
 
+  const candidateMediaPaths = buildCandidateMediaPaths(filename);
+  const mediaRefs = await db
+    .select({
+      visibility: boards.visibility,
+      ownerUserId: boards.ownerUserId,
+    })
+    .from(mediaItems)
+    .innerJoin(boards, eq(mediaItems.boardId, boards.id))
+    .where(
+      candidateMediaPaths.length === 1
+        ? eq(mediaItems.filePath, candidateMediaPaths[0])
+        : or(...candidateMediaPaths.map((filePath) => eq(mediaItems.filePath, filePath))),
+    );
+
+  const hasPublicRef = mediaRefs.some((ref) => ref.visibility === "public");
+  const requiresPrivateScope = mediaRefs.length > 0 && !hasPublicRef;
+
+  if (requiresPrivateScope) {
+    const session = await getSessionUser();
+    if (!session) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    const canAccess = mediaRefs.some((ref) =>
+      isInOwnerScope(session.user, ref.ownerUserId),
+    );
+    if (!canAccess) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+  }
+
   try {
     const object = await readStoredObject(filename);
     if (!object) {
@@ -31,7 +87,9 @@ export async function GET(
       headers: {
         "Content-Type": object.contentType,
         "Content-Length": object.contentLength.toString(),
-        "Cache-Control": "public, max-age=31536000, immutable",
+        "Cache-Control": requiresPrivateScope
+          ? "private, no-store"
+          : "public, max-age=31536000, immutable",
       },
     });
   } catch (error) {


### PR DESCRIPTION
## 概要
- private ボードに紐づく画像が `/uploads/...` の直リンクで誰でも閲覧できる状態だったため、アップロード配信ルートで認証チェックを追加しました。
- public ボードで使われている画像は従来どおり公開しつつ、private ボード専用の画像だけを Owner スコープで保護しています。

## 原因
- `src/app/uploads/[...path]/route.ts` がストレージ上のオブジェクトをそのまま返しており、`media_items` / `boards.visibility` / `ownerUserId` を参照していませんでした。

## 変更内容
- `src/app/uploads/[...path]/route.ts`
  - 要求された `/uploads/...` パスから対応する `media_items.filePath` を解決
  - 対象ファイルが public ボードから参照されていない場合のみ認証を要求
  - private ボード専用画像では、ログインユーザーがその `ownerUserId` の Owner スコープにいるか確認
  - サムネイル (`/uploads/thumbs/...`) も元画像へ逆引きして同じ制御を適用
  - private 用レスポンスは `Cache-Control: private, no-store` に変更

## 確認
- `pnpm build`

Closes #107