### PR TITLE
fix: PIN認証期限切れ時は /pin/login のPIN導線を隠す

### DIFF
--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -8,7 +8,13 @@ import Link from "next/link";
 import { KeyRound } from "lucide-react";
 import { KeinageLogo } from "@/components/KeinageLogo";
 
-export default function LoginClient({ redirectTo }: { redirectTo?: string | null }) {
+export default function LoginClient({
+  redirectTo,
+  showPinLoginLink,
+}: {
+  redirectTo?: string | null;
+  showPinLoginLink: boolean;
+}) {
   const router = useRouter();
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
@@ -125,14 +131,16 @@ export default function LoginClient({ redirectTo }: { redirectTo?: string | null
             </button>
           </form>
 
-          <div className="mt-6 text-center">
-            <Link
-              href={pinLoginHref}
-              className="text-sm text-gray-500 hover:text-blue-600"
-            >
-              PINでログインする
-            </Link>
-          </div>
+          {showPinLoginLink && (
+            <div className="mt-6 text-center">
+              <Link
+                href={pinLoginHref}
+                className="text-sm text-gray-500 hover:text-blue-600"
+              >
+                PINでログインする
+              </Link>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -45,6 +45,29 @@ export default async function LoginPage({
   const sessionCookie = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
   const deviceToken = cookieStore.get(DEVICE_AUTH_COOKIE)?.value;
   const deviceAuthGrant = await getDeviceAuthGrantByToken(deviceToken);
+  let showPinLoginLink = false;
+
+  if (deviceAuthGrant?.user.pinHash) {
+    const expireSetting = await getOwnerSetting(
+      resolveOwnerUserId(deviceAuthGrant.user),
+      AUTH_EXPIRE_DAYS_KEY,
+    );
+    const expireDays = expireSetting
+      ? parseInt(expireSetting, 10)
+      : DEFAULT_AUTH_EXPIRE_DAYS;
+
+    showPinLoginLink = isFullAuthValid(
+      deviceAuthGrant.lastFullAuthAt,
+      expireDays,
+    );
+
+    console.log("[/pin/login] PIN link eligibility", {
+      userId: deviceAuthGrant.user.userId,
+      expireDays,
+      showPinLoginLink,
+    });
+  }
+
   if (sessionCookie) {
     const sessionRow = await db.query.authSessions.findFirst({
       where: and(
@@ -91,5 +114,10 @@ export default async function LoginPage({
   }
 
   console.log("[/pin/login] Rendering LoginClient");
-  return <LoginClient redirectTo={redirectTo} />;
+  return (
+    <LoginClient
+      redirectTo={redirectTo}
+      showPinLoginLink={showPinLoginLink}
+    />
+  );
 }


### PR DESCRIPTION
## 概要
- `/pin/login` で常に表示していた「PINでログインする」導線を、端末ごとの PIN 利用可能期間に応じて出し分けるようにしました。
- 初回ログインや PIN 認証可能期間切れ後はリンクを非表示にし、PIN がまだ使える端末では引き続き表示します。

## 原因
- `/pin/login` の UI が、端末ごとの `device-auth` と full-auth 有効期限を見ずに、PIN ログイン導線を常時表示していました。

## 変更内容
- `src/app/pin/login/page.tsx`
  - `device-auth` と owner の認証期限設定から、現在の端末で PIN ログイン可能かを判定
  - `LoginClient` に `showPinLoginLink` を渡すよう変更
- `src/app/pin/login/LoginClient.tsx`
  - `showPinLoginLink` が true のときだけ「PINでログインする」リンクを表示するよう変更

## 確認
- `pnpm build`

Closes #119