### PR TITLE
[codex] fix user locale isolation

### DIFF
--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -25,6 +25,10 @@ import {
   buildRateLimitKey,
   resolveRateLimitClientIp,
 } from "@/lib/rate-limit";
+import {
+  resolveAuthenticatedLocale,
+  setLocaleCookie,
+} from "@/lib/locale-cookie";
 
 /** POST /api/auth/credentials/login — email/userId + password login */
 export async function POST(request: NextRequest) {
@@ -151,9 +155,14 @@ export async function POST(request: NextRequest) {
     expiresAt,
   });
 
-  const res = NextResponse.json({ success: true });
+  const locale = resolveAuthenticatedLocale({
+    storedLocale: user.locale,
+    acceptLanguage: request.headers.get("accept-language"),
+  });
+  const res = NextResponse.json({ success: true, locale });
   res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
   setDeviceAuthCookie(res, deviceToken);
+  setLocaleCookie(res, locale);
   clearLegacyLastUserCookie(res);
   return res;
 }

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -142,6 +142,8 @@ export async function GET(request: NextRequest) {
       userId: user.id,
       redirectTo: absoluteUrl(request, redirectPath),
       setupSessionMaxAge: user.pinHash ? undefined : SETUP_SESSION_MAX_AGE,
+      locale: user.locale,
+      acceptLanguage: request.headers.get("accept-language"),
     });
     response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
     return response;
@@ -187,6 +189,8 @@ export async function GET(request: NextRequest) {
       userId: createdUser.id,
       redirectTo: absoluteUrl(request, "/pin/setup"),
       setupSessionMaxAge: SETUP_SESSION_MAX_AGE,
+      locale: createdUser.locale,
+      acceptLanguage: request.headers.get("accept-language"),
     });
     response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
     return response;
@@ -257,6 +261,8 @@ export async function GET(request: NextRequest) {
       userId: createdUser.id,
       redirectTo: absoluteUrl(request, "/pin/setup"),
       setupSessionMaxAge: SETUP_SESSION_MAX_AGE,
+      locale: createdUser.locale,
+      acceptLanguage: request.headers.get("accept-language"),
     });
     response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
     return response;

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -32,6 +32,10 @@ import {
   buildRateLimitKey,
   resolveRateLimitClientIp,
 } from "@/lib/rate-limit";
+import {
+  resolveAuthenticatedLocale,
+  setLocaleCookie,
+} from "@/lib/locale-cookie";
 
 /** POST /api/auth/pin/verify — verify PIN and issue session */
 export async function POST(request: NextRequest) {
@@ -154,11 +158,16 @@ export async function POST(request: NextRequest) {
     expiresAt,
   });
 
-  const res = NextResponse.json({ success: true });
+  const locale = resolveAuthenticatedLocale({
+    storedLocale: adminUser.locale,
+    acceptLanguage: request.headers.get("accept-language"),
+  });
+  const res = NextResponse.json({ success: true, locale });
   res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
   if (deviceToken) {
     setDeviceAuthCookie(res, deviceToken);
   }
+  setLocaleCookie(res, locale);
   clearLegacyLastUserCookie(res);
   return res;
 }

--- a/src/app/pin/PinLoginClient.tsx
+++ b/src/app/pin/PinLoginClient.tsx
@@ -9,6 +9,7 @@ import { Lock } from "lucide-react";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { PinInput } from "@/components/auth/PinInput";
 import { KeinageLogo } from "@/components/KeinageLogo";
+import { isSupportedLocale } from "@/lib/i18n";
 
 export default function PinLoginClient({
   userId,
@@ -18,7 +19,7 @@ export default function PinLoginClient({
   redirectTo?: string | null;
 }) {
   const router = useRouter();
-  const { t } = useLocale();
+  const { t, setLocale } = useLocale();
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
   const [verifying, setVerifying] = useState(false);
@@ -50,6 +51,10 @@ export default function PinLoginClient({
           return;
         }
 
+        if (isSupportedLocale(data.locale)) {
+          setLocale(data.locale);
+        }
+
         router.push(redirectTo || "/boards");
       } catch {
         setError(t("error.network"));
@@ -57,7 +62,7 @@ export default function PinLoginClient({
         setVerifying(false);
       }
     },
-    [router, redirectTo, verifying, blocked, t],
+    [router, redirectTo, verifying, blocked, t, setLocale],
   );
 
   const accountLoginHref = redirectTo

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -9,6 +9,7 @@ import { KeyRound } from "lucide-react";
 import { GoogleAuthButton } from "@/components/auth/GoogleAuthButton";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { KeinageLogo } from "@/components/KeinageLogo";
+import { isSupportedLocale } from "@/lib/i18n";
 
 export default function LoginClient({
   redirectTo,
@@ -20,7 +21,7 @@ export default function LoginClient({
   googleAuthEnabled: boolean;
 }) {
   const router = useRouter();
-  const { t } = useLocale();
+  const { t, setLocale } = useLocale();
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -52,6 +53,10 @@ export default function LoginClient({
           return;
         }
 
+        if (isSupportedLocale(data.locale)) {
+          setLocale(data.locale);
+        }
+
         router.push(redirectTo || "/boards");
       } catch {
         setError(t("error.network"));
@@ -59,7 +64,7 @@ export default function LoginClient({
         setSubmitting(false);
       }
     },
-    [router, redirectTo, identifier, password, submitting, blocked, t],
+    [router, redirectTo, identifier, password, submitting, blocked, t, setLocale],
   );
 
   const pinLoginHref = redirectTo

--- a/src/components/i18n/LocaleProvider.tsx
+++ b/src/components/i18n/LocaleProvider.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import {
   DEFAULT_LOCALE,
   LOCALE_COOKIE_NAME,
+  isSupportedLocale,
   formatDate,
   formatDateTime,
   formatTime,
@@ -52,13 +53,22 @@ export function LocaleProvider({
   const [locale, setLocaleState] = useState<SupportedLocale>(initialLocale);
 
   useEffect(() => {
+    setLocaleState(initialLocale);
+  }, [initialLocale]);
+
+  useEffect(() => {
     document.documentElement.lang = locale;
     document.cookie = `${LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
   }, [locale]);
 
+  const setLocale = (nextLocale: SupportedLocale) => {
+    if (!isSupportedLocale(nextLocale)) return;
+    setLocaleState(nextLocale);
+  };
+
   const value: LocaleContextValue = {
     locale,
-    setLocale: setLocaleState,
+    setLocale,
     t: (key, vars) => translate(locale, key, vars),
     formatDate: (value, options) => formatDate(value, locale, options),
     formatDateTime: (value, options) => formatDateTime(value, locale, options),

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -23,6 +23,10 @@ import {
 } from "@/lib/oidc";
 import { generateSessionToken } from "@/lib/pin";
 import { buildPublicAppUrl } from "@/lib/public-origin";
+import {
+  resolveAuthenticatedLocale,
+  setLocaleCookie,
+} from "@/lib/locale-cookie";
 
 export const GOOGLE_OAUTH_STATE_COOKIE = "google-oauth-state";
 export const GOOGLE_OAUTH_STATE_MAX_AGE = 60 * 10;
@@ -126,6 +130,8 @@ export async function createSignedInResponse(input: {
   userId: string;
   redirectTo: string;
   setupSessionMaxAge?: number;
+  locale?: string | null;
+  acceptLanguage?: string | null;
 }) {
   const now = new Date().toISOString();
   const sessionToken = generateSessionToken();
@@ -151,6 +157,13 @@ export async function createSignedInResponse(input: {
     buildAuthCookieOptions(sessionMaxAge),
   );
   setDeviceAuthCookie(response, deviceToken);
+  setLocaleCookie(
+    response,
+    resolveAuthenticatedLocale({
+      storedLocale: input.locale,
+      acceptLanguage: input.acceptLanguage,
+    }),
+  );
   clearLegacyLastUserCookie(response);
   return response;
 }

--- a/src/lib/i18n-server.ts
+++ b/src/lib/i18n-server.ts
@@ -13,14 +13,21 @@ import {
   translate,
   translateWeatherTelop,
 } from "@/lib/i18n";
+import { resolveAuthenticatedLocale } from "@/lib/locale-cookie";
 
 export async function getRequestLocale() {
   const cookieStore = await cookies();
   const headerStore = await headers();
   const session = await getSessionUser();
 
+  if (session) {
+    return resolveAuthenticatedLocale({
+      storedLocale: session.user.locale,
+      acceptLanguage: headerStore.get("accept-language"),
+    });
+  }
+
   return resolvePreferredLocale({
-    storedLocale: session?.user.locale,
     cookieLocale: cookieStore.get(LOCALE_COOKIE_NAME)?.value ?? null,
     acceptLanguage: headerStore.get("accept-language"),
   });

--- a/src/lib/locale-cookie.ts
+++ b/src/lib/locale-cookie.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import type { NextResponse } from "next/server";
+import {
+  LOCALE_COOKIE_NAME,
+  resolvePreferredLocale,
+  type SupportedLocale,
+} from "@/lib/i18n";
+
+const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+export function resolveAuthenticatedLocale(input: {
+  storedLocale?: string | null;
+  acceptLanguage?: string | null;
+}): SupportedLocale {
+  return resolvePreferredLocale({
+    storedLocale: input.storedLocale,
+    cookieLocale: null,
+    acceptLanguage: input.acceptLanguage,
+  });
+}
+
+export function setLocaleCookie(response: NextResponse, locale: SupportedLocale) {
+  response.cookies.set(LOCALE_COOKIE_NAME, locale, {
+    httpOnly: false,
+    sameSite: "lax",
+    path: "/",
+    maxAge: LOCALE_COOKIE_MAX_AGE,
+    secure: process.env.NODE_ENV === "production",
+  });
+}


### PR DESCRIPTION
## Summary
- Isolate authenticated locale resolution from shared locale cookies
- Sync authenticated locale after credentials, PIN, and Google login
- Keep the client locale provider aligned when the server initial locale changes

## Root Cause
The shared keinage-locale cookie could remain from a previous user on the same browser and influence the next authenticated user's i18n state.

## Validation
- pnpm exec eslint <changed files>
- pnpm exec tsc --noEmit
- pnpm build

Note: pnpm lint still fails on pre-existing React Hooks/Compiler issues outside this change.