### PR TITLE
[codex] 40x/50xエラー画面をアプリ固有デザインにする

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,24 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect } from "react";
+import { ErrorScreen } from "@/components/ErrorScreen";
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <ErrorScreen
+      statusLabel="500 / Server Error"
+      title="エラーが発生しました"
+      description="処理中に問題が発生しました。しばらくしてから再度お試しください。"
+    />
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,28 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect } from "react";
+import { ErrorScreen } from "@/components/ErrorScreen";
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body>
+        <ErrorScreen
+          statusLabel="500 / Server Error"
+          title="重大なエラーが発生しました"
+          description="画面を表示できませんでした。時間をおいて再度アクセスしてください。"
+        />
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { ErrorScreen } from "@/components/ErrorScreen";
+
+export default function NotFound() {
+  return (
+    <ErrorScreen
+      statusLabel="404 / Not Found"
+      title="ページが見つかりません"
+      description="指定されたページは削除されたか、URL が間違っている可能性があります。"
+    />
+  );
+}

--- a/src/components/ErrorScreen.tsx
+++ b/src/components/ErrorScreen.tsx
@@ -1,0 +1,40 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import Link from "next/link";
+import { KeinageLogo } from "@/components/KeinageLogo";
+
+export function ErrorScreen({
+  statusLabel,
+  title,
+  description,
+}: {
+  statusLabel: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-white px-4 py-10 text-slate-900">
+      <div className="w-full max-w-md text-center">
+        <div className="mb-8 flex flex-col items-center gap-3">
+          <KeinageLogo className="h-14 w-auto text-slate-900" />
+          <p className="text-sm font-semibold tracking-wide text-slate-500">
+            {statusLabel}
+          </p>
+        </div>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+          <h1 className="text-xl font-bold text-slate-950">{title}</h1>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            {description}
+          </p>
+          <Link
+            href="/pin/login"
+            className="mt-6 inline-flex min-h-11 items-center justify-center rounded-lg bg-slate-950 px-5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2"
+          >
+            管理者画面へログインする
+          </Link>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要
- 404 用の `not-found.tsx` を追加し、アプリ固有のエラー画面を表示するようにしました。
- 500 系の `error.tsx` と `global-error.tsx` を追加しました。
- 共通の `ErrorScreen` コンポーネントで、中央の Keinage ロゴ、エラー要約、管理者ログインボタンを表示します。

## 対応 Issue
- Closes #122

## 確認内容
- `pnpm exec eslint src/components/ErrorScreen.tsx src/app/not-found.tsx src/app/error.tsx src/app/global-error.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`

## 補足
- `docker-compose.yml` にローカルの未コミット変更がありますが、この PR には含めていません。
