### PR TITLE
[codex] signupとlogin導線を改善する

### DIFF
--- a/src/app/api/auth/credentials/setup/route.ts
+++ b/src/app/api/auth/credentials/setup/route.ts
@@ -69,7 +69,10 @@ export async function POST(request: NextRequest) {
   });
   if (existingUser) {
     return NextResponse.json(
-      { error: "同じユーザーID・メールアドレス・電話番号では登録できません" },
+      {
+        code: "user_exists",
+        error: "登録済みのユーザーがあります。ログインしてください",
+      },
       { status: 409 },
     );
   }

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -32,6 +32,14 @@ function errorRedirect(request: NextRequest, pathname: string, message: string) 
   return response;
 }
 
+function noticeRedirect(request: NextRequest, pathname: string, notice: string) {
+  const url = new URL(absoluteUrl(request, pathname));
+  url.searchParams.set("notice", notice);
+  const response = NextResponse.redirect(url);
+  response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
+  return response;
+}
+
 function createGoogleUserIdBase(email: string) {
   const localPart = email.split("@")[0] ?? "";
   const normalized = localPart
@@ -160,7 +168,7 @@ export async function GET(request: NextRequest) {
       where: eq(users.email, googleUser.email),
     });
     if (existingAccount || existingUser) {
-      return errorRedirect(request, "/signup", "user-already-exists");
+      return noticeRedirect(request, "/pin/login", "signup-existing");
     }
 
     const userId = await buildUniqueGoogleUserId(googleUser.email);

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -13,10 +13,12 @@ import { isSupportedLocale } from "@/lib/i18n";
 
 export default function LoginClient({
   redirectTo,
+  notice,
   showPinLoginLink,
   googleAuthEnabled,
 }: {
   redirectTo?: string | null;
+  notice?: "signup-existing" | null;
   showPinLoginLink: boolean;
   googleAuthEnabled: boolean;
 }) {
@@ -92,6 +94,12 @@ export default function LoginClient({
             </p>
           </div>
 
+          {notice === "signup-existing" && (
+            <p className="mb-4 rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-center text-sm text-blue-700">
+              すでに登録済みのアカウントがあります。ログインしてください。
+            </p>
+          )}
+
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label
@@ -157,16 +165,22 @@ export default function LoginClient({
             </div>
           )}
 
-          {showPinLoginLink && (
-            <div className="mt-6 text-center">
+          <div className="mt-6 space-y-3 text-center">
+            {showPinLoginLink && (
               <Link
                 href={pinLoginHref}
-                className="text-sm text-gray-500 hover:text-blue-600"
+                className="block text-sm text-gray-500 hover:text-blue-600"
               >
                 {t("auth.login.loginWithPin")}
               </Link>
-            </div>
-          )}
+            )}
+            <Link
+              href="/signup"
+              className="block text-sm text-gray-500 hover:text-blue-600"
+            >
+              アカウントを作成する
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -26,13 +26,17 @@ export const dynamic = "force-dynamic";
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ redirectTo?: string | string[] }>;
+  searchParams: Promise<{
+    redirectTo?: string | string[];
+    notice?: string | string[];
+  }>;
 }) {
   console.log("[/pin/login] START");
   const params = await searchParams;
   const redirectTo = sanitizeRedirectTarget(
     typeof params.redirectTo === "string" ? params.redirectTo : null,
   );
+  const notice = typeof params.notice === "string" ? params.notice : null;
 
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
@@ -118,6 +122,7 @@ export default async function LoginPage({
   return (
     <LoginClient
       redirectTo={redirectTo}
+      notice={notice === "signup-existing" ? "signup-existing" : null}
       showPinLoginLink={showPinLoginLink}
       googleAuthEnabled={isGoogleAuthEnabled()}
     />

--- a/src/app/signup/SignupRequestClient.tsx
+++ b/src/app/signup/SignupRequestClient.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { MailPlus } from "lucide-react";
 import { GoogleAuthButton } from "@/components/auth/GoogleAuthButton";
 import { useLocale } from "@/components/i18n/LocaleProvider";
@@ -11,15 +12,17 @@ import { KeinageLogo } from "@/components/KeinageLogo";
 
 export default function SignupRequestClient({
   googleAuthEnabled,
+  initialError,
 }: {
   googleAuthEnabled: boolean;
+  initialError?: string | null;
 }) {
   const router = useRouter();
   const { t } = useLocale();
   const [userId, setUserId] = useState("");
   const [email, setEmail] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
-  const [error, setError] = useState("");
+  const [error, setError] = useState(initialError ?? "");
   const [submitting, setSubmitting] = useState(false);
 
   async function handleSubmit(event: React.FormEvent) {
@@ -40,6 +43,10 @@ export default function SignupRequestClient({
       const data = await res.json();
 
       if (!res.ok) {
+        if (res.status === 409 && data.code === "user_exists") {
+          router.push("/pin/login?notice=signup-existing");
+          return;
+        }
         setError(data.error || t("auth.signupRequest.failed"));
         return;
       }
@@ -145,6 +152,15 @@ export default function SignupRequestClient({
               </GoogleAuthButton>
             </div>
           )}
+
+          <div className="mt-6 text-center">
+            <Link
+              href="/pin/login"
+              className="text-sm text-gray-500 hover:text-blue-600"
+            >
+              すでにアカウントをお持ちの方はログイン
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,6 +5,25 @@ import { isGoogleAuthEnabled } from "@/lib/google-auth";
 
 export const dynamic = "force-dynamic";
 
-export default function SignupPage() {
-  return <SignupRequestClient googleAuthEnabled={isGoogleAuthEnabled()} />;
+const SIGNUP_ERROR_MESSAGES: Record<string, string> = {
+  "user-already-exists": "登録済みのユーザーがあります。ログインしてください。",
+};
+
+export default async function SignupPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string | string[] }>;
+}) {
+  const params = await searchParams;
+  const errorCode = typeof params.error === "string" ? params.error : null;
+  const initialError = errorCode
+    ? SIGNUP_ERROR_MESSAGES[errorCode] ?? "登録に失敗しました。時間を置いて再度お試しください。"
+    : null;
+
+  return (
+    <SignupRequestClient
+      googleAuthEnabled={isGoogleAuthEnabled()}
+      initialError={initialError}
+    />
+  );
 }


### PR DESCRIPTION
## 概要
- signup で既存のユーザーID・メールアドレス・電話番号が見つかった場合、ログイン画面へ誘導するようにしました。
- signup のその他の失敗は画面内にエラーとして表示します。
- signup 画面にログイン導線を追加し、ログイン画面に signup 導線を追加しました。
- Google owner signup の既存アカウント衝突もログイン画面へ誘導します。

## 対応 Issue
- Closes #140

## 確認内容
- `pnpm exec eslint src/app/api/auth/credentials/setup/route.ts src/app/signup/page.tsx src/app/signup/SignupRequestClient.tsx src/app/pin/login/page.tsx src/app/pin/login/LoginClient.tsx src/app/api/auth/google/callback/route.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`

## 補足
- `docker-compose.yml` にローカルの未コミット変更がありますが、この PR には含めていません。
