### PR TITLE
[codex] Billing modeとPlan基盤を追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,25 @@ GOOGLE_OAUTH_ENABLED=false
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 
+# Optional billing / plan foundation.
+# Self-hosted defaults: billing disabled and plan enforcement unlimited.
+# Official SaaS can set BILLING_MODE=stripe and PLAN_ENFORCEMENT_MODE=billing.
+BILLING_MODE=disabled
+# disabled | stripe
+PLAN_ENFORCEMENT_MODE=unlimited
+# unlimited | local | billing
+
+# Stripe Billing settings (only required when BILLING_MODE=stripe).
+# Never commit real secret keys or price IDs.
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_LITE_MONTHLY=
+STRIPE_PRICE_LITE_YEARLY=
+STRIPE_PRICE_STANDARD_MONTHLY=
+STRIPE_PRICE_STANDARD_YEARLY=
+STRIPE_PRICE_STANDARD_PLUS_MONTHLY=
+STRIPE_PRICE_STANDARD_PLUS_YEARLY=
+
 # SMTP settings for PIN reset email (optional)
 # If not configured, unauthenticated email-based signup / PIN reset stays disabled.
 SMTP_HOST=smtp.example.com

--- a/drizzle/0009_woozy_champions.sql
+++ b/drizzle/0009_woozy_champions.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "owner_subscriptions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"owner_user_id" text NOT NULL,
+	"billing_mode" text DEFAULT 'disabled' NOT NULL,
+	"plan_code" text DEFAULT 'free' NOT NULL,
+	"billing_interval" text,
+	"status" text DEFAULT 'none' NOT NULL,
+	"stripe_customer_id" text,
+	"stripe_subscription_id" text,
+	"current_period_end" text,
+	"cancel_at_period_end" boolean DEFAULT false NOT NULL,
+	"created_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "owner_subscriptions" ADD CONSTRAINT "owner_subscriptions_owner_user_id_users_id_fk" FOREIGN KEY ("owner_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "owner_subscriptions_owner_user_id_unique" ON "owner_subscriptions" USING btree ("owner_user_id");--> statement-breakpoint
+CREATE INDEX "owner_subscriptions_stripe_customer_id_idx" ON "owner_subscriptions" USING btree ("stripe_customer_id");--> statement-breakpoint
+CREATE INDEX "owner_subscriptions_stripe_subscription_id_idx" ON "owner_subscriptions" USING btree ("stripe_subscription_id");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1249 @@
+{
+  "id": "87555af0-b0b0-436c-a8a5-763336afe25e",
+  "prevId": "09ccfb68-4237-4071-868f-838c5eee0aae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_deletion_requests": {
+      "name": "account_deletion_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_deletion_requests_owner_user_id_unique": {
+          "name": "account_deletion_requests_owner_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_user_id"
+          ]
+        },
+        "account_deletion_requests_token_unique": {
+          "name": "account_deletion_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "auth_accounts_provider_account_unique": {
+          "name": "auth_accounts_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_unique": {
+          "name": "auth_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_owner_user_id_users_id_fk": {
+          "name": "boards_owner_user_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_auth_grants": {
+      "name": "device_auth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token_hash": {
+          "name": "device_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_auth_grants_user_id_users_id_fk": {
+          "name": "device_auth_grants_user_id_users_id_fk",
+          "tableFrom": "device_auth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_auth_grants_device_token_hash_unique": {
+          "name": "device_auth_grants_device_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_oauth_flows": {
+      "name": "google_oauth_flows",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_to": {
+          "name": "redirect_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_signup_token": {
+          "name": "shared_signup_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owner_subscriptions": {
+      "name": "owner_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "plan_code": {
+          "name": "plan_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "owner_subscriptions_owner_user_id_unique": {
+          "name": "owner_subscriptions_owner_user_id_unique",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owner_subscriptions_stripe_customer_id_idx": {
+          "name": "owner_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owner_subscriptions_stripe_subscription_id_idx": {
+          "name": "owner_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "owner_subscriptions_owner_user_id_users_id_fk": {
+          "name": "owner_subscriptions_owner_user_id_users_id_fk",
+          "tableFrom": "owner_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_attempts": {
+      "name": "pin_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_reset_tokens": {
+      "name": "pin_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pin_reset_tokens_user_id_users_id_fk": {
+          "name": "pin_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "pin_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pin_reset_tokens_token_unique": {
+          "name": "pin_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_owner_user_id_users_id_fk": {
+          "name": "settings_owner_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_owner_user_id_key_pk": {
+          "name": "settings_owner_user_id_key_pk",
+          "columns": [
+            "owner_user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_signup_requests": {
+      "name": "shared_signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_signup_requests_owner_user_id_users_id_fk": {
+          "name": "shared_signup_requests_owner_user_id_users_id_fk",
+          "tableFrom": "shared_signup_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shared_signup_requests_token_unique": {
+          "name": "shared_signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_requests": {
+      "name": "signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_requests_token_unique": {
+          "name": "signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_owner_user_id_users_id_fk": {
+          "name": "users_owner_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777450480097,
       "tag": "0008_loud_dorian_gray",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777532241597,
+      "tag": "0009_woozy_champions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/billing/plan/route.ts
+++ b/src/app/api/billing/plan/route.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from "next/server";
+import { getAdminSessionUser } from "@/lib/auth";
+import { getEffectivePlanForUser } from "@/lib/billing";
+
+/** GET /api/billing/plan — return the current owner billing/plan foundation state */
+export async function GET() {
+  const session = await getAdminSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const effectivePlan = await getEffectivePlanForUser(session.user);
+
+  return NextResponse.json({
+    ownerUserId: effectivePlan.ownerUserId,
+    billingMode: effectivePlan.billingMode,
+    planEnforcementMode: effectivePlan.planEnforcementMode,
+    plan: effectivePlan.plan,
+    subscription: effectivePlan.subscription,
+  });
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
-import { pgTable, text, integer, boolean, primaryKey, AnyPgColumn, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, boolean, primaryKey, AnyPgColumn, uniqueIndex, index } from "drizzle-orm/pg-core";
 import { sql, relations } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
@@ -81,6 +81,41 @@ export const settings = pgTable(
   },
   (table) => ({
     pk: primaryKey({ columns: [table.ownerUserId, table.key] }),
+  }),
+);
+
+export const ownerSubscriptions = pgTable(
+  "owner_subscriptions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => randomUUID()),
+    ownerUserId: text("owner_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    billingMode: text("billing_mode").notNull().default("disabled"),
+    planCode: text("plan_code").notNull().default("free"),
+    billingInterval: text("billing_interval"),
+    status: text("status").notNull().default("none"),
+    stripeCustomerId: text("stripe_customer_id"),
+    stripeSubscriptionId: text("stripe_subscription_id"),
+    currentPeriodEnd: text("current_period_end"),
+    cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
+    createdAt: text("created_at")
+      .notNull()
+      .default(isoNow),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(isoNow)
+      .$onUpdate(() => new Date().toISOString()),
+  },
+  (table) => ({
+    ownerUnique: uniqueIndex("owner_subscriptions_owner_user_id_unique")
+      .on(table.ownerUserId),
+    stripeCustomerIdx: index("owner_subscriptions_stripe_customer_id_idx")
+      .on(table.stripeCustomerId),
+    stripeSubscriptionIdx: index("owner_subscriptions_stripe_subscription_id_idx")
+      .on(table.stripeSubscriptionId),
   }),
 );
 
@@ -278,6 +313,14 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(authSessions),
   deviceAuthGrants: many(deviceAuthGrants),
   pinResetTokens: many(pinResetTokens),
+  ownerSubscriptions: many(ownerSubscriptions),
+}));
+
+export const ownerSubscriptionsRelations = relations(ownerSubscriptions, ({ one }) => ({
+  owner: one(users, {
+    fields: [ownerSubscriptions.ownerUserId],
+    references: [users.id],
+  }),
 }));
 
 export const authAccountsRelations = relations(authAccounts, ({ one }) => ({

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { ownerSubscriptions, type users } from "@/db/schema";
+import { resolveOwnerUserId } from "@/lib/ownership";
+import {
+  getBillingConfig,
+  getPlanDefinition,
+  isBillingInterval,
+  isBillingMode,
+  isPlanCode,
+  isSubscriptionStatus,
+  type BillingInterval,
+  type BillingMode,
+  type PlanCode,
+  type PlanEnforcementMode,
+  type SubscriptionStatus,
+} from "@/lib/plans";
+
+type UserLike = Pick<typeof users.$inferSelect, "id" | "attribute" | "ownerUserId">;
+
+export interface OwnerSubscriptionState {
+  id: string;
+  ownerUserId: string;
+  billingMode: BillingMode;
+  planCode: PlanCode;
+  billingInterval: BillingInterval | null;
+  status: SubscriptionStatus;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface EffectivePlan {
+  ownerUserId: string;
+  billingMode: BillingMode;
+  planEnforcementMode: PlanEnforcementMode;
+  plan: ReturnType<typeof getPlanDefinition>;
+  subscription: OwnerSubscriptionState | null;
+}
+
+function normalizeSubscription(
+  row: typeof ownerSubscriptions.$inferSelect,
+): OwnerSubscriptionState {
+  return {
+    id: row.id,
+    ownerUserId: row.ownerUserId,
+    billingMode: isBillingMode(row.billingMode) ? row.billingMode : "disabled",
+    planCode: isPlanCode(row.planCode) ? row.planCode : "free",
+    billingInterval: isBillingInterval(row.billingInterval) ? row.billingInterval : null,
+    status: isSubscriptionStatus(row.status) ? row.status : "none",
+    currentPeriodEnd: row.currentPeriodEnd,
+    cancelAtPeriodEnd: row.cancelAtPeriodEnd,
+  };
+}
+
+export async function getOwnerSubscription(
+  ownerUserId: string,
+): Promise<OwnerSubscriptionState | null> {
+  const row = await db.query.ownerSubscriptions.findFirst({
+    where: eq(ownerSubscriptions.ownerUserId, ownerUserId),
+  });
+
+  return row ? normalizeSubscription(row) : null;
+}
+
+export async function getEffectivePlanForOwner(ownerUserId: string): Promise<EffectivePlan> {
+  const { billingMode, planEnforcementMode } = getBillingConfig();
+  const subscription = await getOwnerSubscription(ownerUserId);
+
+  if (billingMode === "disabled" || planEnforcementMode === "unlimited") {
+    return {
+      ownerUserId,
+      billingMode,
+      planEnforcementMode,
+      plan: getPlanDefinition("unlimited"),
+      subscription,
+    };
+  }
+
+  if (planEnforcementMode === "local") {
+    const planCode = subscription?.planCode ?? "free";
+    return {
+      ownerUserId,
+      billingMode,
+      planEnforcementMode,
+      plan: getPlanDefinition(planCode),
+      subscription,
+    };
+  }
+
+  const paidSubscriptionActive =
+    subscription?.billingMode === "stripe" &&
+    ["trialing", "active", "past_due"].includes(subscription.status);
+  const planCode = paidSubscriptionActive ? subscription.planCode : "free";
+
+  return {
+    ownerUserId,
+    billingMode,
+    planEnforcementMode,
+    plan: getPlanDefinition(planCode),
+    subscription,
+  };
+}
+
+export async function getEffectivePlanForUser(user: UserLike): Promise<EffectivePlan> {
+  return getEffectivePlanForOwner(resolveOwnerUserId(user));
+}

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,204 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+
+export const BILLING_MODES = ["disabled", "stripe"] as const;
+export type BillingMode = (typeof BILLING_MODES)[number];
+
+export const PLAN_ENFORCEMENT_MODES = ["unlimited", "local", "billing"] as const;
+export type PlanEnforcementMode = (typeof PLAN_ENFORCEMENT_MODES)[number];
+
+export const PLAN_CODES = [
+  "self_hosted",
+  "free",
+  "lite",
+  "standard",
+  "standard_plus",
+  "unlimited",
+] as const;
+export type PlanCode = (typeof PLAN_CODES)[number];
+
+export const BILLING_INTERVALS = ["monthly", "yearly"] as const;
+export type BillingInterval = (typeof BILLING_INTERVALS)[number];
+
+export const SUBSCRIPTION_STATUSES = [
+  "none",
+  "incomplete",
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "unpaid",
+  "paused",
+] as const;
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUSES)[number];
+
+export interface PlanLimits {
+  boards: number | null;
+  images: number | null;
+  storageBytes: number | null;
+  maxResolution: number | null;
+  videoEnabled: boolean;
+  watermark: boolean;
+  maxUploadBytes: number | null;
+}
+
+export interface PlanDefinition {
+  code: PlanCode;
+  name: string;
+  limits: PlanLimits;
+}
+
+const MB = 1024 ** 2;
+const GB = 1024 ** 3;
+
+export const PLAN_DEFINITIONS = {
+  self_hosted: {
+    code: "self_hosted",
+    name: "Self-hosted",
+    limits: {
+      boards: null,
+      images: null,
+      storageBytes: null,
+      maxResolution: null,
+      videoEnabled: true,
+      watermark: false,
+      maxUploadBytes: null,
+    },
+  },
+  free: {
+    code: "free",
+    name: "Free",
+    limits: {
+      boards: 1,
+      images: 3,
+      storageBytes: 20 * MB,
+      maxResolution: 1920,
+      videoEnabled: false,
+      watermark: true,
+      maxUploadBytes: 5 * MB,
+    },
+  },
+  lite: {
+    code: "lite",
+    name: "Lite",
+    limits: {
+      boards: 10,
+      images: null,
+      storageBytes: 1 * GB,
+      maxResolution: 1920,
+      videoEnabled: true,
+      watermark: false,
+      maxUploadBytes: 20 * MB,
+    },
+  },
+  standard: {
+    code: "standard",
+    name: "Standard",
+    limits: {
+      boards: 100,
+      images: null,
+      storageBytes: 10 * GB,
+      maxResolution: 3840,
+      videoEnabled: true,
+      watermark: false,
+      maxUploadBytes: 500 * MB,
+    },
+  },
+  standard_plus: {
+    code: "standard_plus",
+    name: "Standard+",
+    limits: {
+      boards: 300,
+      images: null,
+      storageBytes: 50 * GB,
+      maxResolution: 3840,
+      videoEnabled: true,
+      watermark: false,
+      maxUploadBytes: 2 * GB,
+    },
+  },
+  unlimited: {
+    code: "unlimited",
+    name: "Unlimited",
+    limits: {
+      boards: null,
+      images: null,
+      storageBytes: null,
+      maxResolution: null,
+      videoEnabled: true,
+      watermark: false,
+      maxUploadBytes: null,
+    },
+  },
+} as const satisfies Record<PlanCode, PlanDefinition>;
+
+export function isBillingMode(value: string | null | undefined): value is BillingMode {
+  return BILLING_MODES.includes(value as BillingMode);
+}
+
+export function isPlanEnforcementMode(
+  value: string | null | undefined,
+): value is PlanEnforcementMode {
+  return PLAN_ENFORCEMENT_MODES.includes(value as PlanEnforcementMode);
+}
+
+export function isPlanCode(value: string | null | undefined): value is PlanCode {
+  return PLAN_CODES.includes(value as PlanCode);
+}
+
+export function isBillingInterval(
+  value: string | null | undefined,
+): value is BillingInterval {
+  return BILLING_INTERVALS.includes(value as BillingInterval);
+}
+
+export function isSubscriptionStatus(
+  value: string | null | undefined,
+): value is SubscriptionStatus {
+  return SUBSCRIPTION_STATUSES.includes(value as SubscriptionStatus);
+}
+
+function readEnv(name: string): string | null {
+  const value = process.env[name]?.trim();
+  return value ? value : null;
+}
+
+function readBillingMode(): BillingMode {
+  const value = readEnv("BILLING_MODE");
+  return isBillingMode(value) ? value : "disabled";
+}
+
+function readPlanEnforcementMode(): PlanEnforcementMode {
+  const value = readEnv("PLAN_ENFORCEMENT_MODE");
+  return isPlanEnforcementMode(value) ? value : "unlimited";
+}
+
+export function getBillingConfig() {
+  const billingMode = readBillingMode();
+  const planEnforcementMode = readPlanEnforcementMode();
+
+  return {
+    billingMode,
+    planEnforcementMode,
+    stripeSecretKey: readEnv("STRIPE_SECRET_KEY"),
+    stripeWebhookSecret: readEnv("STRIPE_WEBHOOK_SECRET"),
+    stripePrices: {
+      lite: {
+        monthly: readEnv("STRIPE_PRICE_LITE_MONTHLY"),
+        yearly: readEnv("STRIPE_PRICE_LITE_YEARLY"),
+      },
+      standard: {
+        monthly: readEnv("STRIPE_PRICE_STANDARD_MONTHLY"),
+        yearly: readEnv("STRIPE_PRICE_STANDARD_YEARLY"),
+      },
+      standard_plus: {
+        monthly: readEnv("STRIPE_PRICE_STANDARD_PLUS_MONTHLY"),
+        yearly: readEnv("STRIPE_PRICE_STANDARD_PLUS_YEARLY"),
+      },
+    },
+  } as const;
+}
+
+export function getPlanDefinition(planCode: string | null | undefined): PlanDefinition {
+  return PLAN_DEFINITIONS[isPlanCode(planCode) ? planCode : "unlimited"];
+}


### PR DESCRIPTION
## 概要
- Billing mode / Plan enforcement mode の環境変数読み取りを追加しました。
- OSS 本体に型安全な Plan 定義と制限値を追加しました。
- Owner 単位の `owner_subscriptions` テーブルと migration を追加しました。
- Owner の effective plan を解決する server-side helper を追加しました。
- 管理者向けに現在の billing/plan 基盤状態を返す最小 API を追加しました。

## 対応 Issue
- Closes #147

## Self-hostedでの挙動
- デフォルトは `BILLING_MODE=disabled` / `PLAN_ENFORCEMENT_MODE=unlimited` です。
- Stripe 関連の環境変数が未設定でも build / 起動に影響しません。
- 既存の PostgreSQL、ローカル uploads、S3/RustFS 互換 storage には触れていません。

## 公式SaaSでの挙動
- `BILLING_MODE=stripe` / `PLAN_ENFORCEMENT_MODE=billing` を使うための基盤を追加しました。
- Stripe secret key や price id は環境変数から読む形にしており、コードにはハードコードしていません。
- Stripe Checkout / Portal / Webhook 同期は後続 Issue の範囲として未実装です。

## 確認内容
- `pnpm db:generate`
- `pnpm exec eslint src/lib/plans.ts src/lib/billing.ts src/app/api/billing/plan/route.ts src/db/schema.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
