### PR TITLE
[codex] Stripe CheckoutとCustomer Portal APIを追加する

### DIFF
--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,119 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { getAdminSessionUser } from "@/lib/auth";
+import {
+  getOwnerSubscription,
+  saveOwnerStripeCustomer,
+} from "@/lib/billing";
+import { resolveOwnerUserId } from "@/lib/ownership";
+import { buildPublicAppUrl } from "@/lib/public-origin";
+import {
+  getBillingConfig,
+  getStripePriceId,
+  isBillingInterval,
+  isPaidPlanCode,
+} from "@/lib/plans";
+import {
+  StripeBillingError,
+  createStripeCheckoutSession,
+  createStripeCustomer,
+} from "@/lib/stripe-billing";
+
+function errorResponse(error: unknown) {
+  if (error instanceof StripeBillingError) {
+    console.error("[billing/checkout] Stripe request failed", {
+      code: error.code,
+      status: error.status,
+      message: error.message,
+    });
+    return NextResponse.json({ error: "Stripe連携に失敗しました", code: error.code }, { status: error.status });
+  }
+
+  console.error("[billing/checkout] Failed to create checkout session", error);
+  return NextResponse.json(
+    { error: "Checkout Session の作成に失敗しました", code: "checkout_session_failed" },
+    { status: 500 },
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getAdminSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const { billingMode } = getBillingConfig();
+  if (billingMode !== "stripe") {
+    return NextResponse.json(
+      { error: "Billing is disabled", code: "billing_disabled" },
+      { status: 403 },
+    );
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const planCode = typeof body.planCode === "string" ? body.planCode : null;
+  const interval = typeof body.interval === "string" ? body.interval : null;
+  if (!isPaidPlanCode(planCode) || !isBillingInterval(interval)) {
+    return NextResponse.json(
+      { error: "有料プランと請求間隔を指定してください", code: "invalid_plan_or_interval" },
+      { status: 400 },
+    );
+  }
+
+  const priceId = getStripePriceId(planCode, interval);
+  if (!priceId) {
+    return NextResponse.json(
+      { error: "Stripe price ID が未設定です", code: "stripe_price_not_configured" },
+      { status: 503 },
+    );
+  }
+
+  const successUrl = buildPublicAppUrl("/settings?billing=checkout-success");
+  const cancelUrl = buildPublicAppUrl("/settings?billing=checkout-cancelled");
+  if (!successUrl || !cancelUrl) {
+    return NextResponse.json(
+      { error: "APP_PUBLIC_ORIGIN が未設定、または不正です", code: "public_origin_not_configured" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const ownerUserId = resolveOwnerUserId(session.user);
+    const owner = await db.query.users.findFirst({
+      where: eq(users.id, ownerUserId),
+    });
+    if (!owner) {
+      return NextResponse.json(
+        { error: "Ownerユーザーが見つかりません", code: "owner_not_found" },
+        { status: 404 },
+      );
+    }
+
+    const subscription = await getOwnerSubscription(ownerUserId);
+    const stripeCustomerId = subscription?.stripeCustomerId
+      ?? await createStripeCustomer({
+        ownerUserId,
+        email: owner.email,
+        name: owner.userId,
+      });
+    if (!subscription?.stripeCustomerId) {
+      await saveOwnerStripeCustomer({ ownerUserId, stripeCustomerId });
+    }
+
+    const url = await createStripeCheckoutSession({
+      ownerUserId,
+      customerId: stripeCustomerId,
+      priceId,
+      successUrl,
+      cancelUrl,
+    });
+
+    return NextResponse.json({ url });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from "next/server";
+import { getAdminSessionUser } from "@/lib/auth";
+import { getOwnerSubscription } from "@/lib/billing";
+import { resolveOwnerUserId } from "@/lib/ownership";
+import { buildPublicAppUrl } from "@/lib/public-origin";
+import { getBillingConfig } from "@/lib/plans";
+import {
+  StripeBillingError,
+  createStripePortalSession,
+} from "@/lib/stripe-billing";
+
+function errorResponse(error: unknown) {
+  if (error instanceof StripeBillingError) {
+    console.error("[billing/portal] Stripe request failed", {
+      code: error.code,
+      status: error.status,
+      message: error.message,
+    });
+    return NextResponse.json({ error: "Stripe連携に失敗しました", code: error.code }, { status: error.status });
+  }
+
+  console.error("[billing/portal] Failed to create portal session", error);
+  return NextResponse.json(
+    { error: "Customer Portal Session の作成に失敗しました", code: "portal_session_failed" },
+    { status: 500 },
+  );
+}
+
+export async function POST() {
+  const session = await getAdminSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+  }
+
+  const { billingMode } = getBillingConfig();
+  if (billingMode !== "stripe") {
+    return NextResponse.json(
+      { error: "Billing is disabled", code: "billing_disabled" },
+      { status: 403 },
+    );
+  }
+
+  const returnUrl = buildPublicAppUrl("/settings?billing=portal-return");
+  if (!returnUrl) {
+    return NextResponse.json(
+      { error: "APP_PUBLIC_ORIGIN が未設定、または不正です", code: "public_origin_not_configured" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const ownerUserId = resolveOwnerUserId(session.user);
+    const subscription = await getOwnerSubscription(ownerUserId);
+    if (!subscription?.stripeCustomerId) {
+      return NextResponse.json(
+        { error: "Stripe customer が未作成です", code: "stripe_customer_not_found" },
+        { status: 404 },
+      );
+    }
+
+    const url = await createStripePortalSession({
+      customerId: subscription.stripeCustomerId,
+      returnUrl,
+    });
+
+    return NextResponse.json({ url });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -27,6 +27,8 @@ export interface OwnerSubscriptionState {
   planCode: PlanCode;
   billingInterval: BillingInterval | null;
   status: SubscriptionStatus;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
   currentPeriodEnd: string | null;
   cancelAtPeriodEnd: boolean;
 }
@@ -49,6 +51,8 @@ function normalizeSubscription(
     planCode: isPlanCode(row.planCode) ? row.planCode : "free",
     billingInterval: isBillingInterval(row.billingInterval) ? row.billingInterval : null,
     status: isSubscriptionStatus(row.status) ? row.status : "none",
+    stripeCustomerId: row.stripeCustomerId,
+    stripeSubscriptionId: row.stripeSubscriptionId,
     currentPeriodEnd: row.currentPeriodEnd,
     cancelAtPeriodEnd: row.cancelAtPeriodEnd,
   };
@@ -105,4 +109,37 @@ export async function getEffectivePlanForOwner(ownerUserId: string): Promise<Eff
 
 export async function getEffectivePlanForUser(user: UserLike): Promise<EffectivePlan> {
   return getEffectivePlanForOwner(resolveOwnerUserId(user));
+}
+
+export async function saveOwnerStripeCustomer(params: {
+  ownerUserId: string;
+  stripeCustomerId: string;
+}): Promise<OwnerSubscriptionState> {
+  const existing = await db.query.ownerSubscriptions.findFirst({
+    where: eq(ownerSubscriptions.ownerUserId, params.ownerUserId),
+  });
+
+  if (existing) {
+    const [updated] = await db
+      .update(ownerSubscriptions)
+      .set({
+        billingMode: "stripe",
+        stripeCustomerId: params.stripeCustomerId,
+      })
+      .where(eq(ownerSubscriptions.ownerUserId, params.ownerUserId))
+      .returning();
+
+    return normalizeSubscription(updated);
+  }
+
+  const [created] = await db
+    .insert(ownerSubscriptions)
+    .values({
+      ownerUserId: params.ownerUserId,
+      billingMode: "stripe",
+      stripeCustomerId: params.stripeCustomerId,
+    })
+    .returning();
+
+  return normalizeSubscription(created);
 }

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -17,6 +17,9 @@ export const PLAN_CODES = [
 ] as const;
 export type PlanCode = (typeof PLAN_CODES)[number];
 
+export const PAID_PLAN_CODES = ["lite", "standard", "standard_plus"] as const;
+export type PaidPlanCode = (typeof PAID_PLAN_CODES)[number];
+
 export const BILLING_INTERVALS = ["monthly", "yearly"] as const;
 export type BillingInterval = (typeof BILLING_INTERVALS)[number];
 
@@ -146,6 +149,10 @@ export function isPlanCode(value: string | null | undefined): value is PlanCode 
   return PLAN_CODES.includes(value as PlanCode);
 }
 
+export function isPaidPlanCode(value: string | null | undefined): value is PaidPlanCode {
+  return PAID_PLAN_CODES.includes(value as PaidPlanCode);
+}
+
 export function isBillingInterval(
   value: string | null | undefined,
 ): value is BillingInterval {
@@ -201,4 +208,11 @@ export function getBillingConfig() {
 
 export function getPlanDefinition(planCode: string | null | undefined): PlanDefinition {
   return PLAN_DEFINITIONS[isPlanCode(planCode) ? planCode : "unlimited"];
+}
+
+export function getStripePriceId(
+  planCode: PaidPlanCode,
+  interval: BillingInterval,
+): string | null {
+  return getBillingConfig().stripePrices[planCode][interval];
 }

--- a/src/lib/stripe-billing.ts
+++ b/src/lib/stripe-billing.ts
@@ -1,0 +1,117 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { getBillingConfig } from "@/lib/plans";
+
+const STRIPE_API_BASE = "https://api.stripe.com/v1";
+
+interface StripeCustomer {
+  id: string;
+}
+
+interface StripeSession {
+  id: string;
+  url: string | null;
+}
+
+export class StripeBillingError extends Error {
+  constructor(
+    message: string,
+    readonly status = 502,
+    readonly code = "stripe_request_failed",
+  ) {
+    super(message);
+  }
+}
+
+function getStripeSecretKey(): string {
+  const { stripeSecretKey } = getBillingConfig();
+  if (!stripeSecretKey) {
+    throw new StripeBillingError("Stripe secret key is not configured", 503, "stripe_not_configured");
+  }
+  return stripeSecretKey;
+}
+
+async function postStripeForm<T>(
+  path: string,
+  params: URLSearchParams,
+  options?: { idempotencyKey?: string },
+): Promise<T> {
+  const response = await fetch(`${STRIPE_API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${getStripeSecretKey()}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...(options?.idempotencyKey ? { "Idempotency-Key": options.idempotencyKey } : {}),
+    },
+    body: params,
+  });
+
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = typeof data?.error?.message === "string"
+      ? data.error.message
+      : "Stripe request failed";
+    throw new StripeBillingError(message, response.status);
+  }
+
+  return data as T;
+}
+
+export async function createStripeCustomer(input: {
+  ownerUserId: string;
+  email: string;
+  name?: string | null;
+}): Promise<string> {
+  const params = new URLSearchParams();
+  params.set("email", input.email);
+  params.set("metadata[owner_user_id]", input.ownerUserId);
+  if (input.name) {
+    params.set("name", input.name);
+  }
+
+  const customer = await postStripeForm<StripeCustomer>("/customers", params, {
+    idempotencyKey: `keinage-owner-customer-${input.ownerUserId}`,
+  });
+  return customer.id;
+}
+
+export async function createStripeCheckoutSession(input: {
+  ownerUserId: string;
+  customerId: string;
+  priceId: string;
+  successUrl: string;
+  cancelUrl: string;
+}): Promise<string> {
+  const params = new URLSearchParams();
+  params.set("mode", "subscription");
+  params.set("customer", input.customerId);
+  params.set("client_reference_id", input.ownerUserId);
+  params.set("line_items[0][price]", input.priceId);
+  params.set("line_items[0][quantity]", "1");
+  params.set("success_url", input.successUrl);
+  params.set("cancel_url", input.cancelUrl);
+  params.set("allow_promotion_codes", "true");
+  params.set("metadata[owner_user_id]", input.ownerUserId);
+  params.set("subscription_data[metadata][owner_user_id]", input.ownerUserId);
+
+  const session = await postStripeForm<StripeSession>("/checkout/sessions", params);
+  if (!session.url) {
+    throw new StripeBillingError("Stripe checkout session URL was not returned");
+  }
+  return session.url;
+}
+
+export async function createStripePortalSession(input: {
+  customerId: string;
+  returnUrl: string;
+}): Promise<string> {
+  const params = new URLSearchParams();
+  params.set("customer", input.customerId);
+  params.set("return_url", input.returnUrl);
+
+  const session = await postStripeForm<StripeSession>("/billing_portal/sessions", params);
+  if (!session.url) {
+    throw new StripeBillingError("Stripe portal session URL was not returned");
+  }
+  return session.url;
+}


### PR DESCRIPTION
## 概要
- Stripe Checkout Session 作成 API を追加しました。
- Stripe Customer Portal Session 作成 API を追加しました。
- Owner 単位で Stripe customer id を作成・保存・再利用するようにしました。
- plan / interval から環境変数の Stripe price id を解決する helper を追加しました。
- Stripe SDK 依存は追加せず、Stripe REST API を `fetch` で呼び出す実装にしています。

## 対応 Issue
- Closes #155

## API contract
- `POST /api/billing/checkout`
  - body: `{ "planCode": "lite" | "standard" | "standard_plus", "interval": "monthly" | "yearly" }`
  - response: `{ "url": "https://checkout.stripe.com/..." }`
- `POST /api/billing/portal`
  - response: `{ "url": "https://billing.stripe.com/..." }`

## Self-hostedでの挙動
- `BILLING_MODE=disabled` では API は `billing_disabled` を返して安全に無効化されます。
- Stripe 関連 env が未設定でも build / 起動は壊れません。

## 公式SaaSでの挙動
- `BILLING_MODE=stripe` のときに Checkout / Portal session を作成します。
- Stripe secret key / price id は環境変数から読み、コードにはハードコードしていません。
- Checkout 完了後の subscription 反映は #154 の webhook 同期に委ねます。

## 確認内容
- `pnpm exec eslint src/lib/plans.ts src/lib/billing.ts src/lib/stripe-billing.ts src/app/api/billing/checkout/route.ts src/app/api/billing/portal/route.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`

## 補足
- `docker-compose.yml` にローカルの未コミット変更がありますが、この PR には含めていません。
