### PR TITLE
feat: Stripe webhook同期を安全に実装

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,6 +36,7 @@ flowchart TB
 | `/boards/new` | ボード作成 | 必要 |
 | `/boards/<boardId>` | ボード編集 | 必要 |
 | `/media` | アップロード済みメディア管理 | `admin` |
+| `/billing` | プランとお支払い管理 | `admin` / Billing 有効時 |
 | `/settings` | ユーザー設定・管理設定 | 必要 |
 | `/users` | Shared user 管理 | `admin` |
 | `/delete-account` | Owner アカウント削除リクエスト | Owner / `admin` |
@@ -160,7 +161,18 @@ flowchart TB
 
 Owner user は削除できません。
 
-## 10. 設定・補助 API
+## 10. Billing API
+
+| Method | Path | 内容 | 認証 |
+| --- | --- | --- | --- |
+| `GET` | `/api/billing/plan` | Owner の有効プラン状態を取得 | `admin` |
+| `POST` | `/api/billing/checkout` | 有料プランの Checkout Session を作成 | `admin` |
+| `POST` | `/api/billing/portal` | 支払い管理 Session を作成 | `admin` |
+| `POST` | `/api/billing/webhook` | 決済 webhook を署名検証し、Owner subscription を同期 | webhook signature |
+
+`BILLING_MODE=disabled` では `/billing` 導線は表示されず、`/api/billing/webhook` は 404 を返します。webhook は raw body と `STRIPE_WEBHOOK_SECRET` で署名検証し、event id を保存して重複処理を避けます。
+
+## 11. 設定・補助 API
 
 | Method | Path | 内容 | 認証 |
 | --- | --- | --- | --- |
@@ -172,7 +184,7 @@ Owner user は削除できません。
 
 `/api/weather` は外部天気 API の結果を一定時間キャッシュします。`/api/version` は GitHub Releases API を参照します。
 
-## 11. SSE API
+## 12. SSE API
 
 | Method | Path | 内容 | 認証 |
 | --- | --- | --- | --- |
@@ -187,9 +199,9 @@ Owner user は削除できません。
 | `media-updated` | メディア追加・並び替え・削除 |
 | `message-updated` | メッセージ追加・更新・削除 |
 
-## 12. 代表的なフロー
+## 13. 代表的なフロー
 
-### 12.1 Owner 登録
+### 13.1 Owner 登録
 
 ```mermaid
 sequenceDiagram
@@ -204,7 +216,7 @@ sequenceDiagram
   A-->>U: auth-session + device-auth
 ```
 
-### 12.2 Google ログイン
+### 13.2 Google ログイン
 
 ```mermaid
 sequenceDiagram
@@ -220,7 +232,7 @@ sequenceDiagram
   A-->>U: auth-session + device-auth
 ```
 
-### 12.3 ボード更新
+### 13.3 ボード更新
 
 ```mermaid
 sequenceDiagram

--- a/drizzle/0010_pink_ulik.sql
+++ b/drizzle/0010_pink_ulik.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "stripe_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"event_type" text NOT NULL,
+	"status" text DEFAULT 'processing' NOT NULL,
+	"payload" text NOT NULL,
+	"error" text,
+	"processed_at" text,
+	"created_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(timezone('utc', now()), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "stripe_events_status_idx" ON "stripe_events" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "stripe_events_event_type_idx" ON "stripe_events" USING btree ("event_type");

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1344 @@
+{
+  "id": "db617441-1e18-477a-99b7-de5d35e2a655",
+  "prevId": "87555af0-b0b0-436c-a8a5-763336afe25e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_deletion_requests": {
+      "name": "account_deletion_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_deletion_requests_owner_user_id_unique": {
+          "name": "account_deletion_requests_owner_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_user_id"
+          ]
+        },
+        "account_deletion_requests_token_unique": {
+          "name": "account_deletion_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "auth_accounts_provider_account_unique": {
+          "name": "auth_accounts_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_unique": {
+          "name": "auth_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_owner_user_id_users_id_fk": {
+          "name": "boards_owner_user_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_auth_grants": {
+      "name": "device_auth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token_hash": {
+          "name": "device_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_auth_grants_user_id_users_id_fk": {
+          "name": "device_auth_grants_user_id_users_id_fk",
+          "tableFrom": "device_auth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_auth_grants_device_token_hash_unique": {
+          "name": "device_auth_grants_device_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_oauth_flows": {
+      "name": "google_oauth_flows",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_to": {
+          "name": "redirect_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_signup_token": {
+          "name": "shared_signup_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_board_id_boards_id_fk": {
+          "name": "media_items_board_id_boards_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_board_id_boards_id_fk": {
+          "name": "messages_board_id_boards_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owner_subscriptions": {
+      "name": "owner_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "plan_code": {
+          "name": "plan_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "owner_subscriptions_owner_user_id_unique": {
+          "name": "owner_subscriptions_owner_user_id_unique",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owner_subscriptions_stripe_customer_id_idx": {
+          "name": "owner_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owner_subscriptions_stripe_subscription_id_idx": {
+          "name": "owner_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "owner_subscriptions_owner_user_id_users_id_fk": {
+          "name": "owner_subscriptions_owner_user_id_users_id_fk",
+          "tableFrom": "owner_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_attempts": {
+      "name": "pin_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pin_reset_tokens": {
+      "name": "pin_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pin_reset_tokens_user_id_users_id_fk": {
+          "name": "pin_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "pin_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pin_reset_tokens_token_unique": {
+          "name": "pin_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_owner_user_id_users_id_fk": {
+          "name": "settings_owner_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_owner_user_id_key_pk": {
+          "name": "settings_owner_user_id_key_pk",
+          "columns": [
+            "owner_user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_signup_requests": {
+      "name": "shared_signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_signup_requests_owner_user_id_users_id_fk": {
+          "name": "shared_signup_requests_owner_user_id_users_id_fk",
+          "tableFrom": "shared_signup_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shared_signup_requests_token_unique": {
+          "name": "shared_signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_requests": {
+      "name": "signup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_requests_token_unique": {
+          "name": "signup_requests_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "stripe_events_status_idx": {
+          "name": "stripe_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_event_type_idx": {
+          "name": "stripe_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_full_auth_at": {
+          "name": "last_full_auth_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(timezone('utc', now()), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_owner_user_id_users_id_fk": {
+          "name": "users_owner_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777532241597,
       "tag": "0009_woozy_champions",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777559410988,
+      "tag": "0010_pink_ulik",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from "next/server";
+import { getBillingConfig } from "@/lib/plans";
+import {
+  StripeWebhookError,
+  handleStripeWebhookEvent,
+  verifyStripeWebhookSignature,
+} from "@/lib/stripe-webhook";
+
+export const runtime = "nodejs";
+
+function webhookErrorResponse(error: unknown) {
+  if (error instanceof StripeWebhookError) {
+    console.error("[billing/webhook] Webhook rejected", {
+      code: error.code,
+      status: error.status,
+      message: error.message,
+    });
+    return NextResponse.json({ error: error.code }, { status: error.status });
+  }
+
+  console.error("[billing/webhook] Webhook processing failed", error);
+  return NextResponse.json({ error: "webhook_processing_failed" }, { status: 500 });
+}
+
+export async function POST(request: NextRequest) {
+  const { billingMode, stripeWebhookSecret } = getBillingConfig();
+  if (billingMode !== "stripe") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const rawBody = await request.text();
+  try {
+    verifyStripeWebhookSignature({
+      rawBody,
+      signatureHeader: request.headers.get("stripe-signature"),
+      webhookSecret: stripeWebhookSecret,
+    });
+
+    const result = await handleStripeWebhookEvent({ rawBody });
+    return NextResponse.json(result);
+  } catch (error) {
+    return webhookErrorResponse(error);
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -119,6 +119,25 @@ export const ownerSubscriptions = pgTable(
   }),
 );
 
+export const stripeEvents = pgTable("stripe_events", {
+  id: text("id").primaryKey(),
+  eventType: text("event_type").notNull(),
+  status: text("status").notNull().default("processing"),
+  payload: text("payload").notNull(),
+  error: text("error"),
+  processedAt: text("processed_at"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(isoNow),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(isoNow)
+    .$onUpdate(() => new Date().toISOString()),
+}, (table) => ({
+  statusIdx: index("stripe_events_status_idx").on(table.status),
+  eventTypeIdx: index("stripe_events_event_type_idx").on(table.eventType),
+}));
+
 export const pinResetTokens = pgTable("pin_reset_tokens", {
   id: text("id")
     .primaryKey()

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -216,3 +216,20 @@ export function getStripePriceId(
 ): string | null {
   return getBillingConfig().stripePrices[planCode][interval];
 }
+
+export function resolveStripePriceId(
+  priceId: string | null | undefined,
+): { planCode: PaidPlanCode; interval: BillingInterval } | null {
+  if (!priceId) return null;
+
+  const { stripePrices } = getBillingConfig();
+  for (const planCode of PAID_PLAN_CODES) {
+    for (const interval of BILLING_INTERVALS) {
+      if (stripePrices[planCode][interval] === priceId) {
+        return { planCode, interval };
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lib/stripe-webhook.ts
+++ b/src/lib/stripe-webhook.ts
@@ -1,0 +1,506 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import { createHmac, timingSafeEqual } from "crypto";
+import { eq, or } from "drizzle-orm";
+import { db } from "@/db";
+import { ownerSubscriptions, stripeEvents } from "@/db/schema";
+import {
+  resolveStripePriceId,
+  type BillingInterval,
+  type PaidPlanCode,
+  type SubscriptionStatus,
+} from "@/lib/plans";
+
+const SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
+const SUPPORTED_EVENTS = new Set([
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+  "invoice.payment_failed",
+  "invoice.payment_succeeded",
+]);
+
+export class StripeWebhookError extends Error {
+  constructor(
+    message: string,
+    readonly status = 400,
+    readonly code = "stripe_webhook_error",
+  ) {
+    super(message);
+  }
+}
+
+interface StripeEvent<T = StripeObject> {
+  id: string;
+  type: string;
+  data?: {
+    object?: T;
+  };
+}
+
+type StripeObject = Record<string, unknown>;
+
+interface ResolvedSubscriptionState {
+  ownerUserId: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  planCode: PaidPlanCode | "free";
+  billingInterval: BillingInterval | null;
+  status: SubscriptionStatus;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+function asObject(value: unknown): StripeObject | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as StripeObject
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function stripeId(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  return asString(asObject(value)?.id);
+}
+
+function toIsoFromStripeSeconds(value: unknown): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return new Date(value * 1000).toISOString();
+}
+
+function metadataOwnerUserId(object: StripeObject | null): string | null {
+  return asString(asObject(object?.metadata)?.owner_user_id);
+}
+
+function subscriptionStatus(value: unknown): SubscriptionStatus {
+  switch (value) {
+    case "trialing":
+      return "trialing";
+    case "active":
+      return "active";
+    case "past_due":
+      return "past_due";
+    case "canceled":
+    case "incomplete_expired":
+      return "canceled";
+    case "unpaid":
+      return "unpaid";
+    case "paused":
+      return "paused";
+    case "incomplete":
+      return "incomplete";
+    default:
+      return "none";
+  }
+}
+
+function priceIdFromSubscription(subscription: StripeObject): string | null {
+  const items = asObject(subscription.items);
+  const data = Array.isArray(items?.data) ? items.data : [];
+  const firstItem = asObject(data[0]);
+  const price = asObject(firstItem?.price);
+  return asString(price?.id);
+}
+
+function parseStripeEvent(rawBody: string): StripeEvent {
+  const parsed = JSON.parse(rawBody) as unknown;
+  const event = asObject(parsed);
+  const id = asString(event?.id);
+  const type = asString(event?.type);
+  if (!id || !type) {
+    throw new StripeWebhookError("Invalid Stripe event payload", 400, "invalid_payload");
+  }
+
+  return {
+    id,
+    type,
+    data: asObject(event?.data) as StripeEvent["data"],
+  };
+}
+
+function parseSignatureHeader(signatureHeader: string) {
+  const parts = signatureHeader.split(",");
+  const timestamp = parts
+    .map((part) => part.split("="))
+    .find(([key]) => key === "t")?.[1];
+  const signatures = parts
+    .map((part) => part.split("="))
+    .filter(([key, value]) => key === "v1" && !!value)
+    .map(([, value]) => value);
+
+  return { timestamp, signatures };
+}
+
+export function verifyStripeWebhookSignature(input: {
+  rawBody: string;
+  signatureHeader: string | null;
+  webhookSecret: string | null;
+}) {
+  if (!input.webhookSecret) {
+    throw new StripeWebhookError("Stripe webhook secret is not configured", 503, "webhook_secret_not_configured");
+  }
+  if (!input.signatureHeader) {
+    throw new StripeWebhookError("Stripe signature header is missing", 400, "signature_missing");
+  }
+
+  const { timestamp, signatures } = parseSignatureHeader(input.signatureHeader);
+  const timestampNumber = timestamp ? Number(timestamp) : Number.NaN;
+  if (!Number.isFinite(timestampNumber) || signatures.length === 0) {
+    throw new StripeWebhookError("Stripe signature header is invalid", 400, "signature_invalid");
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - timestampNumber) > SIGNATURE_TOLERANCE_SECONDS) {
+    throw new StripeWebhookError("Stripe signature timestamp is outside tolerance", 400, "signature_expired");
+  }
+
+  const expected = createHmac("sha256", input.webhookSecret)
+    .update(`${timestamp}.${input.rawBody}`)
+    .digest("hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+  const valid = signatures.some((signature) => {
+    const signatureBuffer = Buffer.from(signature, "hex");
+    return signatureBuffer.length === expectedBuffer.length
+      && timingSafeEqual(signatureBuffer, expectedBuffer);
+  });
+
+  if (!valid) {
+    throw new StripeWebhookError("Stripe signature verification failed", 400, "signature_verification_failed");
+  }
+}
+
+async function getEventStatus(eventId: string) {
+  return db.query.stripeEvents.findFirst({
+    where: eq(stripeEvents.id, eventId),
+  });
+}
+
+async function startEventProcessing(event: StripeEvent, rawBody: string) {
+  const inserted = await db
+    .insert(stripeEvents)
+    .values({
+      id: event.id,
+      eventType: event.type,
+      status: "processing",
+      payload: rawBody,
+      error: null,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  if (inserted[0]) {
+    return { shouldProcess: true, duplicate: false };
+  }
+
+  const existing = await getEventStatus(event.id);
+  if (existing?.status === "failed") {
+    await db
+      .update(stripeEvents)
+      .set({
+        status: "processing",
+        eventType: event.type,
+        payload: rawBody,
+        error: null,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(stripeEvents.id, event.id));
+    return { shouldProcess: true, duplicate: false };
+  }
+
+  return { shouldProcess: false, duplicate: true };
+}
+
+async function finishEvent(
+  eventId: string,
+  status: "processed" | "ignored" | "failed",
+  error?: string,
+) {
+  await db
+    .update(stripeEvents)
+    .set({
+      status,
+      error: error ?? null,
+      processedAt: status === "failed" ? null : new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(stripeEvents.id, eventId));
+}
+
+async function findOwnerByStripeIds(input: {
+  stripeCustomerId?: string | null;
+  stripeSubscriptionId?: string | null;
+}) {
+  if (!input.stripeCustomerId && !input.stripeSubscriptionId) return null;
+  const conditions = [
+    input.stripeCustomerId
+      ? eq(ownerSubscriptions.stripeCustomerId, input.stripeCustomerId)
+      : null,
+    input.stripeSubscriptionId
+      ? eq(ownerSubscriptions.stripeSubscriptionId, input.stripeSubscriptionId)
+      : null,
+  ].filter((condition): condition is NonNullable<typeof condition> => !!condition);
+
+  return db.query.ownerSubscriptions.findFirst({
+    where: or(...conditions),
+  });
+}
+
+async function upsertOwnerSubscription(state: ResolvedSubscriptionState) {
+  const existing = await db.query.ownerSubscriptions.findFirst({
+    where: eq(ownerSubscriptions.ownerUserId, state.ownerUserId),
+  });
+  const values = {
+    billingMode: "stripe",
+    planCode: state.planCode,
+    billingInterval: state.billingInterval,
+    status: state.status,
+    stripeCustomerId: state.stripeCustomerId,
+    stripeSubscriptionId: state.stripeSubscriptionId,
+    currentPeriodEnd: state.currentPeriodEnd,
+    cancelAtPeriodEnd: state.cancelAtPeriodEnd,
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (existing) {
+    await db
+      .update(ownerSubscriptions)
+      .set(values)
+      .where(eq(ownerSubscriptions.ownerUserId, state.ownerUserId));
+    return;
+  }
+
+  await db.insert(ownerSubscriptions).values({
+    ownerUserId: state.ownerUserId,
+    ...values,
+  });
+}
+
+async function resolveOwnerUserIdFromObject(object: StripeObject, ids: {
+  stripeCustomerId?: string | null;
+  stripeSubscriptionId?: string | null;
+}) {
+  const ownerFromMetadata = metadataOwnerUserId(object)
+    ?? asString(object.client_reference_id);
+  if (ownerFromMetadata) return ownerFromMetadata;
+
+  const existing = await findOwnerByStripeIds(ids);
+  return existing?.ownerUserId ?? null;
+}
+
+async function handleCheckoutSessionCompleted(object: StripeObject) {
+  const stripeCustomerId = stripeId(object.customer);
+  const stripeSubscriptionId = stripeId(object.subscription);
+  const ownerUserId = await resolveOwnerUserIdFromObject(object, {
+    stripeCustomerId,
+    stripeSubscriptionId,
+  });
+  if (!ownerUserId) {
+    console.error("[billing/webhook] Owner not resolved for checkout.session.completed", {
+      stripeCustomerId,
+      stripeSubscriptionId,
+    });
+    return "ignored" as const;
+  }
+
+  const existing = await db.query.ownerSubscriptions.findFirst({
+    where: eq(ownerSubscriptions.ownerUserId, ownerUserId),
+  });
+  await upsertOwnerSubscription({
+    ownerUserId,
+    stripeCustomerId,
+    stripeSubscriptionId,
+    planCode: existing?.planCode === "lite"
+      || existing?.planCode === "standard"
+      || existing?.planCode === "standard_plus"
+      ? existing.planCode
+      : "free",
+    billingInterval: existing?.billingInterval === "monthly"
+      || existing?.billingInterval === "yearly"
+      ? existing.billingInterval
+      : null,
+    status: existing?.status === "trialing" ? "trialing" : "active",
+    currentPeriodEnd: existing?.currentPeriodEnd ?? null,
+    cancelAtPeriodEnd: existing?.cancelAtPeriodEnd ?? false,
+  });
+
+  return "processed" as const;
+}
+
+async function resolveSubscriptionState(subscription: StripeObject): Promise<ResolvedSubscriptionState | null> {
+  const stripeCustomerId = stripeId(subscription.customer);
+  const stripeSubscriptionId = stripeId(subscription.id);
+  const ownerUserId = await resolveOwnerUserIdFromObject(subscription, {
+    stripeCustomerId,
+    stripeSubscriptionId,
+  });
+  if (!ownerUserId || !stripeSubscriptionId) {
+    console.error("[billing/webhook] Owner or subscription id not resolved for subscription event", {
+      stripeCustomerId,
+      stripeSubscriptionId,
+    });
+    return null;
+  }
+
+  const resolvedPrice = resolveStripePriceId(priceIdFromSubscription(subscription));
+  if (!resolvedPrice) {
+    console.error("[billing/webhook] Unknown subscription price id", {
+      stripeCustomerId,
+      stripeSubscriptionId,
+      priceId: priceIdFromSubscription(subscription),
+    });
+    return null;
+  }
+
+  return {
+    ownerUserId,
+    stripeCustomerId,
+    stripeSubscriptionId,
+    planCode: resolvedPrice.planCode,
+    billingInterval: resolvedPrice.interval,
+    status: subscriptionStatus(subscription.status),
+    currentPeriodEnd: toIsoFromStripeSeconds(subscription.current_period_end),
+    cancelAtPeriodEnd: asBoolean(subscription.cancel_at_period_end),
+  };
+}
+
+async function handleSubscriptionEvent(eventType: string, object: StripeObject) {
+  const state = await resolveSubscriptionState(object);
+
+  if (eventType === "customer.subscription.deleted") {
+    if (!state) {
+      const existing = await findOwnerByStripeIds({
+        stripeCustomerId: stripeId(object.customer),
+        stripeSubscriptionId: stripeId(object.id),
+      });
+      if (!existing) return "ignored" as const;
+
+      await db
+        .update(ownerSubscriptions)
+        .set({
+          planCode: "free",
+          billingInterval: null,
+          status: "canceled",
+          currentPeriodEnd: toIsoFromStripeSeconds(object.current_period_end),
+          cancelAtPeriodEnd: false,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(eq(ownerSubscriptions.ownerUserId, existing.ownerUserId));
+      return "processed" as const;
+    }
+
+    await upsertOwnerSubscription({
+      ...state,
+      planCode: "free",
+      billingInterval: null,
+      status: "canceled",
+      cancelAtPeriodEnd: false,
+    });
+    return "processed" as const;
+  }
+
+  if (!state) return "ignored" as const;
+
+  await upsertOwnerSubscription(state);
+  return "processed" as const;
+}
+
+async function handleInvoiceEvent(eventType: string, object: StripeObject) {
+  const subscription = asObject(object.subscription);
+  if (subscription) {
+    const state = await resolveSubscriptionState(subscription);
+    if (!state) return "ignored" as const;
+    await upsertOwnerSubscription({
+      ...state,
+      status: eventType === "invoice.payment_failed" ? "past_due" : state.status,
+    });
+    return "processed" as const;
+  }
+
+  const stripeCustomerId = stripeId(object.customer);
+  const stripeSubscriptionId = stripeId(object.subscription);
+  const existing = await findOwnerByStripeIds({ stripeCustomerId, stripeSubscriptionId });
+  if (!existing) {
+    console.error("[billing/webhook] Existing subscription not found for invoice event", {
+      stripeCustomerId,
+      stripeSubscriptionId,
+      eventType,
+    });
+    return "ignored" as const;
+  }
+
+  await db
+    .update(ownerSubscriptions)
+    .set({
+      status: eventType === "invoice.payment_failed" ? "past_due" : "active",
+      stripeCustomerId: stripeCustomerId ?? existing.stripeCustomerId,
+      stripeSubscriptionId: stripeSubscriptionId ?? existing.stripeSubscriptionId,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(ownerSubscriptions.ownerUserId, existing.ownerUserId));
+
+  return "processed" as const;
+}
+
+async function processStripeEvent(event: StripeEvent) {
+  if (!SUPPORTED_EVENTS.has(event.type)) {
+    return "ignored" as const;
+  }
+
+  const object = asObject(event.data?.object);
+  if (!object) {
+    throw new StripeWebhookError("Stripe event object is invalid", 400, "invalid_event_object");
+  }
+
+  if (event.type === "checkout.session.completed") {
+    return handleCheckoutSessionCompleted(object);
+  }
+  if (event.type.startsWith("customer.subscription.")) {
+    return handleSubscriptionEvent(event.type, object);
+  }
+  if (event.type.startsWith("invoice.payment_")) {
+    return handleInvoiceEvent(event.type, object);
+  }
+
+  return "ignored" as const;
+}
+
+export async function handleStripeWebhookEvent(input: {
+  rawBody: string;
+}) {
+  const event = parseStripeEvent(input.rawBody);
+  const eventState = await startEventProcessing(event, input.rawBody);
+  if (!eventState.shouldProcess) {
+    return {
+      received: true,
+      duplicate: eventState.duplicate,
+      eventId: event.id,
+      status: "duplicate",
+    };
+  }
+
+  try {
+    const status = await processStripeEvent(event);
+    await finishEvent(event.id, status);
+    return {
+      received: true,
+      duplicate: false,
+      eventId: event.id,
+      status,
+    };
+  } catch (error) {
+    await finishEvent(
+      event.id,
+      "failed",
+      error instanceof Error ? error.message : "Unknown webhook processing error",
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
## 概要
- 決済 webhook endpoint `POST /api/billing/webhook` を追加しました
- raw body と `STRIPE_WEBHOOK_SECRET` による署名検証を実装しました
- `stripe_events` table を追加し、event id 単位で冪等に処理します
- subscription created/updated/deleted、checkout completed、invoice payment failed/succeeded を Owner subscription に同期します
- price id から plan / billing interval を解決する helper を追加しました
- Billing disabled 時は webhook endpoint が 404 を返します
- 追加 endpoint を `docs/API.md` に追記しました

## 確認
- `pnpm db:generate`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/app/api/billing/webhook/route.ts src/lib/stripe-webhook.ts src/lib/plans.ts src/db/schema.ts`
- `pnpm build`

Closes #154