### PR TITLE
feat: Freeプランにウォーターマークを表示

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -119,6 +119,8 @@ flowchart TB
 | `DELETE` | `/api/boards/<id>` | ボード削除 | 必要 |
 | `GET` | `/api/public/boards/<id>` | 公開ボード詳細 | 不要 |
 
+`GET /api/public/boards/<id>` はボード表示に必要な `boardPlan.watermark` を返します。この値は Owner の effective plan からサーバー側で算出され、plan code や subscription 詳細は公開しません。ブラウザ表示上のウォーターマークであり、完全な削除・改ざん防止は保証しません。
+
 ボード更新・削除後は対象ボードへ SSE イベントが発行されます。
 
 ## 7. メディア API

--- a/src/app/(board)/[boardId]/page.tsx
+++ b/src/app/(board)/[boardId]/page.tsx
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { eq, asc, and, or, isNull, gt } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
+import { getEffectivePlanForOwner } from "@/lib/billing";
 import { isInOwnerScope } from "@/lib/ownership";
 import { getTemplate } from "@/lib/templates";
 import { normalizeConfig } from "@/lib/utils";
@@ -71,12 +72,14 @@ export default async function BoardPage({
         or(isNull(messages.expiresAt), gt(messages.expiresAt, now))
       )
     );
+  const effectivePlan = await getEffectivePlanForOwner(board.ownerUserId);
 
   return (
     <LiveBoard
       board={normalizedBoard}
       mediaItems={media}
       messages={activeMessages}
+      boardPlan={{ watermark: effectivePlan.plan.limits.watermark }}
       TemplateComponent={template.component}
     />
   );

--- a/src/app/api/public/boards/[id]/route.ts
+++ b/src/app/api/public/boards/[id]/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { boards, mediaItems, messages } from "@/db/schema";
 import { asc, eq } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
+import { getEffectivePlanForOwner } from "@/lib/billing";
 import { isInOwnerScope } from "@/lib/ownership";
 import { normalizeConfig } from "@/lib/utils";
 
@@ -42,9 +43,13 @@ export async function GET(
     .select()
     .from(messages)
     .where(eq(messages.boardId, id));
+  const effectivePlan = await getEffectivePlanForOwner(board.ownerUserId);
 
   return NextResponse.json({
     ...normalizeConfig(board),
+    boardPlan: {
+      watermark: effectivePlan.plan.limits.watermark,
+    },
     mediaItems: media,
     messages: boardMessages,
   });

--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -34,9 +34,12 @@ export function DateTimeClock({
   const { locale, formatDate } = useLocale();
 
   useEffect(() => {
-    setNow(new Date());
+    const initialTimer = setTimeout(() => setNow(new Date()), 0);
     const timer = setInterval(() => setNow(new Date()), 1000);
-    return () => clearInterval(timer);
+    return () => {
+      clearTimeout(initialTimer);
+      clearInterval(timer);
+    };
   }, []);
 
   if (!now) return null;

--- a/src/components/board/LiveBoard.tsx
+++ b/src/components/board/LiveBoard.tsx
@@ -4,9 +4,16 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useLocale } from "@/components/i18n/LocaleProvider";
+import { WatermarkOverlay } from "@/components/board/WatermarkOverlay";
 import { useSSE } from "@/hooks/useSSE";
 import { parseJsonObject } from "@/lib/utils";
-import type { Board, MediaItem, Message, BoardTemplateProps } from "@/types";
+import type {
+  Board,
+  MediaItem,
+  Message,
+  BoardTemplateProps,
+  PublicBoardPlan,
+} from "@/types";
 
 const CURSOR_HIDE_DELAY = 3000;
 
@@ -14,7 +21,22 @@ interface LiveBoardProps {
   board: Board;
   mediaItems: MediaItem[];
   messages: Message[];
+  boardPlan: PublicBoardPlan;
   TemplateComponent: React.ComponentType<BoardTemplateProps>;
+}
+
+const DEFAULT_PUBLIC_BOARD_PLAN: PublicBoardPlan = {
+  watermark: false,
+};
+
+function parsePublicBoardPlan(raw: unknown): PublicBoardPlan {
+  if (!raw || typeof raw !== "object") {
+    return DEFAULT_PUBLIC_BOARD_PLAN;
+  }
+
+  return {
+    watermark: (raw as Partial<PublicBoardPlan>).watermark === true,
+  };
 }
 
 /**
@@ -26,11 +48,13 @@ export default function LiveBoard({
   board: initialBoard,
   mediaItems: initialMedia,
   messages: initialMessages,
+  boardPlan: initialBoardPlan,
   TemplateComponent,
 }: LiveBoardProps) {
   const [board, setBoard] = useState(initialBoard);
   const [mediaItems, setMediaItems] = useState(initialMedia);
   const [messages, setMessages] = useState(initialMessages);
+  const [boardPlan, setBoardPlan] = useState(initialBoardPlan);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -38,21 +62,25 @@ export default function LiveBoard({
   const { t } = useLocale();
 
   // --- Cursor auto-hide ---
-  const resetCursorTimer = useCallback(() => {
-    setCursorVisible(true);
+  const startCursorTimer = useCallback(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => setCursorVisible(false), CURSOR_HIDE_DELAY);
   }, []);
 
+  const resetCursorTimer = useCallback(() => {
+    setCursorVisible(true);
+    startCursorTimer();
+  }, [startCursorTimer]);
+
   useEffect(() => {
-    resetCursorTimer();
+    startCursorTimer();
     const onMove = () => resetCursorTimer();
     window.addEventListener("mousemove", onMove);
     return () => {
       window.removeEventListener("mousemove", onMove);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [resetCursorTimer]);
+  }, [resetCursorTimer, startCursorTimer]);
 
   // --- Fullscreen sync ---
   useEffect(() => {
@@ -87,6 +115,7 @@ export default function LiveBoard({
         createdAt: data.createdAt,
         updatedAt: data.updatedAt,
       });
+      setBoardPlan(parsePublicBoardPlan(data.boardPlan));
       setMediaItems(data.mediaItems ?? []);
       setMessages(data.messages ?? []);
     } catch {
@@ -114,6 +143,7 @@ export default function LiveBoard({
       style={{ cursor: cursorVisible ? "auto" : "none" }}
     >
       <TemplateComponent board={board} mediaItems={mediaItems} messages={messages} />
+      {boardPlan.watermark && <WatermarkOverlay />}
 
       {/* Expand / Restore button */}
       <button

--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -50,13 +50,12 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
   useEffect(() => {
     if (!current) return;
 
-    if (current.type !== "image") {
-      setImageLoaded(true);
-      return;
-    }
+    const loaded =
+      current.type !== "image" || Boolean(currentImageRef.current?.complete);
+    const raf = requestAnimationFrame(() => setImageLoaded(loaded));
 
-    setImageLoaded(Boolean(currentImageRef.current?.complete));
-  }, [current?.id, current?.filePath, current?.type]);
+    return () => cancelAnimationFrame(raf);
+  }, [current]);
 
   // --- Auto-advance timer (starts only after the current image has loaded) ---
   useEffect(() => {

--- a/src/components/board/TickerText.tsx
+++ b/src/components/board/TickerText.tsx
@@ -40,9 +40,9 @@ export function TickerText({
   }, []);
 
   useEffect(() => {
-    setReady(false);
     // Use requestAnimationFrame to ensure DOM is laid out before measuring
     const raf = requestAnimationFrame(() => {
+      setReady(false);
       measure();
     });
     return () => cancelAnimationFrame(raf);

--- a/src/components/board/WatermarkOverlay.tsx
+++ b/src/components/board/WatermarkOverlay.tsx
@@ -1,0 +1,22 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+
+import { KeinageLogo } from "@/components/KeinageLogo";
+
+/**
+ * Free plan attribution shown inside the board canvas.
+ * This client-rendered notice is not a tamper-proof DRM control.
+ */
+export function WatermarkOverlay() {
+  return (
+    <div
+      className="pointer-events-none absolute bottom-[clamp(1rem,2.5vh,2rem)] left-1/2 z-40 flex -translate-x-1/2 flex-col items-center gap-1 text-white opacity-30 mix-blend-difference [--logo-screen:rgba(0,0,0,0.75)]"
+      aria-label="Powered by Keinage"
+    >
+      <KeinageLogo className="h-8 w-16 drop-shadow-[0_1px_8px_rgba(0,0,0,0.35)] sm:h-9 sm:w-[4.5rem]" />
+      <span className="whitespace-nowrap text-[0.65rem] font-semibold tracking-normal drop-shadow-[0_1px_8px_rgba(0,0,0,0.35)] sm:text-[0.7rem]">
+        Powered by Keinage
+      </span>
+    </div>
+  );
+}

--- a/src/components/board/WeatherDisplay.tsx
+++ b/src/components/board/WeatherDisplay.tsx
@@ -54,10 +54,15 @@ export function WeatherDisplay({
   }, [boardId]);
 
   useEffect(() => {
-    fetchWeather();
+    const initialTimer = setTimeout(() => {
+      void fetchWeather();
+    }, 0);
     // Refresh every 30 minutes
     const interval = setInterval(fetchWeather, 30 * 60 * 1000);
-    return () => clearInterval(interval);
+    return () => {
+      clearTimeout(initialTimer);
+      clearInterval(interval);
+    };
   }, [fetchWeather]);
 
   if (!weather) return null;

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -91,10 +91,14 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
       typeof data.config === "string" ? JSON.parse(data.config) : data.config;
     setConfig(parsed && typeof parsed === "object" ? parsed : {});
     setLoading(false);
-  }, [boardId]);
+  }, [boardId, t]);
 
   useEffect(() => {
-    fetchBoard();
+    const timer = setTimeout(() => {
+      void fetchBoard();
+    }, 0);
+
+    return () => clearTimeout(timer);
   }, [fetchBoard]);
 
   async function handleSave() {

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -16,7 +16,10 @@ interface UseSSEOptions {
  */
 export function useSSE({ boardId, onEvent }: UseSSEOptions) {
   const onEventRef = useRef(onEvent);
-  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
 
   const connect = useCallback(() => {
     const es = new EventSource(`/api/sse/${boardId}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,11 @@ export type NewBoard = InferInsertModel<typeof boards>;
 export type NewMediaItem = InferInsertModel<typeof mediaItems>;
 export type NewMessage = InferInsertModel<typeof messages>;
 
+// Public board payload includes only safe display flags derived server-side.
+export interface PublicBoardPlan {
+  watermark: boolean;
+}
+
 // Template types
 export type TemplateId = "simple" | "photo-clock" | "retro" | "message" | "call-number";
 


### PR DESCRIPTION
## 概要
- Free plan の board 表示に Keinage ロゴと `Powered by Keinage` のウォーターマークを追加
- board 表示と public board API で Owner の effective plan から `boardPlan.watermark` をサーバー側算出
- ブラウザ上のウォーターマークは完全な改ざん防止ではない旨を実装コメントと docs に明記
- 既存 lint error を解消するため、関連する hook 呼び出しのタイミングを最小限整理

## 確認
- `pnpm lint`（warning 7 件、error 0）
- `pnpm build`

Closes #148