### PR TITLE
refactor: 動画付きボードの初期表示を高速化

### DIFF
--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -42,6 +42,7 @@ const ALLOWED_IMAGE_TYPES = [
 ];
 const ALLOWED_VIDEO_TYPES = ["video/mp4", "video/webm"];
 const ALLOWED_TYPES = [...ALLOWED_IMAGE_TYPES, ...ALLOWED_VIDEO_TYPES];
+const ALLOWED_VIDEO_POSTER_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
 function planLimitResponse(error: unknown) {
   if (isPlanLimitError(error)) {
@@ -97,6 +98,7 @@ export async function POST(request: NextRequest) {
   }
 
   const file = formData.get("file");
+  const poster = formData.get("poster");
   const boardId = formData.get("boardId");
   const duration = formData.get("duration");
 
@@ -182,8 +184,20 @@ export async function POST(request: NextRequest) {
     buffer = Buffer.from(await resizeImage(buffer, sanitizedExt, maxLongEdge));
   }
 
-  const thumbnail =
+  let thumbnail =
     mediaType === "image" ? await generateThumbnail(buffer, filename) : null;
+
+  if (mediaType === "video" && poster instanceof File && poster.size > 0) {
+    if (!ALLOWED_VIDEO_POSTER_TYPES.includes(poster.type)) {
+      return NextResponse.json(
+        { error: "Unsupported poster image type" },
+        { status: 400 },
+      );
+    }
+
+    const posterBuffer = Buffer.from(await poster.arrayBuffer());
+    thumbnail = await generateThumbnail(posterBuffer, "poster.jpg");
+  }
 
   try {
     await assertCanUploadMedia({

--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLocale } from "@/components/i18n/LocaleProvider";
+import { thumbUrl } from "@/lib/utils";
 import type { MediaItem } from "@/types";
 
 /** How many upcoming images to preload ahead of the current slide. */
@@ -16,6 +17,80 @@ interface MediaSliderProps {
   interval?: number;
   /** How media fits the container: "contain" (show all) or "cover" (fill, may crop) */
   objectFit?: "contain" | "cover";
+}
+
+interface DeferredVideoSlideProps {
+  item: MediaItem;
+  fitClass: string;
+  onEnded: () => void;
+}
+
+function DeferredVideoSlide({ item, fitClass, onEnded }: DeferredVideoSlideProps) {
+  const { t } = useLocale();
+  const [shouldLoad, setShouldLoad] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [posterFailed, setPosterFailed] = useState(false);
+  const [videoFailed, setVideoFailed] = useState(false);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const poster = thumbUrl(item.filePath);
+  const showLoading = !isPlaying && !videoFailed;
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      setShouldLoad(true);
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div className="relative h-full w-full bg-black">
+      <div className="absolute inset-0 bg-black" aria-hidden />
+      {!isPlaying && !posterFailed && (
+        <img
+          src={poster}
+          alt=""
+          className={`absolute inset-0 z-10 h-full w-full ${fitClass}`}
+          onError={() => setPosterFailed(true)}
+        />
+      )}
+      <video
+        ref={videoRef}
+        src={shouldLoad && !videoFailed ? item.filePath : undefined}
+        poster={posterFailed ? undefined : poster}
+        preload="metadata"
+        className={`absolute inset-0 z-20 h-full w-full transition-opacity duration-300 ${fitClass} ${
+          isPlaying ? "opacity-100" : "opacity-0"
+        }`}
+        autoPlay
+        loop
+        muted
+        playsInline
+        onCanPlay={() => {
+          void videoRef.current?.play().catch(() => {
+            // Muted autoplay should normally succeed; leave the poster visible if it does not.
+          });
+        }}
+        onPlaying={() => setIsPlaying(true)}
+        onEnded={onEnded}
+        onError={() => {
+          setVideoFailed(true);
+          console.error("[MediaSlider] Failed to load video", {
+            mediaId: item.id,
+            filePath: item.filePath,
+          });
+        }}
+      />
+      {showLoading && (
+        <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 bg-black/20 text-white">
+          <div className="size-10 animate-spin rounded-full border-2 border-white/25 border-t-white" />
+          <span className="rounded bg-black/35 px-3 py-1 text-sm font-medium">
+            {t("common.loading")}
+          </span>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }: MediaSliderProps) {
@@ -102,10 +177,10 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
   const fitClass = objectFit === "cover" ? "object-cover" : "object-contain";
 
   return (
-    <div className="relative h-full w-full overflow-hidden bg-black">
+    <div className="relative isolate h-full w-full overflow-hidden bg-black">
       <AnimatePresence mode="wait">
         <motion.div
-          key={current.id}
+          key={`${current.id}:${current.filePath}`}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -113,12 +188,9 @@ export function MediaSlider({ mediaItems, interval = 5, objectFit = "contain" }:
           className="absolute inset-0"
         >
           {current.type === "video" ? (
-            <video
-              src={current.filePath}
-              className={`h-full w-full ${fitClass}`}
-              autoPlay
-              muted
-              playsInline
+            <DeferredVideoSlide
+              item={current}
+              fitClass={fitClass}
               onEnded={advance}
             />
           ) : (

--- a/src/components/dashboard/MediaUploadZone.tsx
+++ b/src/components/dashboard/MediaUploadZone.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { AlertCircle, Upload, X, GripVertical, Trash2, Image, Film } from "lucide-react";
+import { AlertCircle, Upload, X, GripVertical, Trash2, Image as ImageIcon, Film } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -22,6 +22,96 @@ interface MediaUploadZoneProps {
 interface UploadProgress {
   name: string;
   progress: number;
+}
+
+const VIDEO_TYPES = new Set(["video/mp4", "video/webm"]);
+const VIDEO_POSTER_MIME_TYPE = "image/jpeg";
+const VIDEO_POSTER_EXTENSION = ".jpg";
+
+function waitForVideoEvent(video: HTMLVideoElement, eventName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out while waiting for ${eventName}`));
+    }, 8000);
+
+    const cleanup = () => {
+      window.clearTimeout(timeout);
+      video.removeEventListener(eventName, handleEvent);
+      video.removeEventListener("error", handleError);
+    };
+
+    const handleEvent = () => {
+      cleanup();
+      resolve();
+    };
+
+    const handleError = () => {
+      cleanup();
+      reject(new Error("Could not load video for poster generation"));
+    };
+
+    video.addEventListener(eventName, handleEvent, { once: true });
+    video.addEventListener("error", handleError, { once: true });
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    canvas.toBlob(resolve, VIDEO_POSTER_MIME_TYPE, 0.82);
+  });
+}
+
+async function createVideoPoster(file: File): Promise<File | null> {
+  if (!VIDEO_TYPES.has(file.type)) return null;
+
+  const objectUrl = URL.createObjectURL(file);
+  const video = document.createElement("video");
+  video.muted = true;
+  video.preload = "metadata";
+  video.playsInline = true;
+  video.src = objectUrl;
+
+  try {
+    video.load();
+    await waitForVideoEvent(video, "loadedmetadata");
+
+    const duration = Number.isFinite(video.duration) ? video.duration : 0;
+    const seekTarget = duration > 0.3 ? Math.min(0.25, duration / 3) : 0;
+    if (seekTarget > 0) {
+      video.currentTime = seekTarget;
+      await waitForVideoEvent(video, "seeked");
+    } else if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+      await waitForVideoEvent(video, "loadeddata");
+    }
+
+    const width = video.videoWidth;
+    const height = video.videoHeight;
+    if (width <= 0 || height <= 0) return null;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) return null;
+    context.drawImage(video, 0, 0, width, height);
+
+    const blob = await canvasToBlob(canvas);
+    if (!blob) return null;
+
+    const baseName = file.name.replace(/\.[^.]+$/, "");
+    return new File([blob], `${baseName}${VIDEO_POSTER_EXTENSION}`, {
+      type: VIDEO_POSTER_MIME_TYPE,
+    });
+  } catch (error) {
+    console.error("[MediaUploadZone] Failed to generate video poster", {
+      filename: file.name,
+      error,
+    });
+    return null;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
 }
 
 export default function MediaUploadZone({
@@ -58,6 +148,10 @@ export default function MediaUploadZone({
         const formData = new FormData();
         formData.append("file", file);
         formData.append("boardId", boardId);
+        const poster = await createVideoPoster(file);
+        if (poster) {
+          formData.append("poster", poster);
+        }
 
         try {
           const res = await fetch("/api/media", {
@@ -310,6 +404,14 @@ export default function MediaUploadZone({
                   />
                 ) : (
                   <div className="flex size-full items-center justify-center">
+                    <img
+                      src={thumbUrl(item.filePath)}
+                      alt=""
+                      className="absolute inset-0 size-full object-cover"
+                      onError={(e) => {
+                        (e.currentTarget.style.display = "none");
+                      }}
+                    />
                     <Film className="size-5 text-muted-foreground" />
                   </div>
                 )}
@@ -320,7 +422,7 @@ export default function MediaUploadZone({
                 <div className="flex items-center gap-2">
                   <Badge variant="outline" className="shrink-0">
                     {item.type === "image" ? (
-                      <Image className="mr-1 size-3" />
+                      <ImageIcon className="mr-1 size-3" />
                     ) : (
                       <Film className="mr-1 size-3" />
                     )}

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -1244,9 +1244,16 @@ export function SettingsClient({
                         alt=""
                         className="h-full w-full object-cover"
                       />
+                    ) : file.thumbPath ? (
+                      <img
+                        src={file.thumbPath}
+                        alt=""
+                        className="h-full w-full object-cover"
+                      />
                     ) : (
                       <video
                         src={file.filePath}
+                        preload="metadata"
                         muted
                         className="h-full w-full object-cover"
                       />

--- a/src/lib/media-storage.ts
+++ b/src/lib/media-storage.ts
@@ -197,7 +197,7 @@ export function storageKeyFromPublicPath(filePath: string): string {
 export function thumbnailStorageKeyFromFilename(filename: string): string {
   const safeName = path.basename(filename);
   const ext = path.extname(safeName).toLowerCase();
-  const thumbExt = ext === ".gif" ? ".jpg" : ext;
+  const thumbExt = [".gif", ".mp4", ".webm"].includes(ext) ? ".jpg" : ext;
   const base = path.basename(safeName, ext);
   return `${THUMB_PREFIX}${base}${thumbExt}`;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,6 +11,7 @@ export function cn(...inputs: ClassValue[]) {
  * Derive the thumbnail URL from an original upload path.
  * e.g. `/uploads/uuid.jpg` -> `/uploads/thumbs/uuid.jpg`
  *      `/uploads/uuid.gif` -> `/uploads/thumbs/uuid.jpg` (GIF → JPEG thumb)
+ *      `/uploads/uuid.mp4` -> `/uploads/thumbs/uuid.jpg` (video poster)
  */
 export function thumbUrl(filePath: string): string {
   const parts = filePath.split("/");
@@ -18,7 +19,7 @@ export function thumbUrl(filePath: string): string {
   const dotIdx = filename.lastIndexOf(".");
   const name = dotIdx >= 0 ? filename.slice(0, dotIdx) : filename;
   const ext = dotIdx >= 0 ? filename.slice(dotIdx).toLowerCase() : "";
-  const thumbExt = ext === ".gif" ? ".jpg" : ext;
+  const thumbExt = [".gif", ".mp4", ".webm"].includes(ext) ? ".jpg" : ext;
   return `/uploads/thumbs/${name}${thumbExt}`;
 }
 


### PR DESCRIPTION
## 概要
- ボード表示の動画スライドを初回描画後に `src` 設定する遅延ロード方式へ変更
- `video` は `preload="metadata"`、`muted` / `playsInline` / `loop` / `autoPlay` を維持
- 動画アップロード時にブラウザで poster JPEG を生成し、`/uploads/thumbs/<name>.jpg` として保存
- 生成した poster をボード表示前の poster と、ボード編集画面・メディア管理画面の動画サムネイルに利用
- 動画読み込み中は poster または黒背景 fallback の上に読み込み中アニメーションを表示
- poster 未取得・動画読み込み失敗時もボード全体が崩れないように調整

## 補足
- サーバー側での MP4 フレーム抽出や HLS/DASH 対応は行っていません。poster はアップロード時にブラウザで生成します。

## 確認
- `pnpm lint`（warning 9 件、error 0）
- `pnpm build`

Closes #178