### PR TITLE
呼び出し画面テンプレートのURLがPrivate IPになる問題を修正

### DIFF
--- a/src/components/dashboard/CallScreenAdmin.tsx
+++ b/src/components/dashboard/CallScreenAdmin.tsx
@@ -41,10 +41,18 @@ export default function CallScreenAdmin({
   // Fetch local network IP for the URL
   useEffect(() => {
     (async () => {
+      const origin = window.location.origin;
+      const hostname = window.location.hostname;
+
+      if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+        setNetworkOrigin(origin);
+        return;
+      }
+
       try {
         const res = await fetch("/api/network");
         if (!res.ok) {
-          setNetworkOrigin(window.location.origin);
+          setNetworkOrigin(origin);
           return;
         }
         const data = await res.json();
@@ -53,10 +61,10 @@ export default function CallScreenAdmin({
           const protocol = window.location.protocol;
           setNetworkOrigin(`${protocol}//${data.ip}${port ? `:${port}` : ""}`);
         } else {
-          setNetworkOrigin(window.location.origin);
+          setNetworkOrigin(origin);
         }
       } catch {
-        setNetworkOrigin(window.location.origin);
+        setNetworkOrigin(origin);
       }
     })();
   }, []);


### PR DESCRIPTION
## 概要
- 呼び出し画面テンプレートの呼び出し画面 URL が、非 localhost 環境でも private IP になる問題を修正します

## 変更内容
- `CallScreenAdmin` の URL 生成ロジックを更新
- `localhost` / `127.0.0.1` の場合のみ `/api/network` からローカルIPを採用
- それ以外の環境では `window.location.origin` をそのまま使用

## 確認
- `pnpm build`

Closes #221
