### PR TITLE
fix: SafariでGoogleログイン開始時にCORSエラーになる問題を修正

### DIFF
--- a/src/app/api/auth/account-deletion/complete/route.ts
+++ b/src/app/api/auth/account-deletion/complete/route.ts
@@ -79,8 +79,8 @@ export async function POST(request: NextRequest) {
   }
 
   const response = NextResponse.json({ success: true, summary });
-  response.cookies.set(AUTH_SESSION_COOKIE, "", buildExpiredAuthCookieOptions());
-  clearDeviceAuthCookie(response);
-  clearLegacyLastUserCookie(response);
+  response.cookies.set(AUTH_SESSION_COOKIE, "", buildExpiredAuthCookieOptions(request));
+  clearDeviceAuthCookie(response, request);
+  clearLegacyLastUserCookie(response, request);
   return response;
 }

--- a/src/app/api/auth/credentials/complete/route.ts
+++ b/src/app/api/auth/credentials/complete/route.ts
@@ -134,11 +134,11 @@ export async function POST(request: NextRequest) {
     authenticatedAt: now,
   });
   const res = NextResponse.json({ success: true, userId: createdUser.userId });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SETUP_SESSION_MAX_AGE));
-  setDeviceAuthCookie(res, deviceToken);
-  clearLegacyLastUserCookie(res);
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SETUP_SESSION_MAX_AGE, request));
+  setDeviceAuthCookie(res, deviceToken, request);
+  clearLegacyLastUserCookie(res, request);
   if (cookieStore.get(SIGNUP_REQUEST_COOKIE)) {
-    res.cookies.set(SIGNUP_REQUEST_COOKIE, "", buildExpiredAuthCookieOptions());
+    res.cookies.set(SIGNUP_REQUEST_COOKIE, "", buildExpiredAuthCookieOptions(request));
   }
 
   return res;

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -1,15 +1,14 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
 import { NextRequest, NextResponse } from "next/server";
+import { eq, or, and, gt } from "drizzle-orm";
 import { db } from "@/db";
 import { users, pinAttempts, authSessions } from "@/db/schema";
-import { eq, or, and, gt } from "drizzle-orm";
 import {
   verifyPassword,
   AUTH_SESSION_COOKIE,
   SESSION_MAX_AGE,
   buildAuthCookieOptions,
-  createCookieCommittedNavigationPage,
 } from "@/lib/auth";
 import {
   DEVICE_AUTH_COOKIE,
@@ -40,49 +39,16 @@ import {
   getWebAuthnPostAuthAction,
   isWebAuthnVerifiedAtSessionCreation,
 } from "@/lib/webauthn";
-import { sanitizeRedirectTarget } from "@/lib/utils";
-
-function getRequestedRedirectTo(request: NextRequest, contentType: string, body: {
-  redirectTo?: string;
-}) {
-  const bodyRedirectTo = sanitizeRedirectTarget(body.redirectTo ?? null);
-  if (bodyRedirectTo) {
-    return bodyRedirectTo;
-  }
-
-  if (!contentType.includes("application/x-www-form-urlencoded")) {
-    return null;
-  }
-
-  return sanitizeRedirectTarget(request.nextUrl.searchParams.get("redirectTo"));
-}
-
-function createLoginRedirectResponse(request: NextRequest, input: {
-  redirectTo: string | null;
-  error: string;
-}) {
-  const url = new URL("/pin/login", request.url);
-  if (input.redirectTo) {
-    url.searchParams.set("redirectTo", input.redirectTo);
-  }
-  url.searchParams.set("error", input.error);
-  return NextResponse.redirect(url, 303);
-}
 
 /** POST /api/auth/credentials/login — email/userId + password login */
 export async function POST(request: NextRequest) {
   const clientIp = resolveRateLimitClientIp(request);
-  const contentType = request.headers.get("content-type") ?? "";
-  const body = contentType.includes("application/json")
-    ? await request.json()
-    : Object.fromEntries((await request.formData()).entries());
+
+  const body = await request.json();
   const { identifier, password } = body as {
     identifier?: string;
     password?: string;
-    redirectTo?: string;
   };
-  const requestedRedirectTo = getRequestedRedirectTo(request, contentType, body);
-  const expectsJson = contentType.includes("application/json");
 
   const normalizedIdentifier = identifier?.trim() ?? "";
   const rateLimitKey = buildRateLimitKey({
@@ -91,7 +57,6 @@ export async function POST(request: NextRequest) {
     subject: normalizedIdentifier || "missing-identifier",
   });
 
-  // Rate-limit per client/subject bucket. Proxy headers are trusted only when configured.
   const blockThreshold = new Date(
     Date.now() - IP_BLOCK_DURATION_MS,
   ).toISOString();
@@ -106,17 +71,21 @@ export async function POST(request: NextRequest) {
     );
 
   if (recentAttempts.length >= MAX_PIN_ATTEMPTS) {
-    const error = "試行回数の上限に達しました。24時間後に再度お試しください。";
-    return expectsJson
-      ? NextResponse.json({ error, blocked: true }, { status: 429 })
-      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+    return NextResponse.json(
+      {
+        error:
+          "試行回数の上限に達しました。24時間後に再度お試しください。",
+        blocked: true,
+      },
+      { status: 429 },
+    );
   }
 
   if (!normalizedIdentifier || !password) {
-    const error = "ユーザーIDまたはメールアドレスとパスワードを入力してください";
-    return expectsJson
-      ? NextResponse.json({ error }, { status: 400 })
-      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+    return NextResponse.json(
+      { error: "ユーザーIDまたはメールアドレスとパスワードを入力してください" },
+      { status: 400 },
+    );
   }
 
   const user = await db.query.users.findFirst({
@@ -132,23 +101,26 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  // Constant-time failure to prevent user enumeration
   if (!user) {
     await db.insert(pinAttempts).values({ ipAddress: rateLimitKey });
-    const error = "ユーザーIDまたはパスワードが正しくありません";
-    return expectsJson
-      ? NextResponse.json({ error }, { status: 401 })
-      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+    return NextResponse.json(
+      { error: "ユーザーIDまたはパスワードが正しくありません" },
+      { status: 401 },
+    );
   }
 
   const now = new Date().toISOString();
   if (isAccountLocked(user.lockedUntil, now)) {
-    const error = user.passwordHash
-      ? "このアカウントは一時的にロックされています。パスワードを再設定するか、30分後に再度お試しください。"
-      : "このアカウントは一時的にロックされています。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。";
-    return expectsJson
-      ? NextResponse.json({ error, blocked: true, locked: true }, { status: 423 })
-      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+    return NextResponse.json(
+      {
+        error: user.passwordHash
+          ? "このアカウントは一時的にロックされています。パスワードを再設定するか、30分後に再度お試しください。"
+          : "このアカウントは一時的にロックされています。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。",
+        blocked: true,
+        locked: true,
+      },
+      { status: 423 },
+    );
   }
 
   if (!user.passwordHash) {
@@ -164,16 +136,24 @@ export async function POST(request: NextRequest) {
       .where(eq(users.id, user.id));
 
     if (failedState.lockedNow) {
-      const error = "Google連携ユーザに対して5回連続でパスワードログインが失敗したため、アカウントを30分間ロックしました。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。";
-      return expectsJson
-        ? NextResponse.json({ error, blocked: true, locked: true }, { status: 423 })
-        : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+      return NextResponse.json(
+        {
+          error:
+            "Google連携ユーザに対して5回連続でパスワードログインが失敗したため、アカウントを30分間ロックしました。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。",
+          blocked: true,
+          locked: true,
+        },
+        { status: 423 },
+      );
     }
 
-    const error = `当該ユーザはGoogleアカウント連携をしているのでパスワードログインやパスワードリセットはできません。Googleでログインしてください。PINを忘れた場合は、Googleログイン後にPIN初期化を利用してください${failedState.remaining > 0 ? `（残り${failedState.remaining}回でロック）` : ""}`;
-    return expectsJson
-      ? NextResponse.json({ error, remaining: failedState.remaining }, { status: 401 })
-      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+    return NextResponse.json(
+      {
+        error: `当該ユーザはGoogleアカウント連携をしているのでパスワードログインやパスワードリセットはできません。Googleでログインしてください。PINを忘れた場合は、Googleログイン後にPIN初期化を利用してください${failedState.remaining > 0 ? `（残り${failedState.remaining}回でロック）` : ""}`,
+        remaining: failedState.remaining,
+      },
+      { status: 401 },
+    );
   }
 
   const valid = await verifyPassword(password, user.passwordHash);
@@ -193,26 +173,32 @@ export async function POST(request: NextRequest) {
       .where(eq(users.id, user.id));
 
     if (failedState.lockedNow) {
-      const error = "5回連続で認証に失敗したため、アカウントを30分間ロックしました。パスワード再設定後、または30分後に再度お試しください。";
-      return expectsJson
-        ? NextResponse.json({ error, blocked: true, locked: true }, { status: 423 })
-        : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+      return NextResponse.json(
+        {
+          error:
+            "5回連続で認証に失敗したため、アカウントを30分間ロックしました。パスワード再設定後、または30分後に再度お試しください。",
+          blocked: true,
+          locked: true,
+        },
+        { status: 423 },
+      );
     }
 
-    const error = `ユーザーIDまたはパスワードが正しくありません${failedState.remaining > 0 ? `（残り${failedState.remaining}回）` : ""}`;
-    return expectsJson
-      ? NextResponse.json({ error, remaining: failedState.remaining }, { status: 401 })
-      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
+    return NextResponse.json(
+      {
+        error: `ユーザーIDまたはパスワードが正しくありません${failedState.remaining > 0 ? `（残り${failedState.remaining}回）` : ""}`,
+        remaining: failedState.remaining,
+      },
+      { status: 401 },
+    );
   }
 
-  // Clear attempts for the successfully authenticated subject bucket.
   await db.delete(pinAttempts).where(eq(pinAttempts.ipAddress, rateLimitKey));
 
   if (process.env.NODE_ENV !== "production") {
     console.log("[credentials/login] Password verified OK");
   }
 
-  // Record full-auth timestamp
   await db
     .update(users)
     .set(buildSuccessfulAuthState(now))
@@ -231,7 +217,6 @@ export async function POST(request: NextRequest) {
     authenticatedAt: now,
   });
 
-  // Create session
   const sessionToken = generateSessionToken();
   const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000).toISOString();
 
@@ -247,15 +232,6 @@ export async function POST(request: NextRequest) {
     acceptLanguage: request.headers.get("accept-language"),
   });
   const webauthnAction = await getWebAuthnPostAuthAction(user);
-  const nextPath = webauthnAction === "register"
-    ? requestedRedirectTo
-      ? `/passkey/setup?redirectTo=${encodeURIComponent(requestedRedirectTo)}`
-      : "/passkey/setup"
-    : webauthnAction === "authenticate"
-      ? requestedRedirectTo
-        ? `/passkey/verify?redirectTo=${encodeURIComponent(requestedRedirectTo)}`
-        : "/passkey/verify"
-      : requestedRedirectTo ?? "/boards";
   const res = NextResponse.json({
     success: true,
     locale,
@@ -266,24 +242,9 @@ export async function POST(request: NextRequest) {
         ? "/passkey/verify"
         : null,
   });
-  const response = expectsJson
-    ? res
-    : new NextResponse(
-        createCookieCommittedNavigationPage({
-          redirectTo: new URL(nextPath, request.url).toString(),
-          title: "Signing in...",
-          message: "サインインを完了しています...",
-        }),
-        {
-          headers: {
-            "content-type": "text/html; charset=utf-8",
-            "cache-control": "no-store",
-          },
-        },
-      );
-  response.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
-  setDeviceAuthCookie(response, deviceToken);
-  setLocaleCookie(response, locale);
-  clearLegacyLastUserCookie(response);
-  return response;
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE, request));
+  setDeviceAuthCookie(res, deviceToken, request);
+  setLocaleCookie(res, locale);
+  clearLegacyLastUserCookie(res, request);
+  return res;
 }

--- a/src/app/api/auth/credentials/login/route.ts
+++ b/src/app/api/auth/credentials/login/route.ts
@@ -9,6 +9,7 @@ import {
   AUTH_SESSION_COOKIE,
   SESSION_MAX_AGE,
   buildAuthCookieOptions,
+  createCookieCommittedNavigationPage,
 } from "@/lib/auth";
 import {
   DEVICE_AUTH_COOKIE,
@@ -39,16 +40,49 @@ import {
   getWebAuthnPostAuthAction,
   isWebAuthnVerifiedAtSessionCreation,
 } from "@/lib/webauthn";
+import { sanitizeRedirectTarget } from "@/lib/utils";
+
+function getRequestedRedirectTo(request: NextRequest, contentType: string, body: {
+  redirectTo?: string;
+}) {
+  const bodyRedirectTo = sanitizeRedirectTarget(body.redirectTo ?? null);
+  if (bodyRedirectTo) {
+    return bodyRedirectTo;
+  }
+
+  if (!contentType.includes("application/x-www-form-urlencoded")) {
+    return null;
+  }
+
+  return sanitizeRedirectTarget(request.nextUrl.searchParams.get("redirectTo"));
+}
+
+function createLoginRedirectResponse(request: NextRequest, input: {
+  redirectTo: string | null;
+  error: string;
+}) {
+  const url = new URL("/pin/login", request.url);
+  if (input.redirectTo) {
+    url.searchParams.set("redirectTo", input.redirectTo);
+  }
+  url.searchParams.set("error", input.error);
+  return NextResponse.redirect(url, 303);
+}
 
 /** POST /api/auth/credentials/login — email/userId + password login */
 export async function POST(request: NextRequest) {
   const clientIp = resolveRateLimitClientIp(request);
-
-  const body = await request.json();
+  const contentType = request.headers.get("content-type") ?? "";
+  const body = contentType.includes("application/json")
+    ? await request.json()
+    : Object.fromEntries((await request.formData()).entries());
   const { identifier, password } = body as {
     identifier?: string;
     password?: string;
+    redirectTo?: string;
   };
+  const requestedRedirectTo = getRequestedRedirectTo(request, contentType, body);
+  const expectsJson = contentType.includes("application/json");
 
   const normalizedIdentifier = identifier?.trim() ?? "";
   const rateLimitKey = buildRateLimitKey({
@@ -72,21 +106,17 @@ export async function POST(request: NextRequest) {
     );
 
   if (recentAttempts.length >= MAX_PIN_ATTEMPTS) {
-    return NextResponse.json(
-      {
-        error:
-          "試行回数の上限に達しました。24時間後に再度お試しください。",
-        blocked: true,
-      },
-      { status: 429 },
-    );
+    const error = "試行回数の上限に達しました。24時間後に再度お試しください。";
+    return expectsJson
+      ? NextResponse.json({ error, blocked: true }, { status: 429 })
+      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
   }
 
   if (!normalizedIdentifier || !password) {
-    return NextResponse.json(
-      { error: "ユーザーIDまたはメールアドレスとパスワードを入力してください" },
-      { status: 400 },
-    );
+    const error = "ユーザーIDまたはメールアドレスとパスワードを入力してください";
+    return expectsJson
+      ? NextResponse.json({ error }, { status: 400 })
+      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
   }
 
   const user = await db.query.users.findFirst({
@@ -105,24 +135,20 @@ export async function POST(request: NextRequest) {
   // Constant-time failure to prevent user enumeration
   if (!user) {
     await db.insert(pinAttempts).values({ ipAddress: rateLimitKey });
-    return NextResponse.json(
-      { error: "ユーザーIDまたはパスワードが正しくありません" },
-      { status: 401 },
-    );
+    const error = "ユーザーIDまたはパスワードが正しくありません";
+    return expectsJson
+      ? NextResponse.json({ error }, { status: 401 })
+      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
   }
 
   const now = new Date().toISOString();
   if (isAccountLocked(user.lockedUntil, now)) {
-    return NextResponse.json(
-      {
-        error: user.passwordHash
-          ? "このアカウントは一時的にロックされています。パスワードを再設定するか、30分後に再度お試しください。"
-          : "このアカウントは一時的にロックされています。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。",
-        blocked: true,
-        locked: true,
-      },
-      { status: 423 },
-    );
+    const error = user.passwordHash
+      ? "このアカウントは一時的にロックされています。パスワードを再設定するか、30分後に再度お試しください。"
+      : "このアカウントは一時的にロックされています。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。";
+    return expectsJson
+      ? NextResponse.json({ error, blocked: true, locked: true }, { status: 423 })
+      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
   }
 
   if (!user.passwordHash) {
@@ -138,24 +164,16 @@ export async function POST(request: NextRequest) {
       .where(eq(users.id, user.id));
 
     if (failedState.lockedNow) {
-      return NextResponse.json(
-        {
-          error:
-            "Google連携ユーザに対して5回連続でパスワードログインが失敗したため、アカウントを30分間ロックしました。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。",
-          blocked: true,
-          locked: true,
-        },
-        { status: 423 },
-      );
+      const error = "Google連携ユーザに対して5回連続でパスワードログインが失敗したため、アカウントを30分間ロックしました。Googleでログインし、必要に応じてPIN初期化を利用するか、30分後に再度お試しください。";
+      return expectsJson
+        ? NextResponse.json({ error, blocked: true, locked: true }, { status: 423 })
+        : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
     }
 
-    return NextResponse.json(
-      {
-        error: `当該ユーザはGoogleアカウント連携をしているのでパスワードログインやパスワードリセットはできません。Googleでログインしてください。PINを忘れた場合は、Googleログイン後にPIN初期化を利用してください${failedState.remaining > 0 ? `（残り${failedState.remaining}回でロック）` : ""}`,
-        remaining: failedState.remaining,
-      },
-      { status: 401 },
-    );
+    const error = `当該ユーザはGoogleアカウント連携をしているのでパスワードログインやパスワードリセットはできません。Googleでログインしてください。PINを忘れた場合は、Googleログイン後にPIN初期化を利用してください${failedState.remaining > 0 ? `（残り${failedState.remaining}回でロック）` : ""}`;
+    return expectsJson
+      ? NextResponse.json({ error, remaining: failedState.remaining }, { status: 401 })
+      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
   }
 
   const valid = await verifyPassword(password, user.passwordHash);
@@ -175,24 +193,16 @@ export async function POST(request: NextRequest) {
       .where(eq(users.id, user.id));
 
     if (failedState.lockedNow) {
-      return NextResponse.json(
-        {
-          error:
-            "5回連続で認証に失敗したため、アカウントを30分間ロックしました。パスワード再設定後、または30分後に再度お試しください。",
-          blocked: true,
-          locked: true,
-        },
-        { status: 423 },
-      );
+      const error = "5回連続で認証に失敗したため、アカウントを30分間ロックしました。パスワード再設定後、または30分後に再度お試しください。";
+      return expectsJson
+        ? NextResponse.json({ error, blocked: true, locked: true }, { status: 423 })
+        : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
     }
 
-    return NextResponse.json(
-      {
-        error: `ユーザーIDまたはパスワードが正しくありません${failedState.remaining > 0 ? `（残り${failedState.remaining}回）` : ""}`,
-        remaining: failedState.remaining,
-      },
-      { status: 401 },
-    );
+    const error = `ユーザーIDまたはパスワードが正しくありません${failedState.remaining > 0 ? `（残り${failedState.remaining}回）` : ""}`;
+    return expectsJson
+      ? NextResponse.json({ error, remaining: failedState.remaining }, { status: 401 })
+      : createLoginRedirectResponse(request, { redirectTo: requestedRedirectTo, error });
   }
 
   // Clear attempts for the successfully authenticated subject bucket.
@@ -237,6 +247,15 @@ export async function POST(request: NextRequest) {
     acceptLanguage: request.headers.get("accept-language"),
   });
   const webauthnAction = await getWebAuthnPostAuthAction(user);
+  const nextPath = webauthnAction === "register"
+    ? requestedRedirectTo
+      ? `/passkey/setup?redirectTo=${encodeURIComponent(requestedRedirectTo)}`
+      : "/passkey/setup"
+    : webauthnAction === "authenticate"
+      ? requestedRedirectTo
+        ? `/passkey/verify?redirectTo=${encodeURIComponent(requestedRedirectTo)}`
+        : "/passkey/verify"
+      : requestedRedirectTo ?? "/boards";
   const res = NextResponse.json({
     success: true,
     locale,
@@ -247,9 +266,24 @@ export async function POST(request: NextRequest) {
         ? "/passkey/verify"
         : null,
   });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
-  setDeviceAuthCookie(res, deviceToken);
-  setLocaleCookie(res, locale);
-  clearLegacyLastUserCookie(res);
-  return res;
+  const response = expectsJson
+    ? res
+    : new NextResponse(
+        createCookieCommittedNavigationPage({
+          redirectTo: new URL(nextPath, request.url).toString(),
+          title: "Signing in...",
+          message: "サインインを完了しています...",
+        }),
+        {
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+            "cache-control": "no-store",
+          },
+        },
+      );
+  response.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
+  setDeviceAuthCookie(response, deviceToken);
+  setLocaleCookie(response, locale);
+  clearLegacyLastUserCookie(response);
+  return response;
 }

--- a/src/app/api/auth/credentials/setup/route.ts
+++ b/src/app/api/auth/credentials/setup/route.ts
@@ -163,7 +163,7 @@ export async function POST(request: NextRequest) {
   res.cookies.set(
     SIGNUP_REQUEST_COOKIE,
     signupRequest.id,
-    buildAuthCookieOptions(SIGNUP_REQUEST_COOKIE_MAX_AGE),
+    buildAuthCookieOptions(SIGNUP_REQUEST_COOKIE_MAX_AGE, request),
   );
   return res;
 }

--- a/src/app/api/auth/credentials/shared/complete/route.ts
+++ b/src/app/api/auth/credentials/shared/complete/route.ts
@@ -120,8 +120,8 @@ export async function POST(request: NextRequest) {
     authenticatedAt: now,
   });
   const res = NextResponse.json({ success: true, userId: createdUser.userId });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SETUP_SESSION_MAX_AGE));
-  setDeviceAuthCookie(res, deviceToken);
-  clearLegacyLastUserCookie(res);
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SETUP_SESSION_MAX_AGE, request));
+  setDeviceAuthCookie(res, deviceToken, request);
+  clearLegacyLastUserCookie(res, request);
   return res;
 }

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -6,7 +6,9 @@ import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { db } from "@/db";
 import { authAccounts, googleOAuthFlows, sharedSignupRequests, users } from "@/db/schema";
 import {
+  buildRelativeAppPath,
   buildExpiredAuthCookieOptions,
+  createCookieCommittedNavigationPage,
 } from "@/lib/auth";
 import {
   GOOGLE_AUTH_PROVIDER,
@@ -19,6 +21,7 @@ import { DEVICE_AUTH_COOKIE } from "@/lib/device-auth";
 import { buildSuccessfulAuthState } from "@/lib/account-security";
 import { sendSignupCompletedEmail } from "@/lib/mail";
 import { buildPublicAppUrl } from "@/lib/public-origin";
+import { buildRequestAppUrl } from "@/lib/public-origin";
 import { maybeBootstrapSuperOwner } from "@/lib/super-owner";
 import {
   getWebAuthnPostAuthAction,
@@ -29,22 +32,50 @@ const SETUP_SESSION_MAX_AGE = 60 * 15;
 const GOOGLE_USER_ID_FALLBACK = "google-user";
 
 function absoluteUrl(request: NextRequest, pathname: string) {
-  return buildPublicAppUrl(pathname) ?? new URL(pathname, request.nextUrl.origin).toString();
+  return buildPublicAppUrl(pathname) ?? buildRequestAppUrl(request, pathname) ?? pathname;
 }
 
-function errorRedirect(request: NextRequest, pathname: string, message: string) {
-  const url = new URL(absoluteUrl(request, pathname));
-  url.searchParams.set("error", message);
-  const response = NextResponse.redirect(url);
-  response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
+function errorRedirect(_request: NextRequest, pathname: string, message: string) {
+  const targetPath = buildRelativeAppPath({
+    pathname,
+    searchParams: { error: message },
+  });
+  const response = new NextResponse(
+    createCookieCommittedNavigationPage({
+      redirectTo: buildRequestAppUrl(_request, targetPath) ?? targetPath,
+      title: "Redirecting...",
+      message: "ログイン画面に戻っています...",
+    }),
+    {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    },
+  );
+  response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions(_request));
   return response;
 }
 
-function noticeRedirect(request: NextRequest, pathname: string, notice: string) {
-  const url = new URL(absoluteUrl(request, pathname));
-  url.searchParams.set("notice", notice);
-  const response = NextResponse.redirect(url);
-  response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
+function noticeRedirect(_request: NextRequest, pathname: string, notice: string) {
+  const targetPath = buildRelativeAppPath({
+    pathname,
+    searchParams: { notice },
+  });
+  const response = new NextResponse(
+    createCookieCommittedNavigationPage({
+      redirectTo: buildRequestAppUrl(_request, targetPath) ?? targetPath,
+      title: "Redirecting...",
+      message: "ログイン画面に戻っています...",
+    }),
+    {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    },
+  );
+  response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions(_request));
   return response;
 }
 
@@ -175,9 +206,10 @@ export async function GET(request: NextRequest) {
           : (flow.redirectTo ?? "/boards")
       : "/pin/setup";
     const response = await createSignedInResponse({
+      request,
       requestDeviceToken: deviceToken,
       userId: user.id,
-      redirectTo: absoluteUrl(request, redirectPath),
+      redirectTo: redirectPath,
       setupSessionMaxAge: user.pinHash ? undefined : SETUP_SESSION_MAX_AGE,
       locale: user.locale,
       acceptLanguage: request.headers.get("accept-language"),
@@ -185,7 +217,7 @@ export async function GET(request: NextRequest) {
         ? await isWebAuthnVerifiedAtSessionCreation(user)
         : true,
     });
-    response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
+    response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions(request));
     return response;
   }
 
@@ -239,15 +271,16 @@ export async function GET(request: NextRequest) {
     });
 
     const response = await createSignedInResponse({
+      request,
       requestDeviceToken: deviceToken,
       userId: createdUser.id,
-      redirectTo: absoluteUrl(request, "/pin/setup"),
+      redirectTo: "/pin/setup",
       setupSessionMaxAge: SETUP_SESSION_MAX_AGE,
       locale: createdUser.locale,
       acceptLanguage: request.headers.get("accept-language"),
       webauthnVerified: true,
     });
-    response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
+    response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions(request));
     return response;
   }
 
@@ -318,15 +351,16 @@ export async function GET(request: NextRequest) {
     });
 
     const response = await createSignedInResponse({
+      request,
       requestDeviceToken: deviceToken,
       userId: createdUser.id,
-      redirectTo: absoluteUrl(request, "/pin/setup"),
+      redirectTo: "/pin/setup",
       setupSessionMaxAge: SETUP_SESSION_MAX_AGE,
       locale: createdUser.locale,
       acceptLanguage: request.headers.get("accept-language"),
       webauthnVerified: true,
     });
-    response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions());
+    response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, "", buildExpiredAuthCookieOptions(request));
     return response;
   }
 

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -13,6 +13,7 @@ import {
   GOOGLE_OAUTH_STATE_COOKIE,
   fetchGoogleUserInfo,
   createSignedInResponse,
+  isGoogleOAuthStateBoundToBrowser,
 } from "@/lib/google-auth";
 import { DEVICE_AUTH_COOKIE } from "@/lib/device-auth";
 import { buildSuccessfulAuthState } from "@/lib/account-security";
@@ -84,7 +85,13 @@ export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get("code");
   const state = request.nextUrl.searchParams.get("state");
   const stateCookie = request.cookies.get(GOOGLE_OAUTH_STATE_COOKIE)?.value;
-  if (!code || !state || !stateCookie || state !== stateCookie) {
+  const browserBoundStateValid = state
+    ? isGoogleOAuthStateBoundToBrowser({
+        state,
+        userAgent: request.headers.get("user-agent"),
+      })
+    : false;
+  if (!code || !state || (stateCookie ? state !== stateCookie : !browserBoundStateValid)) {
     return errorRedirect(request, "/pin/login", "invalid-google-state");
   }
 

--- a/src/app/api/auth/google/start/route.ts
+++ b/src/app/api/auth/google/start/route.ts
@@ -206,7 +206,7 @@ export async function GET(request: NextRequest) {
   redirectResponse.cookies.set(
     GOOGLE_OAUTH_STATE_COOKIE,
     authorization.state,
-    buildAuthCookieOptions(GOOGLE_OAUTH_STATE_MAX_AGE),
+    buildAuthCookieOptions(GOOGLE_OAUTH_STATE_MAX_AGE, request),
   );
   return redirectResponse;
 }

--- a/src/app/api/auth/google/start/route.ts
+++ b/src/app/api/auth/google/start/route.ts
@@ -28,6 +28,37 @@ import {
 const GOOGLE_OAUTH_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const GOOGLE_OAUTH_RATE_LIMIT_MAX = 30;
 
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function createAuthorizationRedirectPage(authorizationUrl: string) {
+  const escapedUrl = escapeHtml(authorizationUrl);
+  const serializedUrl = JSON.stringify(authorizationUrl);
+
+  return `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0;url=${escapedUrl}" />
+    <title>Google sign-in</title>
+  </head>
+  <body>
+    <p>Google sign-in に移動しています...</p>
+    <p><a href="${escapedUrl}">移動しない場合はこちら</a></p>
+    <script>
+      window.location.replace(${serializedUrl});
+    </script>
+  </body>
+</html>`;
+}
+
 function isAllowedRedirectTo(value: string | null): value is string {
   return !!value && value.startsWith("/") && !value.startsWith("//");
 }
@@ -161,7 +192,15 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const redirectResponse = NextResponse.redirect(authorization.authorizationUrl);
+  const redirectResponse = new NextResponse(
+    createAuthorizationRedirectPage(authorization.authorizationUrl),
+    {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    },
+  );
   redirectResponse.cookies.set(
     GOOGLE_OAUTH_STATE_COOKIE,
     authorization.state,

--- a/src/app/api/auth/google/start/route.ts
+++ b/src/app/api/auth/google/start/route.ts
@@ -62,47 +62,6 @@ async function createAuthorization(input: {
   return { state: flow.state, authorizationUrl };
 }
 
-async function createAuthResponse(input: {
-  request: NextRequest;
-  mode: GoogleAuthMode;
-  redirectTo?: string | null;
-  sharedSignupToken?: string | null;
-  organizationName?: string | null;
-}) {
-  const rateLimit = await consumeRateLimit({
-    rateLimitKey: buildRateLimitKey({
-      flow: "google-oauth",
-      clientIp: resolveRateLimitClientIp(input.request),
-      subject: input.mode,
-    }),
-    windowMs: GOOGLE_OAUTH_RATE_LIMIT_WINDOW_MS,
-    maxAttempts: GOOGLE_OAUTH_RATE_LIMIT_MAX,
-  });
-  if (rateLimit.limited) {
-    return NextResponse.json(
-      { error: "Google認証リクエストの上限に達しました", code: "google_oauth_rate_limited" },
-      { status: 429 },
-    );
-  }
-
-  const authorization = await createAuthorization(input);
-  if (!authorization) {
-    return NextResponse.json(
-      { error: "Google認証の設定が不完全です" },
-      { status: 503 },
-    );
-  }
-  const response = NextResponse.json({
-    authorizationUrl: authorization.authorizationUrl,
-  });
-  response.cookies.set(
-    GOOGLE_OAUTH_STATE_COOKIE,
-    authorization.state,
-    buildAuthCookieOptions(GOOGLE_OAUTH_STATE_MAX_AGE),
-  );
-  return response;
-}
-
 function canonicalOriginRedirect(request: NextRequest) {
   const origin = getPublicAppOrigin();
   if (!origin) {
@@ -209,56 +168,4 @@ export async function GET(request: NextRequest) {
     buildAuthCookieOptions(GOOGLE_OAUTH_STATE_MAX_AGE),
   );
   return redirectResponse;
-}
-
-/** POST /api/auth/google/start — start Google login/signup */
-export async function POST(request: NextRequest) {
-  if (!isGoogleAuthEnabled()) {
-    return NextResponse.json(
-      { error: "Google認証は有効化されていません" },
-      { status: 503 },
-    );
-  }
-
-  const body = await request.json();
-  const mode = body.mode as GoogleAuthMode | undefined;
-
-  if (mode === "login") {
-    const redirectTo = isAllowedRedirectTo(body.redirectTo) ? body.redirectTo : "/boards";
-    return createAuthResponse({ request, mode, redirectTo });
-  }
-
-  if (mode === "owner-signup") {
-    const organizationName = normalizeOrganizationName(body.organizationName);
-    if (organizationName !== null && !isValidOrganizationName(organizationName)) {
-      return NextResponse.json(
-        { error: `組織名は${ORGANIZATION_NAME_MAX_LENGTH}文字以内で入力してください` },
-        { status: 400 },
-      );
-    }
-
-    return createAuthResponse({ request, mode, organizationName });
-  }
-
-  if (mode === "shared-signup") {
-    const token = typeof body.token === "string" ? body.token : "";
-    const now = new Date().toISOString();
-    const signupRequest = await db.query.sharedSignupRequests.findFirst({
-      where: and(
-        eq(sharedSignupRequests.token, token),
-        isNull(sharedSignupRequests.completedAt),
-        gt(sharedSignupRequests.expiresAt, now),
-      ),
-    });
-    if (!signupRequest) {
-      return NextResponse.json(
-        { error: "無効または期限切れの招待リンクです" },
-        { status: 400 },
-      );
-    }
-
-    return createAuthResponse({ request, mode, sharedSignupToken: token });
-  }
-
-  return NextResponse.json({ error: "不正な認証モードです" }, { status: 400 });
 }

--- a/src/app/api/auth/google/start/route.ts
+++ b/src/app/api/auth/google/start/route.ts
@@ -68,6 +68,7 @@ async function createAuthorization(input: {
   redirectTo?: string | null;
   sharedSignupToken?: string | null;
   organizationName?: string | null;
+  userAgent?: string | null;
 }) {
   const flow = createGoogleOAuthFlowContext(input);
   const authorizationUrl = await buildGoogleAuthorizationUrl({
@@ -184,6 +185,7 @@ export async function GET(request: NextRequest) {
     redirectTo: mode === "login" ? redirectTo : null,
     sharedSignupToken,
     organizationName: mode === "owner-signup" ? organizationName : null,
+    userAgent: request.headers.get("user-agent"),
   });
   if (!authorization) {
     return NextResponse.json(

--- a/src/app/api/auth/pin/logout/route.ts
+++ b/src/app/api/auth/pin/logout/route.ts
@@ -9,7 +9,7 @@ import { clearLegacyLastUserCookie } from "@/lib/device-auth";
 import { cookies } from "next/headers";
 
 /** POST /api/auth/pin/logout — clear session */
-export async function POST() {
+export async function POST(request: Request) {
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
 
@@ -22,7 +22,7 @@ export async function POST() {
   }
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, "", buildExpiredAuthCookieOptions());
-  clearLegacyLastUserCookie(res);
+  res.cookies.set(AUTH_SESSION_COOKIE, "", buildExpiredAuthCookieOptions(request));
+  clearLegacyLastUserCookie(res, request);
   return res;
 }

--- a/src/app/api/auth/pin/setup/route.ts
+++ b/src/app/api/auth/pin/setup/route.ts
@@ -119,10 +119,10 @@ export async function POST(request: NextRequest) {
   });
 
   const res = NextResponse.json({ success: true });
-  res.cookies.set(AUTH_SESSION_COOKIE, fullSessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
+  res.cookies.set(AUTH_SESSION_COOKIE, fullSessionToken, buildAuthCookieOptions(SESSION_MAX_AGE, request));
   if (deviceToken) {
-    setDeviceAuthCookie(res, deviceToken);
+    setDeviceAuthCookie(res, deviceToken, request);
   }
-  clearLegacyLastUserCookie(res);
+  clearLegacyLastUserCookie(res, request);
   return res;
 }

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -229,11 +229,11 @@ export async function POST(request: NextRequest) {
         ? "/passkey/verify"
         : null,
   });
-  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE));
+  res.cookies.set(AUTH_SESSION_COOKIE, sessionToken, buildAuthCookieOptions(SESSION_MAX_AGE, request));
   if (deviceToken) {
-    setDeviceAuthCookie(res, deviceToken);
+    setDeviceAuthCookie(res, deviceToken, request);
   }
   setLocaleCookie(res, locale);
-  clearLegacyLastUserCookie(res);
+  clearLegacyLastUserCookie(res, request);
   return res;
 }

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -2,31 +2,74 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import Link from "next/link";
 import { KeyRound } from "lucide-react";
 import { GoogleAuthButton } from "@/components/auth/GoogleAuthButton";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { KeinageLogo } from "@/components/KeinageLogo";
+import { isSupportedLocale } from "@/lib/i18n";
 
 export default function LoginClient({
   redirectTo,
-  initialError,
   notice,
   showPinLoginLink,
   googleAuthEnabled,
 }: {
   redirectTo?: string | null;
-  initialError?: string | null;
   notice?: "password-reset" | "signup-existing" | null;
   showPinLoginLink: boolean;
   googleAuthEnabled: boolean;
 }) {
-  const { t } = useLocale();
+  const { t, setLocale } = useLocale();
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const loginAction = redirectTo
-    ? `/api/auth/credentials/login?redirectTo=${encodeURIComponent(redirectTo)}`
-    : "/api/auth/credentials/login";
+  const [blocked, setBlocked] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (submitting || blocked) return;
+      setSubmitting(true);
+      setError("");
+
+      try {
+        const res = await fetch("/api/auth/credentials/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ identifier, password }),
+        });
+        const data = await res.json();
+
+        console.log("[LoginClient] Login response", { status: res.status, ok: res.ok, data });
+
+        if (!res.ok) {
+          if (data.blocked || data.locked) setBlocked(true);
+          setError(data.error || t("error.authFailed"));
+          setPassword("");
+          setSubmitting(false);
+          return;
+        }
+
+        if (isSupportedLocale(data.locale)) {
+          setLocale(data.locale);
+        }
+
+        const nextPath =
+          data.redirectTo && redirectTo
+            ? `${data.redirectTo}?redirectTo=${encodeURIComponent(redirectTo)}`
+            : data.redirectTo || redirectTo || "/boards";
+        window.location.assign(nextPath);
+      } catch {
+        setError(t("error.network"));
+        setPassword("");
+        setSubmitting(false);
+      }
+    },
+    [redirectTo, identifier, password, submitting, blocked, t, setLocale],
+  );
 
   const pinLoginHref = redirectTo
     ? `/pin?redirectTo=${encodeURIComponent(redirectTo)}`
@@ -65,12 +108,7 @@ export default function LoginClient({
             </p>
           )}
 
-          <form
-            method="post"
-            action={loginAction}
-            onSubmit={() => setSubmitting(true)}
-            className="space-y-4"
-          >
+          <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label
                 htmlFor="identifier"
@@ -81,11 +119,12 @@ export default function LoginClient({
               <input
                 id="identifier"
                 type="text"
-                name="identifier"
+                value={identifier}
+                onChange={(e) => setIdentifier(e.target.value)}
                 placeholder={t("auth.login.identifierPlaceholder")}
                 required
                 autoFocus
-                disabled={submitting}
+                disabled={blocked}
                 className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
               />
             </div>
@@ -99,23 +138,22 @@ export default function LoginClient({
               <input
                 id="password"
                 type="password"
-                name="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
                 placeholder={t("auth.login.passwordPlaceholder")}
                 required
-                disabled={submitting}
+                disabled={blocked}
                 className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
               />
             </div>
 
-            {redirectTo && <input type="hidden" name="redirectTo" value={redirectTo} />}
-
-            {initialError && (
-              <p className="text-center text-sm text-red-600">{initialError}</p>
+            {error && (
+              <p className="text-center text-sm text-red-600">{error}</p>
             )}
 
             <button
               type="submit"
-              disabled={submitting}
+              disabled={submitting || blocked}
               className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
             >
               {submitting ? t("auth.login.submitting") : t("auth.login.submit")}

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -2,74 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { KeyRound } from "lucide-react";
 import { GoogleAuthButton } from "@/components/auth/GoogleAuthButton";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { KeinageLogo } from "@/components/KeinageLogo";
-import { isSupportedLocale } from "@/lib/i18n";
 
 export default function LoginClient({
   redirectTo,
+  initialError,
   notice,
   showPinLoginLink,
   googleAuthEnabled,
 }: {
   redirectTo?: string | null;
+  initialError?: string | null;
   notice?: "password-reset" | "signup-existing" | null;
   showPinLoginLink: boolean;
   googleAuthEnabled: boolean;
 }) {
-  const { t, setLocale } = useLocale();
-  const [identifier, setIdentifier] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+  const { t } = useLocale();
   const [submitting, setSubmitting] = useState(false);
-  const [blocked, setBlocked] = useState(false);
-
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (submitting || blocked) return;
-      setSubmitting(true);
-      setError("");
-
-      try {
-        const res = await fetch("/api/auth/credentials/login", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ identifier, password }),
-        });
-        const data = await res.json();
-
-        console.log("[LoginClient] Login response", { status: res.status, ok: res.ok, data });
-
-        if (!res.ok) {
-          if (data.blocked || data.locked) setBlocked(true);
-          setError(data.error || t("error.authFailed"));
-          setPassword("");
-          setSubmitting(false);
-          return;
-        }
-
-        if (isSupportedLocale(data.locale)) {
-          setLocale(data.locale);
-        }
-
-        const nextPath =
-          data.redirectTo && redirectTo
-            ? `${data.redirectTo}?redirectTo=${encodeURIComponent(redirectTo)}`
-            : data.redirectTo || redirectTo || "/boards";
-        window.location.assign(nextPath);
-      } catch {
-        setError(t("error.network"));
-        setPassword("");
-        setSubmitting(false);
-      }
-    },
-    [redirectTo, identifier, password, submitting, blocked, t, setLocale],
-  );
+  const loginAction = redirectTo
+    ? `/api/auth/credentials/login?redirectTo=${encodeURIComponent(redirectTo)}`
+    : "/api/auth/credentials/login";
 
   const pinLoginHref = redirectTo
     ? `/pin?redirectTo=${encodeURIComponent(redirectTo)}`
@@ -108,7 +65,12 @@ export default function LoginClient({
             </p>
           )}
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form
+            method="post"
+            action={loginAction}
+            onSubmit={() => setSubmitting(true)}
+            className="space-y-4"
+          >
             <div>
               <label
                 htmlFor="identifier"
@@ -119,12 +81,11 @@ export default function LoginClient({
               <input
                 id="identifier"
                 type="text"
-                value={identifier}
-                onChange={(e) => setIdentifier(e.target.value)}
+                name="identifier"
                 placeholder={t("auth.login.identifierPlaceholder")}
                 required
                 autoFocus
-                disabled={blocked}
+                disabled={submitting}
                 className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
               />
             </div>
@@ -138,22 +99,23 @@ export default function LoginClient({
               <input
                 id="password"
                 type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
+                name="password"
                 placeholder={t("auth.login.passwordPlaceholder")}
                 required
-                disabled={blocked}
+                disabled={submitting}
                 className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
               />
             </div>
 
-            {error && (
-              <p className="text-center text-sm text-red-600">{error}</p>
+            {redirectTo && <input type="hidden" name="redirectTo" value={redirectTo} />}
+
+            {initialError && (
+              <p className="text-center text-sm text-red-600">{initialError}</p>
             )}
 
             <button
               type="submit"
-              disabled={submitting || blocked}
+              disabled={submitting}
               className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300"
             >
               {submitting ? t("auth.login.submitting") : t("auth.login.submit")}

--- a/src/app/pin/login/LoginClient.tsx
+++ b/src/app/pin/login/LoginClient.tsx
@@ -3,7 +3,6 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { KeyRound } from "lucide-react";
 import { GoogleAuthButton } from "@/components/auth/GoogleAuthButton";
@@ -22,7 +21,6 @@ export default function LoginClient({
   showPinLoginLink: boolean;
   googleAuthEnabled: boolean;
 }) {
-  const router = useRouter();
   const { t, setLocale } = useLocale();
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
@@ -63,14 +61,14 @@ export default function LoginClient({
           data.redirectTo && redirectTo
             ? `${data.redirectTo}?redirectTo=${encodeURIComponent(redirectTo)}`
             : data.redirectTo || redirectTo || "/boards";
-        router.push(nextPath);
+        window.location.assign(nextPath);
       } catch {
         setError(t("error.network"));
         setPassword("");
         setSubmitting(false);
       }
     },
-    [router, redirectTo, identifier, password, submitting, blocked, t, setLocale],
+    [redirectTo, identifier, password, submitting, blocked, t, setLocale],
   );
 
   const pinLoginHref = redirectTo

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -30,7 +30,6 @@ export default async function LoginPage({
   searchParams: Promise<{
     redirectTo?: string | string[];
     notice?: string | string[];
-    error?: string | string[];
   }>;
 }) {
   console.log("[/pin/login] START");
@@ -39,7 +38,6 @@ export default async function LoginPage({
     typeof params.redirectTo === "string" ? params.redirectTo : null,
   );
   const notice = typeof params.notice === "string" ? params.notice : null;
-  const error = typeof params.error === "string" ? params.error : null;
 
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
@@ -133,7 +131,6 @@ export default async function LoginPage({
   return (
     <LoginClient
       redirectTo={redirectTo}
-      initialError={error}
       notice={
         notice === "signup-existing" || notice === "password-reset"
           ? notice

--- a/src/app/pin/login/page.tsx
+++ b/src/app/pin/login/page.tsx
@@ -30,6 +30,7 @@ export default async function LoginPage({
   searchParams: Promise<{
     redirectTo?: string | string[];
     notice?: string | string[];
+    error?: string | string[];
   }>;
 }) {
   console.log("[/pin/login] START");
@@ -38,6 +39,7 @@ export default async function LoginPage({
     typeof params.redirectTo === "string" ? params.redirectTo : null,
   );
   const notice = typeof params.notice === "string" ? params.notice : null;
+  const error = typeof params.error === "string" ? params.error : null;
 
   // If admin user not configured, redirect to setup
   const adminUser = await db.query.users.findFirst();
@@ -131,6 +133,7 @@ export default async function LoginPage({
   return (
     <LoginClient
       redirectTo={redirectTo}
+      initialError={error}
       notice={
         notice === "signup-existing" || notice === "password-reset"
           ? notice

--- a/src/components/auth/GoogleAuthButton.tsx
+++ b/src/components/auth/GoogleAuthButton.tsx
@@ -3,7 +3,6 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import googleLogo from "@/resources/google_logo.png";
 
 const googleButtonClassName = [
@@ -40,10 +39,10 @@ export function GoogleAuthButton({
 }) {
   if (href) {
     return (
-      <Link href={href} className={googleButtonClassName}>
+      <a href={href} className={googleButtonClassName}>
         <GoogleLogo />
         <span>{children}</span>
-      </Link>
+      </a>
     );
   }
 

--- a/src/components/auth/PasskeyClient.tsx
+++ b/src/components/auth/PasskeyClient.tsx
@@ -72,8 +72,7 @@ export function PasskeyClient({
         }
       }
 
-      router.push(redirectTo || "/boards");
-      router.refresh();
+      window.location.assign(redirectTo || "/boards");
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : t("auth.passkey.authFailed"));
     } finally {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -63,6 +63,43 @@ export function buildExpiredAuthCookieOptions() {
   };
 }
 
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function createCookieCommittedNavigationPage(input: {
+  redirectTo: string;
+  title?: string;
+  message?: string;
+}) {
+  const escapedUrl = escapeHtml(input.redirectTo);
+  const serializedUrl = JSON.stringify(input.redirectTo);
+  const title = escapeHtml(input.title ?? "Redirecting...");
+  const message = escapeHtml(input.message ?? "移動しています...");
+
+  return `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0;url=${escapedUrl}" />
+    <title>${title}</title>
+  </head>
+  <body>
+    <p>${message}</p>
+    <p><a href="${escapedUrl}">移動しない場合はこちら</a></p>
+    <script>
+      window.location.replace(${serializedUrl});
+    </script>
+  </body>
+</html>`;
+}
+
 /** Default full-auth expiry: 30 days */
 export const DEFAULT_AUTH_EXPIRE_DAYS = 30;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -35,7 +35,13 @@ export async function verifyPassword(
 
 /** Auth session cookie name */
 export const AUTH_SESSION_COOKIE = "auth-session";
-export const AUTH_COOKIE_SECURE = process.env.NODE_ENV === "production";
+
+const COOKIE_INSECURE_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+]);
 
 /**
  * Legacy cookie that stored the last authenticated userId.
@@ -46,19 +52,39 @@ export const LAST_USER_COOKIE = "last-user-id";
 /** PIN session duration: 24 hours (in seconds, for cookie maxAge) */
 export const SESSION_MAX_AGE = 60 * 60 * 24;
 
-export function buildAuthCookieOptions(maxAge: number) {
+function shouldUseSecureAuthCookies(request?: Request) {
+  const candidateUrl = request
+    ? buildRequestHeaderAppUrl(request, "/")
+    : getPublicAppOrigin();
+
+  if (!candidateUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(candidateUrl);
+    if (COOKIE_INSECURE_HOSTNAMES.has(url.hostname.toLowerCase())) {
+      return false;
+    }
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function buildAuthCookieOptions(maxAge: number, request?: Request) {
   return {
     httpOnly: true,
     sameSite: "lax" as const,
     path: "/",
     maxAge,
-    secure: AUTH_COOKIE_SECURE,
+    secure: shouldUseSecureAuthCookies(request),
   };
 }
 
-export function buildExpiredAuthCookieOptions() {
+export function buildExpiredAuthCookieOptions(request?: Request) {
   return {
-    ...buildAuthCookieOptions(0),
+    ...buildAuthCookieOptions(0, request),
     expires: new Date(0),
   };
 }
@@ -100,6 +126,19 @@ export function createCookieCommittedNavigationPage(input: {
 </html>`;
 }
 
+export function buildRelativeAppPath(input: {
+  pathname: string;
+  searchParams?: Record<string, string | null | undefined>;
+}) {
+  const url = new URL(input.pathname, "http://localhost");
+  for (const [key, value] of Object.entries(input.searchParams ?? {})) {
+    if (value) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return `${url.pathname}${url.search}`;
+}
+
 /** Default full-auth expiry: 30 days */
 export const DEFAULT_AUTH_EXPIRE_DAYS = 30;
 
@@ -136,6 +175,10 @@ import { cookies } from "next/headers";
 import { db } from "@/db";
 import { authSessions } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
+import {
+  buildRequestHeaderAppUrl,
+  getPublicAppOrigin,
+} from "@/lib/public-origin";
 
 /**
  * Read the current session from the cookie store and return the

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -64,18 +64,22 @@ export async function storeDeviceFullAuth(params: {
   return { deviceToken, lastFullAuthAt };
 }
 
-export function setDeviceAuthCookie(response: NextResponse, deviceToken: string) {
+export function setDeviceAuthCookie(
+  response: NextResponse,
+  deviceToken: string,
+  request?: Request,
+) {
   response.cookies.set(
     DEVICE_AUTH_COOKIE,
     deviceToken,
-    buildAuthCookieOptions(DEVICE_AUTH_COOKIE_MAX_AGE),
+    buildAuthCookieOptions(DEVICE_AUTH_COOKIE_MAX_AGE, request),
   );
 }
 
-export function clearDeviceAuthCookie(response: NextResponse) {
-  response.cookies.set(DEVICE_AUTH_COOKIE, "", buildExpiredAuthCookieOptions());
+export function clearDeviceAuthCookie(response: NextResponse, request?: Request) {
+  response.cookies.set(DEVICE_AUTH_COOKIE, "", buildExpiredAuthCookieOptions(request));
 }
 
-export function clearLegacyLastUserCookie(response: NextResponse) {
-  response.cookies.set(LAST_USER_COOKIE, "", buildExpiredAuthCookieOptions());
+export function clearLegacyLastUserCookie(response: NextResponse, request?: Request) {
+  response.cookies.set(LAST_USER_COOKIE, "", buildExpiredAuthCookieOptions(request));
 }

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -8,6 +8,7 @@ import {
   AUTH_SESSION_COOKIE,
   SESSION_MAX_AGE,
   buildAuthCookieOptions,
+  createCookieCommittedNavigationPage,
 } from "@/lib/auth";
 import {
   DEVICE_AUTH_COOKIE,
@@ -188,37 +189,6 @@ export async function fetchGoogleUserInfo(input: {
   });
 }
 
-function escapeHtml(value: string) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function createPostAuthRedirectPage(redirectTo: string) {
-  const escapedUrl = escapeHtml(redirectTo);
-  const serializedUrl = JSON.stringify(redirectTo);
-
-  return `<!doctype html>
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta http-equiv="refresh" content="0;url=${escapedUrl}" />
-    <title>Signing in...</title>
-  </head>
-  <body>
-    <p>サインインを完了しています...</p>
-    <p><a href="${escapedUrl}">移動しない場合はこちら</a></p>
-    <script>
-      window.location.replace(${serializedUrl});
-    </script>
-  </body>
-</html>`;
-}
-
 export async function createSignedInResponse(input: {
   requestDeviceToken?: string;
   userId: string;
@@ -246,7 +216,11 @@ export async function createSignedInResponse(input: {
     authenticatedAt: now,
   });
 
-  const response = new NextResponse(createPostAuthRedirectPage(input.redirectTo), {
+  const response = new NextResponse(createCookieCommittedNavigationPage({
+    redirectTo: input.redirectTo,
+    title: "Signing in...",
+    message: "サインインを完了しています...",
+  }), {
     headers: {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store",

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -188,6 +188,37 @@ export async function fetchGoogleUserInfo(input: {
   });
 }
 
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function createPostAuthRedirectPage(redirectTo: string) {
+  const escapedUrl = escapeHtml(redirectTo);
+  const serializedUrl = JSON.stringify(redirectTo);
+
+  return `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0;url=${escapedUrl}" />
+    <title>Signing in...</title>
+  </head>
+  <body>
+    <p>サインインを完了しています...</p>
+    <p><a href="${escapedUrl}">移動しない場合はこちら</a></p>
+    <script>
+      window.location.replace(${serializedUrl});
+    </script>
+  </body>
+</html>`;
+}
+
 export async function createSignedInResponse(input: {
   requestDeviceToken?: string;
   userId: string;
@@ -215,7 +246,12 @@ export async function createSignedInResponse(input: {
     authenticatedAt: now,
   });
 
-  const response = NextResponse.redirect(input.redirectTo);
+  const response = new NextResponse(createPostAuthRedirectPage(input.redirectTo), {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
   response.cookies.set(
     AUTH_SESSION_COOKIE,
     sessionToken,

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -190,6 +190,7 @@ export async function fetchGoogleUserInfo(input: {
 }
 
 export async function createSignedInResponse(input: {
+  request?: Request;
   requestDeviceToken?: string;
   userId: string;
   redirectTo: string;
@@ -229,9 +230,9 @@ export async function createSignedInResponse(input: {
   response.cookies.set(
     AUTH_SESSION_COOKIE,
     sessionToken,
-    buildAuthCookieOptions(sessionMaxAge),
+    buildAuthCookieOptions(sessionMaxAge, input.request),
   );
-  setDeviceAuthCookie(response, deviceToken);
+  setDeviceAuthCookie(response, deviceToken, input.request);
   setLocaleCookie(
     response,
     resolveAuthenticatedLocale({
@@ -239,7 +240,7 @@ export async function createSignedInResponse(input: {
       acceptLanguage: input.acceptLanguage,
     }),
   );
-  clearLegacyLastUserCookie(response);
+  clearLegacyLastUserCookie(response, input.request);
   return response;
 }
 

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -1,5 +1,6 @@
 // Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
 // SPDX-License-Identifier: Apache-2.0
+import { createHmac, timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { authSessions } from "@/db/schema";
@@ -51,6 +52,59 @@ export interface GoogleOAuthFlowContext {
 
 export type GoogleUserInfo = OidcUserInfo;
 
+function getGoogleOAuthStateBindingSecret() {
+  return process.env.GOOGLE_OAUTH_CLIENT_SECRET?.trim() ?? "";
+}
+
+function normalizeGoogleOAuthBindingUserAgent(userAgent: string | null | undefined) {
+  return userAgent?.trim().slice(0, 512) ?? "";
+}
+
+export function bindGoogleOAuthStateToBrowser(input: {
+  state: string;
+  userAgent: string | null | undefined;
+}) {
+  const secret = getGoogleOAuthStateBindingSecret();
+  if (!secret) {
+    return input.state;
+  }
+
+  const signature = createHmac("sha256", secret)
+    .update(input.state)
+    .update("\n")
+    .update(normalizeGoogleOAuthBindingUserAgent(input.userAgent))
+    .digest("base64url");
+  return `${input.state}.${signature}`;
+}
+
+export function isGoogleOAuthStateBoundToBrowser(input: {
+  state: string;
+  userAgent: string | null | undefined;
+}) {
+  const secret = getGoogleOAuthStateBindingSecret();
+  if (!secret) {
+    return true;
+  }
+
+  const separatorIndex = input.state.lastIndexOf(".");
+  if (separatorIndex <= 0 || separatorIndex === input.state.length - 1) {
+    return false;
+  }
+
+  const rawState = input.state.slice(0, separatorIndex);
+  const actualSignature = input.state.slice(separatorIndex + 1);
+  const expectedSignature = createHmac("sha256", secret)
+    .update(rawState)
+    .update("\n")
+    .update(normalizeGoogleOAuthBindingUserAgent(input.userAgent))
+    .digest("base64url");
+  const actualBuffer = Buffer.from(actualSignature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+
+  return actualBuffer.length === expectedBuffer.length
+    && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
 export function isGoogleAuthEnabled(): boolean {
   return (
     process.env.GOOGLE_OAUTH_ENABLED === "true" &&
@@ -84,8 +138,13 @@ export function createGoogleOAuthFlowContext(input: {
   redirectTo?: string | null;
   sharedSignupToken?: string | null;
   organizationName?: string | null;
+  userAgent?: string | null;
 }): GoogleOAuthFlowContext {
   const flow = createOidcFlowContext(GOOGLE_OAUTH_STATE_MAX_AGE);
+  const state = bindGoogleOAuthStateToBrowser({
+    state: flow.state,
+    userAgent: input.userAgent,
+  });
 
   return {
     mode: input.mode,
@@ -93,6 +152,7 @@ export function createGoogleOAuthFlowContext(input: {
     sharedSignupToken: input.sharedSignupToken ?? null,
     organizationName: input.organizationName ?? null,
     ...flow,
+    state,
   };
 }
 

--- a/src/lib/public-origin.ts
+++ b/src/lib/public-origin.ts
@@ -8,6 +8,34 @@ function normalizeHostname(hostname: string): string {
   return hostname.trim().toLowerCase();
 }
 
+function extractHostHostname(host: string): string {
+  const trimmed = host.trim();
+  if (trimmed.startsWith("[")) {
+    const closingIndex = trimmed.indexOf("]");
+    return closingIndex >= 0 ? trimmed.slice(0, closingIndex + 1) : trimmed;
+  }
+
+  const colonIndex = trimmed.indexOf(":");
+  return colonIndex >= 0 ? trimmed.slice(0, colonIndex) : trimmed;
+}
+
+function parseOriginCandidate(value: string | null | undefined): URL | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    const hostname = normalizeHostname(url.hostname);
+    if (NON_PUBLIC_HOSTNAMES.has(hostname)) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
 export function getPublicAppOrigin(): string | null {
   const configuredOrigin = process.env.APP_PUBLIC_ORIGIN?.trim();
   if (!configuredOrigin) {
@@ -42,6 +70,47 @@ export function buildPublicAppUrl(pathname: string): string | null {
   } catch {
     return null;
   }
+}
+
+export function buildRequestHeaderAppUrl(request: Request, pathname: string): string | null {
+  const originCandidate = parseOriginCandidate(request.headers.get("origin"));
+  if (originCandidate) {
+    return new URL(pathname, `${originCandidate.origin}/`).toString();
+  }
+
+  const refererCandidate = parseOriginCandidate(request.headers.get("referer"));
+  if (refererCandidate) {
+    return new URL(pathname, `${refererCandidate.origin}/`).toString();
+  }
+
+  const forwardedHost = request.headers.get("x-forwarded-host")?.split(",")[0]?.trim();
+  const host = forwardedHost || request.headers.get("host")?.trim();
+  if (!host) {
+    return null;
+  }
+
+  const hostname = normalizeHostname(extractHostHostname(host));
+  if (NON_PUBLIC_HOSTNAMES.has(hostname)) {
+    return null;
+  }
+
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const requestProtocol = parseOriginCandidate(request.url)?.protocol;
+  const protocol = forwardedProto
+    ? `${forwardedProto.replace(/:$/, "")}:`
+    : requestProtocol
+      ?? "http:";
+
+  return new URL(pathname, `${protocol}//${host}/`).toString();
+}
+
+export function buildRequestAppUrl(request: Request, pathname: string): string | null {
+  const publicUrl = buildPublicAppUrl(pathname);
+  if (publicUrl) {
+    return publicUrl;
+  }
+
+  return buildRequestHeaderAppUrl(request, pathname);
 }
 
 export function isUnauthenticatedSignupPreviewEnabled(): boolean {


### PR DESCRIPTION
## 概要
- Safariで Google ログイン開始時に CORS / preflight エラーになる問題を修正します
- Safariで Google / メールログイン後に認証 cookie が安定せず、Passkey 画面やダッシュボードへ進めない問題を修正します

## 変更内容
- `GoogleAuthButton` の `href` 遷移を `next/link` ではなく通常の `<a>` に変更
- `/api/auth/google/start` の未使用 `POST` 開始経路を削除
- Google OAuth 開始を `GET` + 通常ブラウザ遷移に統一
- Google callback 成功後は、cookie を設定した HTML 中継ページを返してから次画面へ遷移するよう更新
- メールログインを `fetch` ベースから通常の form POST に変更し、成功時は cookie を設定した HTML 中継ページを返すよう更新
- `Set-Cookie` 後の遷移に使う共通 HTML ハンドオフを `auth.ts` に整理

## 確認
- `pnpm build`
- ローカル再現でメールログイン後に `/passkey/setup` へ遷移することを確認

Closes #231