### PR TITLE
[codex] 数値設定を直接入力できるようにする

### DIFF
--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -434,9 +434,11 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                     <Input
                       id="new-message-priority"
                       value={newMsgPriority}
-                      onChange={(e) => setNewMsgPriority(e.target.value)}
-                      type="number"
-                      min={0}
+                      onChange={(e) => {
+                        if (/^\d*$/.test(e.target.value)) setNewMsgPriority(e.target.value);
+                      }}
+                      inputMode="numeric"
+                      pattern="[0-9]*"
                     />
                   </div>
                   <div className="space-y-1.5">
@@ -509,9 +511,11 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                           <div className="grid gap-2 sm:grid-cols-[100px_140px_minmax(180px,1fr)_auto] sm:items-end">
                             <Input
                               value={editMsgPriority}
-                              onChange={(e) => setEditMsgPriority(e.target.value)}
-                              type="number"
-                              min={0}
+                              onChange={(e) => {
+                                if (/^\d*$/.test(e.target.value)) setEditMsgPriority(e.target.value);
+                              }}
+                              inputMode="numeric"
+                              pattern="[0-9]*"
                             />
                             <Select
                               value={editMsgKind}

--- a/src/components/dashboard/MediaUploadZone.tsx
+++ b/src/components/dashboard/MediaUploadZone.tsx
@@ -6,7 +6,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { AlertCircle, Upload, X, GripVertical, Trash2, Image as ImageIcon, Film } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import {
@@ -673,14 +673,10 @@ export default function MediaUploadZone({
               {/* Duration */}
               <div className="ml-auto flex shrink-0 items-center gap-1">
                 <Label className="text-xs text-muted-foreground">{t("media.durationSeconds")}</Label>
-                <Input
-                  type="number"
+                <NumberInput
                   min={1}
                   value={item.duration}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value, 10);
-                    if (v >= 1) handleDurationChange(item.id, v);
-                  }}
+                  onValueChange={(value) => handleDurationChange(item.id, value)}
                   className="h-7 w-16 text-xs"
                 />
               </div>

--- a/src/components/dashboard/SettingsClient.tsx
+++ b/src/components/dashboard/SettingsClient.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import { WEATHER_AREAS, DEFAULT_CITY_ID } from "@/lib/weather-areas";
 import type { WeatherPrefecture } from "@/lib/weather-areas";
@@ -935,17 +936,13 @@ export function SettingsClient({
             <div className="space-y-1.5">
               <Label htmlFor="max-long-edge">{t("settings.maxLongEdge")}</Label>
               <div className="flex items-center gap-2">
-                <Input
+                <NumberInput
                   id="max-long-edge"
-                  type="number"
                   min={100}
                   max={planMaxResolution ?? undefined}
                   step={100}
                   value={maxLongEdge}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value, 10);
-                    if (v >= 100) setMaxLongEdge(planMaxResolution ? Math.min(v, planMaxResolution) : v);
-                  }}
+                  onValueChange={setMaxLongEdge}
                   className="w-32"
                 />
                 <span className="text-sm text-muted-foreground">px</span>

--- a/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/CallNumberConfigEditor.tsx
@@ -5,6 +5,7 @@
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import {
@@ -120,16 +121,27 @@ export function CallNumberConfigEditor({
         <div className="space-y-3">
           <div className="space-y-1.5">
             <Label htmlFor="cfg-numberFontSize">{t("configEditor.numberFontSize", { size: numberFontSize })}</Label>
-            <input
-              id="cfg-numberFontSize"
-              type="range"
-              min={24}
-              max={120}
-              step={2}
-              value={numberFontSize}
-              onChange={(e) => update("numberFontSize", Number(e.target.value))}
-              className="w-full max-w-48"
-            />
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <input
+                id="cfg-numberFontSize"
+                type="range"
+                min={24}
+                max={120}
+                step={2}
+                value={numberFontSize}
+                onChange={(e) => update("numberFontSize", Number(e.target.value))}
+                className="w-full max-w-48"
+              />
+              <NumberInput
+                aria-label={t("configEditor.numberFontSize", { size: numberFontSize })}
+                min={24}
+                max={120}
+                step={2}
+                value={numberFontSize}
+                onValueChange={(value) => update("numberFontSize", value)}
+                className="w-full sm:w-24"
+              />
+            </div>
             <div className="flex w-full max-w-48 justify-between text-xs text-muted-foreground">
               <span>24px</span>
               <span>120px</span>
@@ -137,13 +149,12 @@ export function CallNumberConfigEditor({
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="cfg-calledExpire">{t("configEditor.calledExpire")}</Label>
-            <Input
+            <NumberInput
               id="cfg-calledExpire"
-              type="number"
               min={1}
               max={60}
               value={calledExpireMinutes}
-              onChange={(e) => update("calledExpireMinutes", parseInt(e.target.value, 10) || 5)}
+              onValueChange={(value) => update("calledExpireMinutes", value)}
               className="w-28"
             />
             <p className="text-xs text-muted-foreground">

--- a/src/components/dashboard/config-editors/ClinicHoursConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/ClinicHoursConfigEditor.tsx
@@ -4,6 +4,7 @@
 
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -128,15 +129,12 @@ export function ClinicHoursConfigEditor({
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-1.5">
           <Label htmlFor="cfg-daysToShow">{t("configEditor.daysToShow")}</Label>
-          <Input
+          <NumberInput
             id="cfg-daysToShow"
-            type="number"
             min={7}
             max={31}
             value={daysToShow}
-            onChange={(e) =>
-              update("daysToShow", Math.min(31, Math.max(7, parseInt(e.target.value, 10) || 14)))
-            }
+            onValueChange={(value) => update("daysToShow", value)}
           />
         </div>
         <div className="space-y-1.5">

--- a/src/components/dashboard/config-editors/FloorGuideConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/FloorGuideConfigEditor.tsx
@@ -5,6 +5,7 @@ import { Plus, Trash2 } from "lucide-react";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -394,13 +395,12 @@ export function FloorGuideConfigEditor({
 
         <div className="max-w-xs space-y-1.5">
           <Label htmlFor="cfg-floor-count">{t("configEditor.floorGuide.floorCount")}</Label>
-          <Input
+          <NumberInput
             id="cfg-floor-count"
-            type="number"
             min={1}
             max={10}
             value={floorCount}
-            onChange={(e) => updateFloorCount(e.target.value)}
+            onValueChange={updateFloorCount}
           />
         </div>
 
@@ -561,25 +561,23 @@ export function FloorGuideConfigEditor({
               <div className="grid gap-3 md:grid-cols-2">
                 <div className="space-y-1.5">
                   <Label htmlFor={`cfg-elevator-start-${index}`}>{t("configEditor.floorGuide.startFloor")}</Label>
-                  <Input
+                  <NumberInput
                     id={`cfg-elevator-start-${index}`}
-                    type="number"
                     min={1}
                     max={floorCount}
                     value={elevator.startFloor}
-                    onChange={(e) => updateElevator(index, { startFloor: clampFloor(e.target.value, elevator.startFloor) ?? elevator.startFloor })}
+                    onValueChange={(value) => updateElevator(index, { startFloor: value })}
                   />
                 </div>
 
                 <div className="space-y-1.5">
                   <Label htmlFor={`cfg-elevator-end-${index}`}>{t("configEditor.floorGuide.endFloor")}</Label>
-                  <Input
+                  <NumberInput
                     id={`cfg-elevator-end-${index}`}
-                    type="number"
                     min={1}
                     max={floorCount}
                     value={elevator.endFloor}
-                    onChange={(e) => updateElevator(index, { endFloor: clampFloor(e.target.value, elevator.endFloor) ?? elevator.endFloor })}
+                    onValueChange={(value) => updateElevator(index, { endFloor: value })}
                   />
                 </div>
               </div>

--- a/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx
@@ -5,6 +5,7 @@
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -93,31 +94,38 @@ export function MessageBoardConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-maxDisplay">{t("configEditor.maxDisplayCount")}</Label>
-        <Input
+        <NumberInput
           id="cfg-maxDisplay"
-          type="number"
           min={1}
           max={100}
           value={maxDisplayCount}
-          onChange={(e) =>
-            update("maxDisplayCount", Math.max(1, parseInt(e.target.value, 10) || 10))
-          }
+          onValueChange={(value) => update("maxDisplayCount", value)}
           className="w-full sm:w-24"
         />
       </div>
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-fontSize">{t("configEditor.fontSize", { size: fontSize })}</Label>
-        <input
-          id="cfg-fontSize"
-          type="range"
-          min={12}
-          max={48}
-          step={1}
-          value={fontSize}
-          onChange={(e) => update("fontSize", Number(e.target.value))}
-          className="w-full sm:max-w-48"
-        />
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <input
+            id="cfg-fontSize"
+            type="range"
+            min={12}
+            max={48}
+            step={1}
+            value={fontSize}
+            onChange={(e) => update("fontSize", Number(e.target.value))}
+            className="w-full sm:max-w-48"
+          />
+          <NumberInput
+            aria-label={t("configEditor.fontSize", { size: fontSize })}
+            min={12}
+            max={48}
+            value={fontSize}
+            onValueChange={(value) => update("fontSize", value)}
+            className="w-full sm:w-24"
+          />
+        </div>
       </div>
 
       <div className="space-y-1.5">

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -5,6 +5,7 @@
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import {
   Select,
   SelectContent,
@@ -83,15 +84,12 @@ export function PhotoClockConfigEditor({
     <div className="space-y-4">
       <div className="space-y-1.5">
         <Label htmlFor="cfg-slideInterval">{t("configEditor.slideInterval")}</Label>
-        <Input
+        <NumberInput
           id="cfg-slideInterval"
-          type="number"
           min={1}
           max={300}
           value={slideInterval}
-          onChange={(e) =>
-            update("slideInterval", Math.max(1, parseInt(e.target.value, 10) || 1))
-          }
+          onValueChange={(value) => update("slideInterval", value)}
           className="w-full sm:w-24"
         />
       </div>
@@ -162,16 +160,27 @@ export function PhotoClockConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-clockSize">{t("configEditor.clockFontSize", { size: clockFontSize })}</Label>
-        <input
-          id="cfg-clockSize"
-          type="range"
-          min={24}
-          max={160}
-          step={4}
-          value={clockFontSize}
-          onChange={(e) => update("clockFontSize", parseInt(e.target.value, 10))}
-          className="w-full sm:max-w-64"
-        />
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <input
+            id="cfg-clockSize"
+            type="range"
+            min={24}
+            max={160}
+            step={4}
+            value={clockFontSize}
+            onChange={(e) => update("clockFontSize", parseInt(e.target.value, 10))}
+            className="w-full sm:max-w-64"
+          />
+          <NumberInput
+            aria-label={t("configEditor.clockFontSize", { size: clockFontSize })}
+            min={24}
+            max={160}
+            step={4}
+            value={clockFontSize}
+            onValueChange={(value) => update("clockFontSize", value)}
+            className="w-full sm:w-24"
+          />
+        </div>
         <div className="flex w-full justify-between text-xs text-muted-foreground sm:max-w-64">
           <span>24px</span>
           <span>160px</span>
@@ -201,16 +210,30 @@ export function PhotoClockConfigEditor({
         <Label htmlFor="cfg-clockOpacity">
           {t("configEditor.clockBgOpacity", { percent: Math.round(clockBgOpacity * 100) })}
         </Label>
-        <input
-          id="cfg-clockOpacity"
-          type="range"
-          min={0}
-          max={1}
-          step={0.05}
-          value={clockBgOpacity}
-          onChange={(e) => update("clockBgOpacity", parseFloat(e.target.value))}
-          className="w-full sm:max-w-48"
-        />
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <input
+            id="cfg-clockOpacity"
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={clockBgOpacity}
+            onChange={(e) => update("clockBgOpacity", parseFloat(e.target.value))}
+            className="w-full sm:max-w-48"
+          />
+          <NumberInput
+            aria-label={t("configEditor.clockBgOpacity", {
+              percent: Math.round(clockBgOpacity * 100),
+            })}
+            min={0}
+            max={1}
+            step={0.05}
+            allowDecimal
+            value={clockBgOpacity}
+            onValueChange={(value) => update("clockBgOpacity", value)}
+            className="w-full sm:w-24"
+          />
+        </div>
       </div>
 
       <div className="flex flex-wrap items-start gap-3">

--- a/src/components/dashboard/config-editors/QrInfoConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/QrInfoConfigEditor.tsx
@@ -4,6 +4,7 @@
 
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -201,13 +202,12 @@ function FontNumber({
   return (
     <div className="space-y-1.5">
       <Label htmlFor={id}>{label}</Label>
-      <Input
+      <NumberInput
         id={id}
-        type="number"
         min={min}
         max={max}
         value={value}
-        onChange={(e) => onChange(Math.min(max, Math.max(min, parseInt(e.target.value, 10) || value)))}
+        onValueChange={onChange}
       />
     </div>
   );

--- a/src/components/dashboard/config-editors/RestaurantMenuConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RestaurantMenuConfigEditor.tsx
@@ -5,6 +5,7 @@
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -285,13 +286,12 @@ function FontNumber({
   return (
     <div className="space-y-1.5">
       <Label htmlFor={id}>{label}</Label>
-      <Input
+      <NumberInput
         id={id}
-        type="number"
         min={12}
         max={120}
         value={value}
-        onChange={(e) => onChange(Math.max(12, parseInt(e.target.value, 10) || value))}
+        onValueChange={onChange}
       />
     </div>
   );

--- a/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx
@@ -5,6 +5,7 @@
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -124,32 +125,39 @@ export function RetroBoardConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-rows">{t("configEditor.rows")}</Label>
-        <Input
+        <NumberInput
           id="cfg-rows"
-          type="number"
           min={1}
           max={20}
           value={rows}
-          onChange={(e) =>
-            updateRows(parseInt(e.target.value, 10))
-          }
+          onValueChange={updateRows}
           className="w-24"
         />
       </div>
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-fontSize">{t("configEditor.retroFontSize", { size: fontSize })}</Label>
-        <Input
-          id="cfg-fontSize"
-          type="range"
-          min={18}
-          max={96}
-          value={fontSize}
-          onChange={(e) =>
-            update("fontSize", Math.max(18, parseInt(e.target.value, 10) || 36))
-          }
-          className="w-full max-w-sm"
-        />
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <Input
+            id="cfg-fontSize"
+            type="range"
+            min={18}
+            max={96}
+            value={fontSize}
+            onChange={(e) =>
+              update("fontSize", Math.max(18, parseInt(e.target.value, 10) || 36))
+            }
+            className="w-full max-w-sm"
+          />
+          <NumberInput
+            aria-label={t("configEditor.retroFontSize", { size: fontSize })}
+            min={18}
+            max={96}
+            value={fontSize}
+            onValueChange={(value) => update("fontSize", value)}
+            className="w-24"
+          />
+        </div>
       </div>
 
       <div className="space-y-1.5">
@@ -177,18 +185,31 @@ export function RetroBoardConfigEditor({
           <Label htmlFor="cfg-leftColumnPercent">
             {t("configEditor.retroLeftColumnWidth", { percent: leftColumnPercent })}
           </Label>
-          <Input
-            id="cfg-leftColumnPercent"
-            type="range"
-            min={20}
-            max={80}
-            step={5}
-            value={leftColumnPercent}
-            onChange={(e) =>
-              update("leftColumnPercent", Math.min(80, Math.max(20, parseInt(e.target.value, 10) || 50)))
-            }
-            className="w-full max-w-sm"
-          />
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <Input
+              id="cfg-leftColumnPercent"
+              type="range"
+              min={20}
+              max={80}
+              step={5}
+              value={leftColumnPercent}
+              onChange={(e) =>
+                update("leftColumnPercent", Math.min(80, Math.max(20, parseInt(e.target.value, 10) || 50)))
+              }
+              className="w-full max-w-sm"
+            />
+            <NumberInput
+              aria-label={t("configEditor.retroLeftColumnWidth", {
+                percent: leftColumnPercent,
+              })}
+              min={20}
+              max={80}
+              step={5}
+              value={leftColumnPercent}
+              onValueChange={(value) => update("leftColumnPercent", value)}
+              className="w-24"
+            />
+          </div>
         </div>
       )}
 
@@ -236,31 +257,26 @@ export function RetroBoardConfigEditor({
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-flipSpeed">{t("configEditor.flipSpeed")}</Label>
-        <Input
+        <NumberInput
           id="cfg-flipSpeed"
-          type="number"
           min={0.01}
           max={1}
           step={0.01}
+          allowDecimal
           value={flipSpeed}
-          onChange={(e) =>
-            update("flipSpeed", Math.max(0.01, parseFloat(e.target.value) || 0.08))
-          }
+          onValueChange={(value) => update("flipSpeed", value)}
           className="w-24"
         />
       </div>
 
       <div className="space-y-1.5">
         <Label htmlFor="cfg-switchInterval">{t("configEditor.switchInterval")}</Label>
-        <Input
+        <NumberInput
           id="cfg-switchInterval"
-          type="number"
           min={1}
           max={300}
           value={switchInterval}
-          onChange={(e) =>
-            update("switchInterval", Math.max(1, parseInt(e.target.value, 10) || 5))
-          }
+          onValueChange={(value) => update("switchInterval", value)}
           className="w-24"
         />
       </div>

--- a/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx
@@ -5,6 +5,7 @@
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -121,15 +122,12 @@ export function SimpleBoardConfigEditor({
         <div className="space-y-3">
           <div className="space-y-1.5">
             <Label htmlFor="cfg-slideInterval">{t("configEditor.slideInterval")}</Label>
-            <Input
+            <NumberInput
               id="cfg-slideInterval"
-              type="number"
               min={1}
               max={300}
               value={slideInterval}
-              onChange={(e) =>
-                update("slideInterval", Math.max(1, parseInt(e.target.value, 10) || 1))
-              }
+              onValueChange={(value) => update("slideInterval", value)}
               className="w-24"
             />
           </div>
@@ -191,31 +189,38 @@ export function SimpleBoardConfigEditor({
         <div className="space-y-3">
           <div className="space-y-1.5">
             <Label htmlFor="cfg-tickerSpeed">{t("configEditor.tickerSpeed")}</Label>
-            <Input
+            <NumberInput
               id="cfg-tickerSpeed"
-              type="number"
               min={10}
               max={500}
               value={tickerSpeed}
-              onChange={(e) =>
-                update("tickerSpeed", Math.max(10, parseInt(e.target.value, 10) || 60))
-              }
+              onValueChange={(value) => update("tickerSpeed", value)}
               className="w-24"
             />
           </div>
 
           <div className="space-y-1.5">
             <Label htmlFor="cfg-tickerFontSize">{t("configEditor.tickerFontSize", { size: tickerFontSize })}</Label>
-            <input
-              id="cfg-tickerFontSize"
-              type="range"
-              min={12}
-              max={64}
-              step={1}
-              value={tickerFontSize}
-              onChange={(e) => update("tickerFontSize", Number(e.target.value))}
-              className="w-full max-w-48"
-            />
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <input
+                id="cfg-tickerFontSize"
+                type="range"
+                min={12}
+                max={64}
+                step={1}
+                value={tickerFontSize}
+                onChange={(e) => update("tickerFontSize", Number(e.target.value))}
+                className="w-full max-w-48"
+              />
+              <NumberInput
+                aria-label={t("configEditor.tickerFontSize", { size: tickerFontSize })}
+                min={12}
+                max={64}
+                value={tickerFontSize}
+                onValueChange={(value) => update("tickerFontSize", value)}
+                className="w-24"
+              />
+            </div>
             <div className="flex w-full max-w-48 justify-between text-xs text-muted-foreground">
               <span>12px</span>
               <span>64px</span>

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -1,0 +1,118 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+
+function formatNumericValue(value: number, allowDecimal: boolean) {
+  if (!Number.isFinite(value)) return "";
+  return allowDecimal ? String(value) : String(Math.trunc(value));
+}
+
+function clampNumericValue(value: number, min?: number, max?: number) {
+  let next = value;
+  if (min !== undefined) next = Math.max(min, next);
+  if (max !== undefined) next = Math.min(max, next);
+  return next;
+}
+
+export function NumberInput({
+  value,
+  onValueChange,
+  min,
+  max,
+  step,
+  allowDecimal,
+  className,
+  onBlur,
+  onFocus,
+  onKeyDown,
+  ...props
+}: Omit<React.ComponentProps<typeof Input>, "type" | "value" | "onChange"> & {
+  value: number;
+  onValueChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  allowDecimal?: boolean;
+}) {
+  const shouldAllowDecimal = allowDecimal ?? (step !== undefined && !Number.isInteger(step));
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [draftValue, setDraftValue] = React.useState("");
+  const displayValue = isEditing
+    ? draftValue
+    : formatNumericValue(value, shouldAllowDecimal);
+  const numericPattern = shouldAllowDecimal ? /^\d*(?:\.\d*)?$/ : /^\d*$/;
+
+  function commit(rawValue: string) {
+    const parsed = Number(rawValue);
+    if (!rawValue || !Number.isFinite(parsed)) {
+      setDraftValue(formatNumericValue(value, shouldAllowDecimal));
+      return;
+    }
+
+    const normalized = shouldAllowDecimal ? parsed : Math.trunc(parsed);
+    const nextValue = clampNumericValue(normalized, min, max);
+    setDraftValue(formatNumericValue(nextValue, shouldAllowDecimal));
+    if (nextValue !== value) {
+      onValueChange(nextValue);
+    }
+  }
+
+  return (
+    <Input
+      {...props}
+      type="text"
+      inputMode={shouldAllowDecimal ? "decimal" : "numeric"}
+      value={displayValue}
+      min={min}
+      max={max}
+      step={step}
+      role="spinbutton"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      className={className}
+      onFocus={(event) => {
+        setIsEditing(true);
+        setDraftValue(formatNumericValue(value, shouldAllowDecimal));
+        onFocus?.(event);
+      }}
+      onBlur={(event) => {
+        commit(event.currentTarget.value);
+        setIsEditing(false);
+        onBlur?.(event);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.currentTarget.blur();
+        }
+        onKeyDown?.(event);
+      }}
+      onChange={(event) => {
+        const rawValue = event.target.value.trim();
+        if (!numericPattern.test(rawValue)) return;
+
+        if (rawValue === "" || rawValue === ".") {
+          setDraftValue(rawValue);
+          return;
+        }
+
+        const parsed = Number(rawValue);
+        if (!Number.isFinite(parsed)) return;
+
+        if (max !== undefined && parsed > max) {
+          setDraftValue(formatNumericValue(max, shouldAllowDecimal));
+          onValueChange(max);
+          return;
+        }
+
+        setDraftValue(rawValue);
+        if (min === undefined || parsed >= min) {
+          onValueChange(shouldAllowDecimal ? parsed : Math.trunc(parsed));
+        }
+      }}
+    />
+  );
+}

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -105,24 +105,7 @@ export function NumberInput({
         const normalizedValue = normalizeNumericText(rawValue);
         if (!numericPattern.test(normalizedValue)) return;
 
-        if (normalizedValue === "" || normalizedValue === ".") {
-          setDraftValue(rawValue);
-          return;
-        }
-
-        const parsed = Number(normalizedValue);
-        if (!Number.isFinite(parsed)) return;
-
-        if (max !== undefined && parsed > max) {
-          setDraftValue(formatNumericValue(max, shouldAllowDecimal));
-          onValueChange(max);
-          return;
-        }
-
-        setDraftValue(normalizedValue);
-        if (min === undefined || parsed >= min) {
-          onValueChange(shouldAllowDecimal ? parsed : Math.trunc(parsed));
-        }
+        setDraftValue(rawValue);
         onCompositionEnd?.(event);
       }}
       onKeyDown={(event) => {

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -110,6 +110,11 @@ export function NumberInput({
       }}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
+          const nativeEvent = event.nativeEvent as KeyboardEvent;
+          if (isComposingRef.current || nativeEvent.isComposing || nativeEvent.keyCode === 229) {
+            onKeyDown?.(event);
+            return;
+          }
           event.currentTarget.blur();
         }
         onKeyDown?.(event);

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -17,6 +17,13 @@ function clampNumericValue(value: number, min?: number, max?: number) {
   return next;
 }
 
+function normalizeNumericText(value: string) {
+  return value
+    .trim()
+    .replace(/[０-９]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0))
+    .replace(/[．。]/g, ".");
+}
+
 export function NumberInput({
   value,
   onValueChange,
@@ -46,8 +53,9 @@ export function NumberInput({
   const numericPattern = shouldAllowDecimal ? /^\d*(?:\.\d*)?$/ : /^\d*$/;
 
   function commit(rawValue: string) {
-    const parsed = Number(rawValue);
-    if (!rawValue || !Number.isFinite(parsed)) {
+    const normalizedValue = normalizeNumericText(rawValue);
+    const parsed = Number(normalizedValue);
+    if (!normalizedValue || !Number.isFinite(parsed)) {
       setDraftValue(formatNumericValue(value, shouldAllowDecimal));
       return;
     }
@@ -92,14 +100,15 @@ export function NumberInput({
       }}
       onChange={(event) => {
         const rawValue = event.target.value.trim();
-        if (!numericPattern.test(rawValue)) return;
+        const normalizedValue = normalizeNumericText(rawValue);
+        if (!numericPattern.test(normalizedValue)) return;
 
-        if (rawValue === "" || rawValue === ".") {
+        if (normalizedValue === "" || normalizedValue === ".") {
           setDraftValue(rawValue);
           return;
         }
 
-        const parsed = Number(rawValue);
+        const parsed = Number(normalizedValue);
         if (!Number.isFinite(parsed)) return;
 
         if (max !== undefined && parsed > max) {

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -33,6 +33,8 @@ export function NumberInput({
   allowDecimal,
   className,
   onBlur,
+  onCompositionEnd,
+  onCompositionStart,
   onFocus,
   onKeyDown,
   ...props
@@ -47,6 +49,7 @@ export function NumberInput({
   const shouldAllowDecimal = allowDecimal ?? (step !== undefined && !Number.isInteger(step));
   const [isEditing, setIsEditing] = React.useState(false);
   const [draftValue, setDraftValue] = React.useState("");
+  const isComposingRef = React.useRef(false);
   const displayValue = isEditing
     ? draftValue
     : formatNumericValue(value, shouldAllowDecimal);
@@ -92,6 +95,36 @@ export function NumberInput({
         setIsEditing(false);
         onBlur?.(event);
       }}
+      onCompositionStart={(event) => {
+        isComposingRef.current = true;
+        onCompositionStart?.(event);
+      }}
+      onCompositionEnd={(event) => {
+        isComposingRef.current = false;
+        const rawValue = event.currentTarget.value.trim();
+        const normalizedValue = normalizeNumericText(rawValue);
+        if (!numericPattern.test(normalizedValue)) return;
+
+        if (normalizedValue === "" || normalizedValue === ".") {
+          setDraftValue(rawValue);
+          return;
+        }
+
+        const parsed = Number(normalizedValue);
+        if (!Number.isFinite(parsed)) return;
+
+        if (max !== undefined && parsed > max) {
+          setDraftValue(formatNumericValue(max, shouldAllowDecimal));
+          onValueChange(max);
+          return;
+        }
+
+        setDraftValue(normalizedValue);
+        if (min === undefined || parsed >= min) {
+          onValueChange(shouldAllowDecimal ? parsed : Math.trunc(parsed));
+        }
+        onCompositionEnd?.(event);
+      }}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
           event.currentTarget.blur();
@@ -102,6 +135,12 @@ export function NumberInput({
         const rawValue = event.target.value.trim();
         const normalizedValue = normalizeNumericText(rawValue);
         if (!numericPattern.test(normalizedValue)) return;
+
+        const nativeEvent = event.nativeEvent as InputEvent;
+        if (isComposingRef.current || nativeEvent.isComposing) {
+          setDraftValue(rawValue);
+          return;
+        }
 
         if (normalizedValue === "" || normalizedValue === ".") {
           setDraftValue(rawValue);


### PR DESCRIPTION
## 概要
- 数値設定をキーボードで直接入力できる `NumberInput` を追加しました
- スライド間隔、スクロール速度、表示件数、フォントサイズ、フロア数などの数値設定を直接入力対応にしました
- range だけだったフォントサイズや透明度などには、スライダーに加えて数値入力欄を併設しました
- 数値以外の文字は入力時に弾き、上限超過は入力中に上限へ丸め、下限未満は確定時に下限へ補正します

## 背景
Issue #243 の対応です。従来は一部の数値設定が直接入力しづらく、スピン操作やスライダー操作に寄っていたため、テンプレート設定全体でキーボード入力しやすくしました。

## 確認
- `pnpm exec eslint src/components/ui/number-input.tsx src/components/dashboard/config-editors/SimpleBoardConfigEditor.tsx src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx src/components/dashboard/config-editors/MessageBoardConfigEditor.tsx src/components/dashboard/config-editors/CallNumberConfigEditor.tsx src/components/dashboard/config-editors/ClinicHoursConfigEditor.tsx src/components/dashboard/config-editors/QrInfoConfigEditor.tsx src/components/dashboard/config-editors/RestaurantMenuConfigEditor.tsx src/components/dashboard/config-editors/RetroBoardConfigEditor.tsx src/components/dashboard/config-editors/FloorGuideConfigEditor.tsx src/components/dashboard/SettingsClient.tsx src/components/dashboard/MediaUploadZone.tsx src/components/dashboard/BoardEditClient.tsx`
- `pnpm build`

## 補足
- `pnpm lint` は既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx` の `react-hooks/set-state-in-effect` で失敗します。今回の変更対象ファイルの lint は通過しています。

Closes #243
