### PR TITLE
[codex] Privateボード表示中のセッション期限切れでもメディア表示を継続

### DIFF
--- a/src/app/api/public/boards/[id]/heartbeat/route.ts
+++ b/src/app/api/public/boards/[id]/heartbeat/route.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import { getSessionUser } from "@/lib/auth";
 import { isBoardDisplayable } from "@/lib/board-status";
 import {
+  hasRecentBoardDisplayAccess,
   normalizeBoardDeviceKey,
   recordBoardDeviceHeartbeat,
 } from "@/lib/board-device-status";
@@ -37,11 +38,17 @@ export async function POST(
 
   if (board.visibility === "private") {
     const session = await getSessionUser();
-    if (!session) {
-      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
-    }
+    const sessionAllowed = session
+      ? isInOwnerScope(session.user, board.ownerUserId)
+      : false;
+    const displayAccessAllowed = sessionAllowed
+      ? false
+      : await hasRecentBoardDisplayAccess({ board, deviceKey });
 
-    if (!isInOwnerScope(session.user, board.ownerUserId)) {
+    if (!sessionAllowed && !displayAccessAllowed) {
+      if (!session) {
+        return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+      }
       return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
   }

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -8,6 +8,11 @@ import { boards, mediaItems } from "@/db/schema";
 import { getSessionUser } from "@/lib/auth";
 import { isBoardDisplayable } from "@/lib/board-status";
 import {
+  BOARD_DISPLAY_ACCESS_QUERY_PARAM,
+  hasRecentBoardDisplayAccess,
+  normalizeBoardDeviceKey,
+} from "@/lib/board-device-status";
+import {
   createCloudFrontSignedUrl,
   isCloudFrontSignedDeliveryMode,
 } from "@/lib/cloudfront-signed-url";
@@ -25,6 +30,7 @@ import {
 export const dynamic = "force-dynamic";
 
 type MediaDeliveryRef = {
+  boardId: string;
   filePath?: string;
   visibility: string;
   ownerUserId: string;
@@ -127,7 +133,10 @@ function mediaIdRouteFromSegments(pathSegments: string[]):
   return null;
 }
 
-async function canAccessMediaRef(refs: MediaDeliveryRef[]): Promise<{
+async function canAccessMediaRef(
+  request: NextRequest,
+  refs: MediaDeliveryRef[],
+): Promise<{
   allowed: boolean;
   requiresPrivateScope: boolean;
 }> {
@@ -144,16 +153,36 @@ async function canAccessMediaRef(refs: MediaDeliveryRef[]): Promise<{
   }
 
   const session = await getSessionUser();
-  if (!session) {
+  if (session) {
+    const allowed = displayableRefs.some((ref) =>
+      isInOwnerScope(session.user, ref.ownerUserId),
+    );
+    if (allowed) {
+      return { allowed: true, requiresPrivateScope };
+    }
+  }
+
+  const displayDeviceKey = normalizeBoardDeviceKey(
+    request.nextUrl.searchParams.get(BOARD_DISPLAY_ACCESS_QUERY_PARAM),
+  );
+  if (!displayDeviceKey) {
     return { allowed: false, requiresPrivateScope };
   }
 
-  return {
-    allowed: displayableRefs.some((ref) =>
-      isInOwnerScope(session.user, ref.ownerUserId),
-    ),
-    requiresPrivateScope,
-  };
+  let allowedByDisplayAccess = false;
+  for (const ref of displayableRefs) {
+    if (
+      await hasRecentBoardDisplayAccess({
+        board: { id: ref.boardId, ownerUserId: ref.ownerUserId },
+        deviceKey: displayDeviceKey,
+      })
+    ) {
+      allowedByDisplayAccess = true;
+      break;
+    }
+  }
+
+  return { allowed: allowedByDisplayAccess, requiresPrivateScope };
 }
 
 async function serveStoredObject(
@@ -222,6 +251,7 @@ async function handleMediaIdDelivery(
 ): Promise<NextResponse> {
   const refs = await db
     .select({
+      boardId: boards.id,
       filePath: mediaItems.filePath,
       visibility: boards.visibility,
       ownerUserId: boards.ownerUserId,
@@ -236,7 +266,7 @@ async function handleMediaIdDelivery(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const access = await canAccessMediaRef(refs);
+  const access = await canAccessMediaRef(request, refs);
   if (!access.allowed) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
@@ -293,6 +323,7 @@ export async function GET(
   const candidateMediaPaths = buildCandidateMediaPaths(filename);
   const mediaRefs = await db
     .select({
+      boardId: boards.id,
       visibility: boards.visibility,
       ownerUserId: boards.ownerUserId,
       isActive: boards.isActive,
@@ -306,7 +337,7 @@ export async function GET(
         : or(...candidateMediaPaths.map((filePath) => eq(mediaItems.filePath, filePath))),
     );
 
-  const access = await canAccessMediaRef(mediaRefs);
+  const access = await canAccessMediaRef(request, mediaRefs);
   if (mediaRefs.length > 0 && !access.allowed) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/src/components/board/LiveBoard.tsx
+++ b/src/components/board/LiveBoard.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { WatermarkOverlay } from "@/components/board/WatermarkOverlay";
 import { useSSE } from "@/hooks/useSSE";
@@ -18,6 +18,7 @@ import type {
 const CURSOR_HIDE_DELAY = 3000;
 const DEVICE_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 const DEVICE_KEY_STORAGE_KEY = "keinage-display-device-key";
+const DISPLAY_ACCESS_QUERY_PARAM = "displayDeviceKey";
 
 interface LiveBoardProps {
   board: Board;
@@ -69,6 +70,18 @@ function getOrCreateDeviceKey() {
   }
 }
 
+function withDisplayAccessQuery(filePath: string, deviceKey: string) {
+  if (!filePath.startsWith("/uploads/")) {
+    return filePath;
+  }
+
+  const [pathname = "", query = ""] = filePath.split("?", 2);
+  const params = new URLSearchParams(query);
+  params.set(DISPLAY_ACCESS_QUERY_PARAM, deviceKey);
+  const serialized = params.toString();
+  return serialized ? `${pathname}?${serialized}` : pathname;
+}
+
 /**
  * Wraps a board template with SSE-based live updates.
  * Initial data comes from server-side rendering (props).
@@ -85,6 +98,7 @@ export default function LiveBoard({
   const [mediaItems, setMediaItems] = useState(initialMedia);
   const [messages, setMessages] = useState(initialMessages);
   const [boardPlan, setBoardPlan] = useState(initialBoardPlan);
+  const [displayDeviceKey, setDisplayDeviceKey] = useState<string | null>(null);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -126,6 +140,17 @@ export default function LiveBoard({
   const exitFullscreen = useCallback(() => {
     if (document.fullscreenElement) document.exitFullscreen?.();
   }, []);
+
+  const displayMediaItems = useMemo(() => {
+    if (board.visibility !== "private" || !displayDeviceKey) {
+      return mediaItems;
+    }
+
+    return mediaItems.map((item) => ({
+      ...item,
+      filePath: withDisplayAccessQuery(item.filePath, displayDeviceKey),
+    }));
+  }, [board.visibility, displayDeviceKey, mediaItems]);
 
   // --- SSE live updates ---
   const refetchData = useCallback(async () => {
@@ -170,6 +195,7 @@ export default function LiveBoard({
 
   useEffect(() => {
     const deviceKey = getOrCreateDeviceKey();
+    const raf = requestAnimationFrame(() => setDisplayDeviceKey(deviceKey));
     let stopped = false;
 
     const sendHeartbeat = async () => {
@@ -191,6 +217,7 @@ export default function LiveBoard({
 
     return () => {
       stopped = true;
+      cancelAnimationFrame(raf);
       window.clearInterval(interval);
     };
   }, [initialBoard.id]);
@@ -203,7 +230,7 @@ export default function LiveBoard({
     >
       <TemplateComponent
         board={board}
-        mediaItems={mediaItems}
+        mediaItems={displayMediaItems}
         messages={messages}
         boardPlan={boardPlan}
       />

--- a/src/lib/board-device-status.ts
+++ b/src/lib/board-device-status.ts
@@ -7,6 +7,8 @@ import { getEffectivePlanForOwner, type EffectivePlan } from "@/lib/billing";
 
 export const BOARD_DEVICE_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 export const BOARD_DEVICE_ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
+export const BOARD_DISPLAY_ACCESS_QUERY_PARAM = "displayDeviceKey";
+export const BOARD_DISPLAY_ACCESS_GRACE_MS = 30 * 60 * 1000;
 
 const DEVICE_KEY_MAX_LENGTH = 128;
 const USER_AGENT_MAX_LENGTH = 500;
@@ -46,15 +48,18 @@ function isOnline(lastSeenAt: string, nowMs: number): boolean {
   return Number.isFinite(time) && nowMs - time <= BOARD_DEVICE_ONLINE_THRESHOLD_MS;
 }
 
+function isRecentDisplayAccess(lastSeenAt: string, nowMs: number): boolean {
+  const time = Date.parse(lastSeenAt);
+  return Number.isFinite(time) && nowMs - time <= BOARD_DISPLAY_ACCESS_GRACE_MS;
+}
+
 export async function recordBoardDeviceHeartbeat(input: {
   board: BoardDeviceBoard;
   deviceKey: string;
   userAgent: string | null;
 }): Promise<{ enabled: boolean }> {
   const effectivePlan = await getEffectivePlanForOwner(input.board.ownerUserId);
-  if (!canUseBoardDeviceStatus(effectivePlan)) {
-    return { enabled: false };
-  }
+  const enabled = canUseBoardDeviceStatus(effectivePlan);
 
   const nowMs = Date.now();
   const now = new Date(nowMs).toISOString();
@@ -91,7 +96,7 @@ export async function recordBoardDeviceHeartbeat(input: {
           updatedAt: now,
         },
       });
-    return { enabled: true };
+    return { enabled };
   }
 
   const shouldUpdate =
@@ -99,7 +104,7 @@ export async function recordBoardDeviceHeartbeat(input: {
     || existing.lastSeenAt < threshold;
 
   if (!shouldUpdate) {
-    return { enabled: true };
+    return { enabled };
   }
 
   await db
@@ -111,7 +116,25 @@ export async function recordBoardDeviceHeartbeat(input: {
     })
     .where(eq(boardDisplayDevices.id, existing.id));
 
-  return { enabled: true };
+  return { enabled };
+}
+
+export async function hasRecentBoardDisplayAccess(input: {
+  board: BoardDeviceBoard;
+  deviceKey: string | null;
+}): Promise<boolean> {
+  if (!input.deviceKey) return false;
+
+  const existing = await db.query.boardDisplayDevices.findFirst({
+    where: and(
+      eq(boardDisplayDevices.ownerUserId, input.board.ownerUserId),
+      eq(boardDisplayDevices.deviceKey, input.deviceKey),
+      eq(boardDisplayDevices.boardId, input.board.id),
+    ),
+  });
+
+  if (!existing) return false;
+  return isRecentDisplayAccess(existing.lastSeenAt, Date.now());
 }
 
 export async function listBoardDeviceStatuses(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,7 +24,7 @@ export function thumbUrl(filePath: string): string {
   const thumbParts = parts.length <= 2
     ? ["/uploads", "thumbs"]
     : [...parts, "thumbs"];
-  return `${parsed.origin}${thumbParts.join("/")}/${name}${thumbExt}`;
+  return `${parsed.origin}${thumbParts.join("/")}/${name}${thumbExt}${parsed.search}`;
 }
 
 function parseMediaUrl(value: string) {
@@ -33,11 +33,14 @@ function parseMediaUrl(value: string) {
     return {
       origin: url.origin,
       pathname: url.pathname,
+      search: url.search,
     };
   } catch {
+    const [pathname = "", search = ""] = value.split("?", 2);
     return {
       origin: "",
-      pathname: value,
+      pathname,
+      search: search ? `?${search}` : "",
     };
   }
 }


### PR DESCRIPTION
## 概要
- Privateボード表示中にログインセッションが期限切れになっても、表示中端末のメディア再取得を継続できるようにしました
- 初回表示は従来通りログインセッションで認可し、表示開始後は表示デバイスの heartbeat に紐づく短時間の継続アクセスで /uploads 配信を許可します
- 動画ポスターなどサムネイルURLにも表示デバイスキーを引き継ぐようにしました

## 背景
Privateボードの画像・動画配信は /uploads 側でもセッション確認を行うため、ページ自体は表示済みでも、セッション期限後の再読込や動画Range取得でメディア取得が失敗する可能性がありました。

## 確認
- pnpm exec eslint src/components/board/LiveBoard.tsx 'src/app/api/public/boards/[id]/heartbeat/route.ts' 'src/app/uploads/[...path]/route.ts' src/lib/board-device-status.ts src/lib/utils.ts
- pnpm build

Closes #250