### PR TITLE
[codex] メディア切替時の時計更新を安定化

### DIFF
--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 
 export type ClockLayout = "standard" | "compact" | "large-time" | "date-top";
@@ -22,6 +22,13 @@ interface DateTimeClockProps {
   fontFamily?: string;
 }
 
+const CLOCK_SETTLE_MS = 20;
+
+function delayToNextSecond() {
+  const elapsedInSecond = Date.now() % 1000;
+  return Math.max(16, 1000 - elapsedInSecond + CLOCK_SETTLE_MS);
+}
+
 export function DateTimeClock({
   is24Hour = true,
   timeFontSize = 48,
@@ -30,36 +37,48 @@ export function DateTimeClock({
   layout = "standard",
   fontFamily,
 }: DateTimeClockProps) {
-  const [now, setNow] = useState<Date | null>(null);
+  const [now, setNow] = useState(() => new Date());
   const { locale, formatDate } = useLocale();
 
   useEffect(() => {
-    const initialTimer = setTimeout(() => setNow(new Date()), 0);
-    const timer = setInterval(() => setNow(new Date()), 1000);
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = () => {
+      setNow(new Date());
+      schedule();
+    };
+
+    const schedule = () => {
+      if (stopped) return;
+      timer = setTimeout(tick, delayToNextSecond());
+    };
+
+    schedule();
+
     return () => {
-      clearTimeout(initialTimer);
-      clearInterval(timer);
+      stopped = true;
+      if (timer) clearTimeout(timer);
     };
   }, []);
 
-  if (!now) return null;
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: !is24Hour,
+      }),
+    [is24Hour, locale],
+  );
 
-  const parts = new Intl.DateTimeFormat(locale, {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: !is24Hour,
-  }).formatToParts(now);
+  const parts = timeFormatter.formatToParts(now);
   const hoursStr = parts.find((part) => part.type === "hour")?.value ?? "00";
   const minutes = parts.find((part) => part.type === "minute")?.value ?? "00";
   const seconds = parts.find((part) => part.type === "second")?.value ?? "00";
   const period = parts.find((part) => part.type === "dayPeriod")?.value ?? "";
-  const timeStr = new Intl.DateTimeFormat(locale, {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: !is24Hour,
-  }).format(now);
+  const timeStr = timeFormatter.format(now);
   const dateStr = formatDate(now, {
     year: "numeric",
     month: "2-digit",

--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { startTransition, useState, useEffect, useCallback, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { clampMediaDuration, DEFAULT_MEDIA_DURATION_SECONDS } from "@/lib/media-duration";
@@ -11,6 +11,7 @@ import type { MediaItem } from "@/types";
 
 /** How many upcoming images to preload ahead of the current slide. */
 const PRELOAD_AHEAD = 2;
+const PRELOAD_DELAY_MS = 120;
 
 interface MediaSliderProps {
   mediaItems: MediaItem[];
@@ -67,6 +68,7 @@ function DeferredVideoSlide({ item, fitClass, loop, onEnded }: DeferredVideoSlid
         <img
           src={poster}
           alt=""
+          decoding="async"
           className={`absolute inset-0 z-10 h-full w-full ${fitClass}`}
           onError={() => setPosterFailed(true)}
         />
@@ -122,16 +124,20 @@ export function MediaSlider({
   const currentImageRef = useRef<HTMLImageElement | null>(null);
 
   const advance = useCallback(() => {
-    setReadyImageKey(null);
-    setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
+    startTransition(() => {
+      setReadyImageKey(null);
+      setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
+    });
   }, [mediaItems.length]);
 
   const safeCurrentIndex =
     mediaItems.length === 0 ? 0 : Math.min(currentIndex, mediaItems.length - 1);
 
-  // --- Preload upcoming media ---
+  // --- Preload upcoming media after the active slide has had a chance to paint. ---
   useEffect(() => {
     if (mediaItems.length <= 1) return;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
 
     for (let offset = 1; offset <= PRELOAD_AHEAD; offset++) {
       const idx = (safeCurrentIndex + offset) % mediaItems.length;
@@ -139,19 +145,27 @@ export function MediaSlider({
       if (!item || preloadedRef.current.has(item.filePath)) continue;
 
       preloadedRef.current.add(item.filePath);
-      if (item.type === "image") {
-        const img = new Image();
-        img.src = item.filePath;
-      } else if (item.playbackStatus === undefined || item.playbackStatus === "available") {
-        const video = document.createElement("video");
-        video.preload = "auto";
-        video.muted = true;
-        video.playsInline = true;
-        video.src = item.filePath;
-        video.load();
-        videoPreloadRef.current.set(item.filePath, video);
-      }
+      const timer = setTimeout(() => {
+        if (item.type === "image") {
+          const img = new Image();
+          img.decoding = "async";
+          img.src = item.filePath;
+        } else if (item.playbackStatus === undefined || item.playbackStatus === "available") {
+          const video = document.createElement("video");
+          video.preload = "metadata";
+          video.muted = true;
+          video.playsInline = true;
+          video.src = item.filePath;
+          video.load();
+          videoPreloadRef.current.set(item.filePath, video);
+        }
+      }, PRELOAD_DELAY_MS * offset);
+      timers.push(timer);
     }
+
+    return () => {
+      for (const timer of timers) clearTimeout(timer);
+    };
   }, [safeCurrentIndex, mediaItems]);
 
   const current = mediaItems[safeCurrentIndex];
@@ -270,6 +284,7 @@ export function MediaSlider({
               ref={setCurrentImageNode}
               src={current.filePath}
               alt=""
+              decoding="async"
               className={`h-full w-full ${fitClass}`}
               onLoad={markCurrentImageReady}
               onError={markCurrentImageReady}


### PR DESCRIPTION
## 概要
- 時計更新を固定の setInterval から、実時刻の秒境界に合わせて次回更新を予約し直す方式へ変更しました
- 時刻フォーマッタをメモ化し、時計更新時の余計な生成コストを抑えました
- メディア切替の state 更新を React transition として扱い、時計更新などの緊急度が高い描画を優先しやすくしました
- 次メディアの先読みを切替直後から少し遅らせ、動画の先読みも metadata に抑えてメインスレッド負荷を軽減しました
- 画像と動画ポスターに async decode を指定しました

## 原因
時計がマウント時基準の setInterval(1000) で更新されていたため、重い画像/動画の切替でメインスレッドが詰まると、更新遅延やその後の短い表示が目立ちやすい状態でした。また、スライド切替タイミングで先読み処理も即時に走り、時計更新と競合しやすくなっていました。

## 確認
- pnpm exec eslint src/components/board/DateTimeClock.tsx src/components/board/MediaSlider.tsx
- pnpm build

Closes #252