### PR TITLE
feat: Keinageホームページへの導線を追加

### DIFF
--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -8,9 +8,11 @@ import {
   CreditCard,
   Activity,
   Bell,
+  ExternalLink,
   MessageCircle,
   LayoutDashboard,
   Settings,
+  Shield,
   Users,
   Menu,
   X,
@@ -55,6 +57,31 @@ function SidebarLink({
       <Icon className="size-4" />
       {children}
     </Link>
+  );
+}
+
+function SidebarExternalLink({
+  href,
+  icon: Icon,
+  children,
+  onClick,
+}: {
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={onClick}
+      className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <Icon className="size-4 shrink-0" />
+      <span className="truncate">{children}</span>
+    </a>
   );
 }
 
@@ -147,9 +174,15 @@ export function DashboardShell({
         <SidebarLink href="/settings" icon={Settings} onClick={closeSidebar}>
           {t("dashboard.navSettings")}
         </SidebarLink>
+        <SidebarExternalLink href="https://keinage.com/privacy" icon={Shield} onClick={closeSidebar}>
+          {t("dashboard.navPrivacyPolicy")}
+        </SidebarExternalLink>
       </nav>
       <Separator />
-      <div className="px-2 py-3">
+      <div className="space-y-1 px-2 py-3">
+        <SidebarExternalLink href="https://keinage.com" icon={ExternalLink} onClick={closeSidebar}>
+          keinage.com
+        </SidebarExternalLink>
         <LogoutButton />
       </div>
     </>

--- a/src/lib/i18n/messages/de.ts
+++ b/src/lib/i18n/messages/de.ts
@@ -37,6 +37,7 @@ export const de = {
   "dashboard.navStatus": "Status",
   "dashboard.navSettings": "Einstellungen",
   "dashboard.navContact": "Kontakt",
+  "dashboard.navPrivacyPolicy": "Datenschutzerklärung",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",
   "announcements.pageTitle": "Announcements",

--- a/src/lib/i18n/messages/en-US.ts
+++ b/src/lib/i18n/messages/en-US.ts
@@ -45,6 +45,7 @@ export const enUS = {
   "dashboard.navStatus": "Status",
   "dashboard.navSettings": "Settings",
   "dashboard.navContact": "Contact",
+  "dashboard.navPrivacyPolicy": "Privacy Policy",
   "dashboard.brandFor": "for {organizationName}",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",

--- a/src/lib/i18n/messages/es-419.ts
+++ b/src/lib/i18n/messages/es-419.ts
@@ -37,6 +37,7 @@ export const es419 = {
   "dashboard.navStatus": "Estado",
   "dashboard.navSettings": "Configuración",
   "dashboard.navContact": "Contacto",
+  "dashboard.navPrivacyPolicy": "Política de privacidad",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",
   "announcements.pageTitle": "Announcements",

--- a/src/lib/i18n/messages/fr.ts
+++ b/src/lib/i18n/messages/fr.ts
@@ -37,6 +37,7 @@ export const fr = {
   "dashboard.navStatus": "Statut",
   "dashboard.navSettings": "Paramètres",
   "dashboard.navContact": "Contact",
+  "dashboard.navPrivacyPolicy": "Politique de confidentialité",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",
   "announcements.pageTitle": "Announcements",

--- a/src/lib/i18n/messages/ja-JP.ts
+++ b/src/lib/i18n/messages/ja-JP.ts
@@ -47,6 +47,7 @@ export const jaJP = {
   "dashboard.navStatus": "ステータス",
   "dashboard.navSettings": "設定",
   "dashboard.navContact": "問い合わせ",
+  "dashboard.navPrivacyPolicy": "プライバシーポリシー",
   "dashboard.brandFor": "for {organizationName}",
   "dashboard.navAnnouncements": "お知らせ",
   "dashboard.navAnnouncementAdmin": "運営通知",

--- a/src/lib/i18n/messages/ko-KR.ts
+++ b/src/lib/i18n/messages/ko-KR.ts
@@ -38,6 +38,7 @@ export const koKR = {
   "dashboard.navStatus": "상태",
   "dashboard.navSettings": "설정",
   "dashboard.navContact": "문의",
+  "dashboard.navPrivacyPolicy": "개인정보 처리방침",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",
   "announcements.pageTitle": "Announcements",

--- a/src/lib/i18n/messages/zh-CN.ts
+++ b/src/lib/i18n/messages/zh-CN.ts
@@ -47,6 +47,7 @@ export const zhCN = {
   "dashboard.navStatus": "状态",
   "dashboard.navSettings": "设置",
   "dashboard.navContact": "联系",
+  "dashboard.navPrivacyPolicy": "隐私政策",
   "dashboard.brandFor": "for {organizationName}",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",

--- a/src/lib/i18n/messages/zh-TW.ts
+++ b/src/lib/i18n/messages/zh-TW.ts
@@ -25,6 +25,7 @@ export const zhTW = {
   "dashboard.navBilling": "方案與付款",
   "dashboard.navStatus": "狀態",
   "dashboard.navContact": "聯絡",
+  "dashboard.navPrivacyPolicy": "隱私權政策",
   "dashboard.navAnnouncements": "Announcements",
   "dashboard.navAnnouncementAdmin": "Admin notices",
   "announcements.pageTitle": "Announcements",


### PR DESCRIPTION
## 概要

Issue #259 の対応として、Keinageアプリのダッシュボードサイドバーから公式サイトへ移動できる導線を追加しました。

## 変更内容

- サイドバーメニュー末尾にプライバシーポリシーへの外部リンクを追加
- サイドバー下部のログアウトボタン上に `keinage.com` への外部リンクを追加
- プライバシーポリシーのメニュー表示用に各言語の翻訳キーを追加

## 確認

- `pnpm build` 成功
- `pnpm lint` は既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx` の `react-hooks/set-state-in-effect` エラーで失敗

Closes #259
