### PR TITLE
refactor: スライドショーの高画質画像読み込みを改善

### DIFF
--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -45,7 +45,7 @@ type ParsedByteRange = {
 
 function cacheControlForAccess(requiresPrivateScope: boolean): string {
   return requiresPrivateScope
-    ? "private, no-store"
+    ? "private, max-age=3600, must-revalidate"
     : "public, max-age=31536000, immutable";
 }
 

--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -12,6 +12,61 @@ import type { MediaItem } from "@/types";
 /** How many upcoming images to preload ahead of the current slide. */
 const PRELOAD_AHEAD = 2;
 const PRELOAD_DELAY_MS = 120;
+const decodedImageCache = new Map<string, Promise<void>>();
+const decodedImages = new Set<string>();
+
+function decodeImage(src: string, fetchPriority: "high" | "low" | "auto" = "auto") {
+  const cached = decodedImageCache.get(src);
+  if (cached) return cached;
+
+  const promise = new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    let settled = false;
+
+    img.decoding = "async";
+    if ("fetchPriority" in img) {
+      (img as HTMLImageElement & { fetchPriority: "high" | "low" | "auto" }).fetchPriority =
+        fetchPriority;
+    }
+
+    const resolveDecoded = () => {
+      if (settled) return;
+      settled = true;
+      const decode = img.decode?.();
+      if (decode) {
+        void decode
+          .catch(() => {
+            // The image is loaded, so keep the slideshow moving even if decode() is unavailable/fails.
+          })
+          .then(() => resolve());
+        return;
+      }
+      resolve();
+    };
+
+    img.onload = resolveDecoded;
+    img.onerror = () => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`Failed to load image: ${src}`));
+    };
+    img.src = src;
+
+    if (img.complete && img.naturalWidth > 0) {
+      resolveDecoded();
+    }
+  })
+    .then(() => {
+      decodedImages.add(src);
+    })
+    .catch((error) => {
+      decodedImageCache.delete(src);
+      throw error;
+    });
+
+  decodedImageCache.set(src, promise);
+  return promise;
+}
 
 interface MediaSliderProps {
   mediaItems: MediaItem[];
@@ -24,6 +79,12 @@ interface DeferredVideoSlideProps {
   fitClass: string;
   loop: boolean;
   onEnded: () => void;
+}
+
+interface DecodedImageSlideProps {
+  item: MediaItem;
+  fitClass: string;
+  onReady: () => void;
 }
 
 function DisabledVideoSlide({ item }: { item: MediaItem }) {
@@ -39,6 +100,51 @@ function DisabledVideoSlide({ item }: { item: MediaItem }) {
         <p className="text-lg font-semibold">{t("board.videoUnavailableTitle")}</p>
         <p className="mt-2 text-sm text-white/75">{t(messageKey)}</p>
       </div>
+    </div>
+  );
+}
+
+function DecodedImageSlide({ item, fitClass, onReady }: DecodedImageSlideProps) {
+  const [isReady, setIsReady] = useState(() => decodedImages.has(item.filePath));
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void decodeImage(item.filePath, "high")
+      .catch((error) => {
+        console.error("[MediaSlider] Failed to decode image", {
+          mediaId: item.id,
+          filePath: item.filePath,
+          error,
+        });
+      })
+      .then(() => {
+        if (cancelled) return;
+        setIsReady(true);
+        onReady();
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [item.filePath, item.id, onReady]);
+
+  useEffect(() => {
+    if (isReady) {
+      onReady();
+    }
+  }, [isReady, onReady]);
+
+  return (
+    <div className="h-full w-full bg-black">
+      {isReady && (
+        <img
+          src={item.filePath}
+          alt=""
+          decoding="async"
+          className={`h-full w-full ${fitClass}`}
+        />
+      )}
     </div>
   );
 }
@@ -119,19 +225,42 @@ export function MediaSlider({
   const { t } = useLocale();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [readyImageKey, setReadyImageKey] = useState<string | null>(null);
-  const preloadedRef = useRef<Set<string>>(new Set());
   const videoPreloadRef = useRef<Map<string, HTMLVideoElement>>(new Map());
-  const currentImageRef = useRef<HTMLImageElement | null>(null);
-
-  const advance = useCallback(() => {
-    startTransition(() => {
-      setReadyImageKey(null);
-      setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
-    });
-  }, [mediaItems.length]);
-
+  const advanceTokenRef = useRef(0);
   const safeCurrentIndex =
     mediaItems.length === 0 ? 0 : Math.min(currentIndex, mediaItems.length - 1);
+
+  const advance = useCallback(() => {
+    if (mediaItems.length <= 0) return;
+
+    const nextIndex = (safeCurrentIndex + 1) % mediaItems.length;
+    const next = mediaItems[nextIndex];
+    const token = advanceTokenRef.current + 1;
+    advanceTokenRef.current = token;
+
+    const commit = () => {
+      if (advanceTokenRef.current !== token) return;
+      startTransition(() => {
+        setReadyImageKey(null);
+        setCurrentIndex(nextIndex);
+      });
+    };
+
+    if (next?.type === "image") {
+      void decodeImage(next.filePath, "high")
+        .catch((error) => {
+          console.error("[MediaSlider] Failed to preload next image", {
+            mediaId: next.id,
+            filePath: next.filePath,
+            error,
+          });
+        })
+        .then(commit);
+      return;
+    }
+
+    commit();
+  }, [safeCurrentIndex, mediaItems]);
 
   // --- Preload upcoming media after the active slide has had a chance to paint. ---
   useEffect(() => {
@@ -142,15 +271,19 @@ export function MediaSlider({
     for (let offset = 1; offset <= PRELOAD_AHEAD; offset++) {
       const idx = (safeCurrentIndex + offset) % mediaItems.length;
       const item = mediaItems[idx];
-      if (!item || preloadedRef.current.has(item.filePath)) continue;
+      if (!item) continue;
 
-      preloadedRef.current.add(item.filePath);
       const timer = setTimeout(() => {
         if (item.type === "image") {
-          const img = new Image();
-          img.decoding = "async";
-          img.src = item.filePath;
+          void decodeImage(item.filePath, offset === 1 ? "high" : "low").catch((error) => {
+            console.error("[MediaSlider] Failed to preload image", {
+              mediaId: item.id,
+              filePath: item.filePath,
+              error,
+            });
+          });
         } else if (item.playbackStatus === undefined || item.playbackStatus === "available") {
+          if (videoPreloadRef.current.has(item.filePath)) return;
           const video = document.createElement("video");
           video.preload = "metadata";
           video.muted = true;
@@ -181,28 +314,6 @@ export function MediaSlider({
       setReadyImageKey(currentKey);
     }
   }, [currentKey]);
-
-  const setCurrentImageNode = useCallback(
-    (node: HTMLImageElement | null) => {
-      currentImageRef.current = node;
-      if (node?.complete) {
-        markCurrentImageReady();
-      }
-    },
-    [markCurrentImageReady],
-  );
-
-  useEffect(() => {
-    if (currentType !== "image") return;
-
-    const raf = requestAnimationFrame(() => {
-      if (currentImageRef.current?.complete) {
-        markCurrentImageReady();
-      }
-    });
-
-    return () => cancelAnimationFrame(raf);
-  }, [currentType, currentKey, markCurrentImageReady]);
 
   // --- Auto-advance timer (starts only after the current image has loaded) ---
   useEffect(() => {
@@ -280,14 +391,10 @@ export function MediaSlider({
               />
             )
           ) : (
-            <img
-              ref={setCurrentImageNode}
-              src={current.filePath}
-              alt=""
-              decoding="async"
-              className={`h-full w-full ${fitClass}`}
-              onLoad={markCurrentImageReady}
-              onError={markCurrentImageReady}
+            <DecodedImageSlide
+              item={current}
+              fitClass={fitClass}
+              onReady={markCurrentImageReady}
             />
           )}
         </motion.div>


### PR DESCRIPTION
## 概要

Issue #261 の対応として、シンプル掲示板/フォトクロックで使われるスライドショー画像の読み込み品質を改善しました。

## 変更内容

- 次に表示する画像を事前に読み込み、`HTMLImageElement.decode()` でデコード完了を待ってからスライドを進めるように変更
- 現在表示中の画像もデコード完了後に描画する専用コンポーネントへ変更し、読み込み途中の画像がフェード中に部分描画されにくいように調整
- 先読み済み画像のPromise/デコード済みURLをキャッシュし、ループ時の再デコード負荷を抑制
- 非公開スコープのアップロード配信ヘッダーを `private, no-store` から `private, max-age=3600, must-revalidate` に変更し、ブラウザ内キャッシュを使えるように調整

## 期待される効果

- 4K程度の高画質画像でも、次スライドが読み込み途中の状態で表示されるのを避け、黒背景から自然にフェードインしやすくなります。
- 非公開ボードでも同一画像のループ時に毎回再取得しにくくなり、スライドショーのカクつきが軽減されます。

## 確認

- `pnpm build` 成功
- `pnpm lint` は既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx` の `react-hooks/set-state-in-effect` エラーで失敗

Closes #261
