### PR TITLE
feat: フォトクロックにランダム再生を追加

### DIFF
--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { startTransition, useState, useEffect, useCallback, useRef } from "react";
+import { startTransition, useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { clampMediaDuration, DEFAULT_MEDIA_DURATION_SECONDS } from "@/lib/media-duration";
@@ -68,10 +68,24 @@ function decodeImage(src: string, fetchPriority: "high" | "low" | "auto" = "auto
   return promise;
 }
 
+function shuffledIndexes(length: number, excludeIndex: number) {
+  const indexes = Array.from({ length }, (_, index) => index).filter(
+    (index) => index !== excludeIndex,
+  );
+
+  for (let index = indexes.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [indexes[index], indexes[swapIndex]] = [indexes[swapIndex], indexes[index]];
+  }
+
+  return indexes;
+}
+
 interface MediaSliderProps {
   mediaItems: MediaItem[];
   /** How media fits the container: "contain" (show all) or "cover" (fill, may crop) */
   objectFit?: "contain" | "cover";
+  playbackOrder?: "sequential" | "random";
 }
 
 interface DeferredVideoSlideProps {
@@ -221,20 +235,48 @@ function DeferredVideoSlide({ item, fitClass, loop, onEnded }: DeferredVideoSlid
 export function MediaSlider({
   mediaItems,
   objectFit = "contain",
+  playbackOrder = "sequential",
 }: MediaSliderProps) {
   const { t } = useLocale();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [readyImageKey, setReadyImageKey] = useState<string | null>(null);
   const videoPreloadRef = useRef<Map<string, HTMLVideoElement>>(new Map());
   const advanceTokenRef = useRef(0);
+  const randomQueueRef = useRef<number[]>([]);
+  const mediaKey = useMemo(
+    () => mediaItems.map((item) => `${item.id}:${item.filePath}`).join("|"),
+    [mediaItems],
+  );
   const safeCurrentIndex =
     mediaItems.length === 0 ? 0 : Math.min(currentIndex, mediaItems.length - 1);
+
+  useEffect(() => {
+    randomQueueRef.current = [];
+  }, [mediaKey, playbackOrder]);
+
+  const ensureRandomQueue = useCallback(() => {
+    randomQueueRef.current = randomQueueRef.current.filter(
+      (index) => index >= 0 && index < mediaItems.length && index !== safeCurrentIndex,
+    );
+    if (randomQueueRef.current.length === 0) {
+      randomQueueRef.current = shuffledIndexes(mediaItems.length, safeCurrentIndex);
+    }
+    return randomQueueRef.current;
+  }, [mediaItems.length, safeCurrentIndex]);
+
+  const nextIndex = useCallback(() => {
+    if (mediaItems.length <= 1) return safeCurrentIndex;
+    if (playbackOrder !== "random") {
+      return (safeCurrentIndex + 1) % mediaItems.length;
+    }
+    return ensureRandomQueue().shift() ?? ((safeCurrentIndex + 1) % mediaItems.length);
+  }, [ensureRandomQueue, mediaItems.length, playbackOrder, safeCurrentIndex]);
 
   const advance = useCallback(() => {
     if (mediaItems.length <= 0) return;
 
-    const nextIndex = (safeCurrentIndex + 1) % mediaItems.length;
-    const next = mediaItems[nextIndex];
+    const upcomingIndex = nextIndex();
+    const next = mediaItems[upcomingIndex];
     const token = advanceTokenRef.current + 1;
     advanceTokenRef.current = token;
 
@@ -242,7 +284,7 @@ export function MediaSlider({
       if (advanceTokenRef.current !== token) return;
       startTransition(() => {
         setReadyImageKey(null);
-        setCurrentIndex(nextIndex);
+        setCurrentIndex(upcomingIndex);
       });
     };
 
@@ -260,7 +302,7 @@ export function MediaSlider({
     }
 
     commit();
-  }, [safeCurrentIndex, mediaItems]);
+  }, [mediaItems, nextIndex]);
 
   // --- Preload upcoming media after the active slide has had a chance to paint. ---
   useEffect(() => {
@@ -268,10 +310,17 @@ export function MediaSlider({
 
     const timers: ReturnType<typeof setTimeout>[] = [];
 
-    for (let offset = 1; offset <= PRELOAD_AHEAD; offset++) {
-      const idx = (safeCurrentIndex + offset) % mediaItems.length;
+    const preloadIndexes =
+      playbackOrder === "random"
+        ? ensureRandomQueue().slice(0, PRELOAD_AHEAD)
+        : Array.from(
+            { length: PRELOAD_AHEAD },
+            (_, offset) => (safeCurrentIndex + offset + 1) % mediaItems.length,
+          );
+
+    preloadIndexes.forEach((idx, offset) => {
       const item = mediaItems[idx];
-      if (!item) continue;
+      if (!item) return;
 
       const timer = setTimeout(() => {
         if (item.type === "image") {
@@ -292,14 +341,14 @@ export function MediaSlider({
           video.load();
           videoPreloadRef.current.set(item.filePath, video);
         }
-      }, PRELOAD_DELAY_MS * offset);
+      }, PRELOAD_DELAY_MS * (offset + 1));
       timers.push(timer);
-    }
+    });
 
     return () => {
       for (const timer of timers) clearTimeout(timer);
     };
-  }, [safeCurrentIndex, mediaItems]);
+  }, [ensureRandomQueue, mediaItems, playbackOrder, safeCurrentIndex]);
 
   const current = mediaItems[safeCurrentIndex];
   const currentKey = current ? `${current.id}:${current.filePath}` : "";

--- a/src/components/board/templates/PhotoClockBoard.tsx
+++ b/src/components/board/templates/PhotoClockBoard.tsx
@@ -40,6 +40,7 @@ export const photoClockDefaultConfig = {
   showWeather: false,
   weatherFontSize: 18,
   objectFit: "contain" as "contain" | "cover",
+  randomPlayback: false,
   fontFamily: "",
   fallbackMediaId: "",
   mediaSchedules: {},
@@ -111,6 +112,7 @@ export default function PhotoClockBoard({
         <MediaSlider
           mediaItems={activeMedia}
           objectFit={config.objectFit}
+          playbackOrder={config.randomPlayback ? "random" : "sequential"}
         />
       ) : (
         <ScheduledMediaFallback

--- a/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/PhotoClockConfigEditor.tsx
@@ -90,6 +90,7 @@ export function PhotoClockConfigEditor({
   const showWeather = (config.showWeather as boolean) ?? false;
   const weatherFontSize = (config.weatherFontSize as number) ?? 18;
   const objectFit = (config.objectFit as string) ?? "contain";
+  const randomPlayback = (config.randomPlayback as boolean) ?? false;
   const fontFamily = (config.fontFamily as string) ?? "";
   const clockOnlyState = clockOnlyStateFromPosition(clockPosition);
 
@@ -136,6 +137,17 @@ export function PhotoClockConfigEditor({
             <SelectItem value="cover">{t("configEditor.objectFitCover")}</SelectItem>
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="flex flex-wrap items-start gap-3">
+        <Switch
+          id="cfg-randomPlayback"
+          checked={randomPlayback}
+          onCheckedChange={(v) => update("randomPlayback", v)}
+        />
+        <Label htmlFor="cfg-randomPlayback" className="min-w-0 flex-1 leading-snug">
+          {t("configEditor.randomPlayback")}
+        </Label>
       </div>
 
       {!showWeather && (

--- a/src/lib/i18n/messages/en-US.ts
+++ b/src/lib/i18n/messages/en-US.ts
@@ -428,6 +428,7 @@ export const enUS = {
   "configEditor.mediaMode": "Media display mode",
   "configEditor.objectFitContain": "Fit entire media (may show margins)",
   "configEditor.objectFitCover": "Fill screen (may crop)",
+  "configEditor.randomPlayback": "Random playback",
   "schedule.title": "Schedule",
   "schedule.plan.none": "Scheduling is not available on this plan.",
   "schedule.plan.timeWeekday": "You can set time ranges and weekdays. Date ranges are available on Standard and higher.",

--- a/src/lib/i18n/messages/ja-JP.ts
+++ b/src/lib/i18n/messages/ja-JP.ts
@@ -430,6 +430,7 @@ export const jaJP = {
   "configEditor.mediaMode": "メディア表示モード",
   "configEditor.objectFitContain": "全体表示（余白ができる場合あり）",
   "configEditor.objectFitCover": "全面表示（トリミングされる場合あり）",
+  "configEditor.randomPlayback": "ランダム再生",
   "schedule.title": "スケジュール",
   "schedule.plan.none": "このプランではスケジュール機能は利用できません",
   "schedule.plan.timeWeekday": "時間帯と曜日を指定できます。日付期間は Standard 以上で利用できます",

--- a/src/lib/i18n/messages/zh-CN.ts
+++ b/src/lib/i18n/messages/zh-CN.ts
@@ -430,6 +430,7 @@ export const zhCN = {
   "configEditor.mediaMode": "媒体显示模式",
   "configEditor.objectFitContain": "完整显示（可能留白）",
   "configEditor.objectFitCover": "铺满显示（可能裁切）",
+  "configEditor.randomPlayback": "随机播放",
   "schedule.title": "排程",
   "schedule.plan.none": "当前套餐不支持排程功能。",
   "schedule.plan.timeWeekday": "可设置时间段和星期。日期范围在 Standard 及以上套餐可用。",


### PR DESCRIPTION
## 概要

Issue #263 の対応として、フォトクロックテンプレートでメディアをランダム再生できるようにしました。

## 変更内容

- フォトクロック設定の「メディア表示モード」の下に「ランダム再生」トグルを追加
- フォトクロック設定に `randomPlayback` を追加し、未設定時は従来どおり順番再生に維持
- `MediaSlider` に `playbackOrder` オプションを追加
- ランダム再生時は現在のスライドを除いたシャッフルキューから次スライドを選ぶようにし、同じメディアが連続しにくいように調整
- ランダム再生時も次候補の画像先読みが働くように調整

## 確認

- `pnpm build` 成功
- `pnpm lint` は既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx` の `react-hooks/set-state-in-effect` エラーで失敗

Closes #263
