### PR TITLE
fix: フォトクロックのスライドショー切替タイミングを安定化

### DIFF
--- a/src/components/board/DateTimeClock.tsx
+++ b/src/components/board/DateTimeClock.tsx
@@ -42,12 +42,13 @@ export function DateTimeClock({
   fontFamily,
   className,
 }: DateTimeClockProps) {
-  const [now, setNow] = useState(() => new Date());
+  const [now, setNow] = useState<Date | null>(null);
   const { locale, formatDate } = useLocale();
 
   useEffect(() => {
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let raf: number | null = null;
 
     const tick = () => {
       setNow(new Date());
@@ -59,10 +60,11 @@ export function DateTimeClock({
       timer = setTimeout(tick, delayToNextSecond());
     };
 
-    schedule();
+    raf = requestAnimationFrame(tick);
 
     return () => {
       stopped = true;
+      if (raf) cancelAnimationFrame(raf);
       if (timer) clearTimeout(timer);
     };
   }, []);
@@ -78,24 +80,27 @@ export function DateTimeClock({
     [is24Hour, locale],
   );
 
-  const parts = timeFormatter.formatToParts(now);
+  const parts = now ? timeFormatter.formatToParts(now) : [];
   const hoursStr = parts.find((part) => part.type === "hour")?.value ?? "00";
   const minutes = parts.find((part) => part.type === "minute")?.value ?? "00";
   const seconds = parts.find((part) => part.type === "second")?.value ?? "00";
   const period = parts.find((part) => part.type === "dayPeriod")?.value ?? "";
-  const timeStr = timeFormatter.format(now);
-  const dateStr = formatDate(now, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    weekday: "short",
-  });
+  const timeStr = now ? timeFormatter.format(now) : "00:00:00";
+  const dateStr = now
+    ? formatDate(now, {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        weekday: "short",
+      })
+    : "0000/00/00";
 
   const resolvedDateFontSize = dateFontSize ?? Math.max(14, Math.round(timeFontSize * 0.35));
 
   const fontStyle = fontFamily || "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
   const hasBackground = bgOpacity > 0;
   const rootClassName = className ?? "";
+  const visibility = now ? undefined : "hidden";
 
   if (layout === "compact") {
     return (
@@ -105,6 +110,7 @@ export function DateTimeClock({
           backgroundColor: hasBackground ? `rgba(0, 0, 0, ${bgOpacity})` : undefined,
           color,
           fontFamily: fontStyle,
+          visibility,
         }}
       >
         <span
@@ -131,6 +137,7 @@ export function DateTimeClock({
           backgroundColor: hasBackground ? `rgba(0, 0, 0, ${bgOpacity})` : undefined,
           color,
           fontFamily: fontStyle,
+          visibility,
         }}
       >
         <span
@@ -163,6 +170,7 @@ export function DateTimeClock({
           backgroundColor: hasBackground ? `rgba(0, 0, 0, ${bgOpacity})` : undefined,
           color,
           fontFamily: fontStyle,
+          visibility,
         }}
       >
         <span
@@ -189,6 +197,7 @@ export function DateTimeClock({
         backgroundColor: hasBackground ? `rgba(0, 0, 0, ${bgOpacity})` : undefined,
         color,
         fontFamily: fontStyle,
+        visibility,
       }}
     >
       <span

--- a/src/components/board/MediaSlider.tsx
+++ b/src/components/board/MediaSlider.tsx
@@ -243,6 +243,9 @@ export function MediaSlider({
   const videoPreloadRef = useRef<Map<string, HTMLVideoElement>>(new Map());
   const advanceTokenRef = useRef(0);
   const randomQueueRef = useRef<number[]>([]);
+  const mediaItemsRef = useRef(mediaItems);
+  const currentIndexRef = useRef(0);
+  const playbackOrderRef = useRef(playbackOrder);
   const mediaKey = useMemo(
     () => mediaItems.map((item) => `${item.id}:${item.filePath}`).join("|"),
     [mediaItems],
@@ -251,32 +254,49 @@ export function MediaSlider({
     mediaItems.length === 0 ? 0 : Math.min(currentIndex, mediaItems.length - 1);
 
   useEffect(() => {
+    mediaItemsRef.current = mediaItems;
+  }, [mediaItems]);
+
+  useEffect(() => {
+    currentIndexRef.current = safeCurrentIndex;
+  }, [safeCurrentIndex]);
+
+  useEffect(() => {
+    playbackOrderRef.current = playbackOrder;
+  }, [playbackOrder]);
+
+  useEffect(() => {
     randomQueueRef.current = [];
   }, [mediaKey, playbackOrder]);
 
   const ensureRandomQueue = useCallback(() => {
+    const items = mediaItemsRef.current;
+    const activeIndex = currentIndexRef.current;
     randomQueueRef.current = randomQueueRef.current.filter(
-      (index) => index >= 0 && index < mediaItems.length && index !== safeCurrentIndex,
+      (index) => index >= 0 && index < items.length && index !== activeIndex,
     );
     if (randomQueueRef.current.length === 0) {
-      randomQueueRef.current = shuffledIndexes(mediaItems.length, safeCurrentIndex);
+      randomQueueRef.current = shuffledIndexes(items.length, activeIndex);
     }
     return randomQueueRef.current;
-  }, [mediaItems.length, safeCurrentIndex]);
+  }, []);
 
   const nextIndex = useCallback(() => {
-    if (mediaItems.length <= 1) return safeCurrentIndex;
-    if (playbackOrder !== "random") {
-      return (safeCurrentIndex + 1) % mediaItems.length;
+    const items = mediaItemsRef.current;
+    const activeIndex = currentIndexRef.current;
+    if (items.length <= 1) return activeIndex;
+    if (playbackOrderRef.current !== "random") {
+      return (activeIndex + 1) % items.length;
     }
-    return ensureRandomQueue().shift() ?? ((safeCurrentIndex + 1) % mediaItems.length);
-  }, [ensureRandomQueue, mediaItems.length, playbackOrder, safeCurrentIndex]);
+    return ensureRandomQueue().shift() ?? ((activeIndex + 1) % items.length);
+  }, [ensureRandomQueue]);
 
   const advance = useCallback(() => {
-    if (mediaItems.length <= 0) return;
+    const items = mediaItemsRef.current;
+    if (items.length <= 0) return;
 
     const upcomingIndex = nextIndex();
-    const next = mediaItems[upcomingIndex];
+    const next = items[upcomingIndex];
     const token = advanceTokenRef.current + 1;
     advanceTokenRef.current = token;
 
@@ -302,7 +322,7 @@ export function MediaSlider({
     }
 
     commit();
-  }, [mediaItems, nextIndex]);
+  }, [nextIndex]);
 
   // --- Preload upcoming media after the active slide has had a chance to paint. ---
   useEffect(() => {


### PR DESCRIPTION
## 概要

Issue #270 の対応として、フォトクロックのスライドショー切替タイミングが指定秒数からずれる問題を修正しました。

## 原因

フォトクロックはスケジュール判定のために `useScheduleNow()` で1分ごとに再レンダーされます。

一方、`MediaSlider` の自動切替タイマーは `advance` callback に依存しており、その `advance` が親から渡される `mediaItems` 配列の参照変化に引きずられて再生成されていました。

そのため、60秒切替のように親の1分更新と同じ周期になる設定では、タイマーが再作成されて切替が遅れる/不安定になる可能性がありました。

また、コンソールに出ていた React error #418 は、時計表示がSSR時刻とクライアント初回時刻で一致しない hydration mismatch の可能性が高いため、あわせて初回描画を安定化しています。

## 変更内容

- `MediaSlider` の `advance` / `nextIndex` を `mediaItems` 配列参照に依存しない安定callbackへ変更
- 最新のメディア一覧・現在index・再生順はrefで参照し、親の定期再レンダーで切替タイマーがリセットされないように調整
- ランダム再生のシャッフルキューも最新状態をref経由で扱うように調整
- `DateTimeClock` はSSR/クライアント初回で同じ非表示プレースホルダーを描画し、マウント後に実時刻を表示するように変更

## 確認

- `pnpm build` 成功
- `pnpm lint` は既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx` の `react-hooks/set-state-in-effect` エラーで失敗
  - 今回変更分のlintエラーは解消済み

Closes #270
