### PR TITLE
ci: dev/main向けにbuild workflowを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: pnpm build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## 概要

- `dev` / `main` 向けの Pull Request 作成・更新時に `pnpm build` を実行するGitHub Actions workflowを追加しました
- `dev` / `main` への push、つまりPRマージ後のブランチ更新時にも `pnpm build` を実行します
- 無料枠を意識し、Issue指定どおり lint は含めず build のみの最小構成にしています

## workflow

- `pull_request`
  - 対象: `dev`, `main`
  - 種別: `opened`, `reopened`, `synchronize`, `ready_for_review`
- `push`
  - 対象: `dev`, `main`
- 実行内容
  - Node.js 20
  - pnpm 10.33.0
  - `pnpm install --frozen-lockfile`
  - `pnpm build`

## 確認

- ローカルで `pnpm build` 成功
- workflow定義のみのため、GitHub Actions上の実行はPR作成後に確認します

Closes #274
