### PR TITLE
feat: お知らせメニューに未読件数を表示

### DIFF
--- a/src/components/dashboard/AnnouncementBanner.tsx
+++ b/src/components/dashboard/AnnouncementBanner.tsx
@@ -2,55 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { AlertTriangle, CheckCircle2, ExternalLink, X } from "lucide-react";
+import { useAnnouncements } from "@/components/dashboard/AnnouncementProvider";
 import {
   AnnouncementRequiredMark,
   getAnnouncementAppearance,
   getRequiredAnnouncementLabelKey,
-  type AnnouncementSeverity,
-  type AnnouncementType,
 } from "@/components/dashboard/announcement-presentation";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-interface Announcement {
-  id: string;
-  title: string;
-  body: string;
-  type: AnnouncementType;
-  severity: AnnouncementSeverity;
-  requireAcknowledgement: boolean;
-  readAt: string | null;
-  acknowledgedAt: string | null;
-}
-
-async function postAnnouncementAction(id: string, action: "read" | "acknowledge") {
-  await fetch(`/api/announcements/${id}/${action}`, { method: "POST" });
-}
-
 export function AnnouncementBanner() {
   const { t } = useLocale();
-  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const { announcements, markAnnouncement } = useAnnouncements();
   const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadAnnouncements() {
-      const res = await fetch("/api/announcements", { cache: "no-store" });
-      if (!res.ok || cancelled) return;
-      const data = await res.json() as { announcements?: Announcement[] };
-      if (!cancelled) {
-        setAnnouncements(data.announcements ?? []);
-      }
-    }
-    void loadAnnouncements();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const important = useMemo(
     () => announcements.find((announcement) => (
@@ -76,22 +44,11 @@ export function AnnouncementBanner() {
   })() : null;
 
   async function markRead(id: string) {
-    setAnnouncements((current) => current.map((announcement) => (
-      announcement.id === id
-        ? { ...announcement, readAt: new Date().toISOString() }
-        : announcement
-    )));
-    await postAnnouncementAction(id, "read");
+    await markAnnouncement(id, "read");
   }
 
   async function acknowledge(id: string) {
-    const now = new Date().toISOString();
-    setAnnouncements((current) => current.map((announcement) => (
-      announcement.id === id
-        ? { ...announcement, readAt: now, acknowledgedAt: now }
-        : announcement
-    )));
-    await postAnnouncementAction(id, "acknowledge");
+    await markAnnouncement(id, "acknowledge");
   }
 
   return (

--- a/src/components/dashboard/AnnouncementProvider.tsx
+++ b/src/components/dashboard/AnnouncementProvider.tsx
@@ -1,0 +1,145 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type {
+  AnnouncementSeverity,
+  AnnouncementType,
+} from "@/components/dashboard/announcement-presentation";
+
+export type AnnouncementTargetScope =
+  | "all"
+  | "free"
+  | "paid"
+  | "lite"
+  | "standard"
+  | "standard_plus";
+export type AnnouncementStatus = "draft" | "published" | "archived";
+
+export interface Announcement {
+  id: string;
+  title: string;
+  body: string;
+  type: AnnouncementType;
+  severity: AnnouncementSeverity;
+  targetScope: AnnouncementTargetScope;
+  publishStatus: AnnouncementStatus;
+  startsAt: string | null;
+  endsAt: string | null;
+  sendEmail: boolean;
+  emailSentAt: string | null;
+  emailLastError: string | null;
+  requireAcknowledgement: boolean;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  readAt: string | null;
+  acknowledgedAt: string | null;
+}
+
+type AnnouncementAction = "read" | "acknowledge";
+
+interface AnnouncementContextValue {
+  announcements: Announcement[];
+  loading: boolean;
+  unreadCount: number;
+  refreshAnnouncements: () => Promise<void>;
+  markAnnouncement: (id: string, action: AnnouncementAction) => Promise<boolean>;
+}
+
+const AnnouncementContext = createContext<AnnouncementContextValue | null>(null);
+
+async function fetchAnnouncements() {
+  try {
+    const response = await fetch("/api/announcements", { cache: "no-store" });
+    if (!response.ok) return null;
+    const data = await response.json() as { announcements?: Announcement[] };
+    return data.announcements ?? [];
+  } catch {
+    return null;
+  }
+}
+
+export function AnnouncementProvider({ children }: { children: React.ReactNode }) {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refreshAnnouncements = useCallback(async () => {
+    const nextAnnouncements = await fetchAnnouncements();
+    if (nextAnnouncements) {
+      setAnnouncements(nextAnnouncements);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAnnouncements() {
+      const nextAnnouncements = await fetchAnnouncements();
+      if (!cancelled && nextAnnouncements) {
+        setAnnouncements(nextAnnouncements);
+      }
+      if (!cancelled) {
+        setLoading(false);
+      }
+    }
+
+    void loadAnnouncements();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const markAnnouncement = useCallback(async (id: string, action: AnnouncementAction) => {
+    const now = new Date().toISOString();
+    setAnnouncements((current) => current.map((announcement) => (
+      announcement.id === id
+        ? {
+            ...announcement,
+            readAt: now,
+            acknowledgedAt: action === "acknowledge" ? now : announcement.acknowledgedAt,
+          }
+        : announcement
+    )));
+
+    try {
+      const response = await fetch(`/api/announcements/${id}/${action}`, { method: "POST" });
+      if (response.ok) return true;
+    } catch {
+      // Restore the server state below.
+    }
+
+    await refreshAnnouncements();
+    return false;
+  }, [refreshAnnouncements]);
+
+  const value = useMemo<AnnouncementContextValue>(() => ({
+    announcements,
+    loading,
+    unreadCount: announcements.filter((announcement) => !announcement.readAt).length,
+    refreshAnnouncements,
+    markAnnouncement,
+  }), [announcements, loading, markAnnouncement, refreshAnnouncements]);
+
+  return (
+    <AnnouncementContext.Provider value={value}>
+      {children}
+    </AnnouncementContext.Provider>
+  );
+}
+
+export function useAnnouncements() {
+  const context = useContext(AnnouncementContext);
+  if (!context) {
+    throw new Error("useAnnouncements must be used within AnnouncementProvider");
+  }
+  return context;
+}

--- a/src/components/dashboard/AnnouncementsClient.tsx
+++ b/src/components/dashboard/AnnouncementsClient.tsx
@@ -20,6 +20,12 @@ import {
   type AnnouncementSeverity,
   type AnnouncementType,
 } from "@/components/dashboard/announcement-presentation";
+import {
+  type Announcement,
+  type AnnouncementStatus,
+  type AnnouncementTargetScope,
+  useAnnouncements,
+} from "@/components/dashboard/AnnouncementProvider";
 import { useLocale } from "@/components/i18n/LocaleProvider";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -42,30 +48,6 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-
-type AnnouncementTargetScope = "all" | "free" | "paid" | "lite" | "standard" | "standard_plus";
-type AnnouncementStatus = "draft" | "published" | "archived";
-
-interface Announcement {
-  id: string;
-  title: string;
-  body: string;
-  type: AnnouncementType;
-  severity: AnnouncementSeverity;
-  targetScope: AnnouncementTargetScope;
-  publishStatus: AnnouncementStatus;
-  startsAt: string | null;
-  endsAt: string | null;
-  sendEmail: boolean;
-  emailSentAt: string | null;
-  emailLastError: string | null;
-  requireAcknowledgement: boolean;
-  publishedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-  readAt?: string | null;
-  acknowledgedAt?: string | null;
-}
 
 const TYPES: AnnouncementType[] = ["info", "maintenance", "incident", "billing", "legal", "termination"];
 const SEVERITIES: AnnouncementSeverity[] = ["low", "medium", "high"];
@@ -106,24 +88,18 @@ function severityVariant(severity: AnnouncementSeverity) {
 
 export function AnnouncementsClient({ isSuperOwner }: { isSuperOwner: boolean }) {
   const { t, formatDateTime } = useLocale();
-  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const {
+    announcements,
+    loading,
+    markAnnouncement,
+    refreshAnnouncements,
+  } = useAnnouncements();
   const [adminAnnouncements, setAdminAnnouncements] = useState<Announcement[]>([]);
-  const [loading, setLoading] = useState(true);
   const [adminLoading, setAdminLoading] = useState(isSuperOwner);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [form, setForm] = useState(EMPTY_FORM);
-
-  const fetchAnnouncements = useCallback(async () => {
-    setLoading(true);
-    const res = await fetch("/api/announcements", { cache: "no-store" });
-    if (res.ok) {
-      const data = await res.json() as { announcements?: Announcement[] };
-      setAnnouncements(data.announcements ?? []);
-    }
-    setLoading(false);
-  }, []);
 
   const fetchAdminAnnouncements = useCallback(async () => {
     if (!isSuperOwner) return;
@@ -137,29 +113,23 @@ export function AnnouncementsClient({ isSuperOwner }: { isSuperOwner: boolean })
   }, [isSuperOwner]);
 
   useEffect(() => {
+    if (!isSuperOwner) {
+      return;
+    }
+
     let cancelled = false;
-    async function loadInitial() {
-      const [userRes, adminRes] = await Promise.all([
-        fetch("/api/announcements", { cache: "no-store" }),
-        isSuperOwner
-          ? fetch("/api/super-owner/announcements", { cache: "no-store" })
-          : Promise.resolve(null),
-      ]);
+    async function loadAdminAnnouncements() {
+      const adminRes = await fetch("/api/super-owner/announcements", { cache: "no-store" });
       if (cancelled) return;
-      if (userRes.ok) {
-        const data = await userRes.json() as { announcements?: Announcement[] };
-        if (!cancelled) setAnnouncements(data.announcements ?? []);
-      }
-      if (adminRes?.ok) {
+      if (adminRes.ok) {
         const data = await adminRes.json() as { announcements?: Announcement[] };
         if (!cancelled) setAdminAnnouncements(data.announcements ?? []);
       }
       if (!cancelled) {
-        setLoading(false);
         setAdminLoading(false);
       }
     }
-    void loadInitial();
+    void loadAdminAnnouncements();
     return () => {
       cancelled = true;
     };
@@ -195,17 +165,7 @@ export function AnnouncementsClient({ isSuperOwner }: { isSuperOwner: boolean })
   }
 
   async function mark(id: string, action: "read" | "acknowledge") {
-    const now = new Date().toISOString();
-    setAnnouncements((current) => current.map((announcement) => (
-      announcement.id === id
-        ? {
-            ...announcement,
-            readAt: now,
-            acknowledgedAt: action === "acknowledge" ? now : announcement.acknowledgedAt,
-          }
-        : announcement
-    )));
-    await fetch(`/api/announcements/${id}/${action}`, { method: "POST" });
+    await markAnnouncement(id, action);
   }
 
   async function saveAnnouncement(event: React.FormEvent) {
@@ -240,7 +200,7 @@ export function AnnouncementsClient({ isSuperOwner }: { isSuperOwner: boolean })
     }
     setMessage(t("announcements.saved"));
     setForm(EMPTY_FORM);
-    await Promise.all([fetchAdminAnnouncements(), fetchAnnouncements()]);
+    await Promise.all([fetchAdminAnnouncements(), refreshAnnouncements()]);
     setSaving(false);
   }
 
@@ -253,7 +213,7 @@ export function AnnouncementsClient({ isSuperOwner }: { isSuperOwner: boolean })
       return;
     }
     setMessage(action === "publish" ? t("announcements.published") : t("announcements.archived"));
-    await Promise.all([fetchAdminAnnouncements(), fetchAnnouncements()]);
+    await Promise.all([fetchAdminAnnouncements(), refreshAnnouncements()]);
   }
 
   return (

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -22,6 +22,10 @@ import { Separator } from "@/components/ui/separator";
 import { LogoutButton } from "@/components/dashboard/LogoutButton";
 import { KeinageLogo } from "@/components/KeinageLogo";
 import { AnnouncementBanner } from "@/components/dashboard/AnnouncementBanner";
+import {
+  AnnouncementProvider,
+  useAnnouncements,
+} from "@/components/dashboard/AnnouncementProvider";
 import { OwnerOnboardingDialog } from "@/components/dashboard/OwnerOnboardingDialog";
 
 function getThemeBootstrapScript(initialTheme: "system" | "light" | "dark") {
@@ -41,11 +45,13 @@ function SidebarLink({
   href,
   icon: Icon,
   children,
+  trailing,
   onClick,
 }: {
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   children: React.ReactNode;
+  trailing?: React.ReactNode;
   onClick?: () => void;
 }) {
   return (
@@ -54,8 +60,9 @@ function SidebarLink({
       onClick={onClick}
       className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
     >
-      <Icon className="size-4" />
-      {children}
+      <Icon className="size-4 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      {trailing}
     </Link>
   );
 }
@@ -85,7 +92,7 @@ function SidebarExternalLink({
   );
 }
 
-export function DashboardShell({
+function DashboardShellContent({
   userId,
   role,
   organizationName,
@@ -107,6 +114,7 @@ export function DashboardShell({
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const initialResolvedTheme = initialTheme === "system" ? undefined : initialTheme;
   const { t } = useLocale();
+  const { unreadCount } = useAnnouncements();
 
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
 
@@ -168,7 +176,19 @@ export function DashboardShell({
         <SidebarLink href="/contact" icon={MessageCircle} onClick={closeSidebar}>
           {t("dashboard.navContact")}
         </SidebarLink>
-        <SidebarLink href="/announcements" icon={Bell} onClick={closeSidebar}>
+        <SidebarLink
+          href="/announcements"
+          icon={Bell}
+          trailing={unreadCount > 0 ? (
+            <span
+              className="inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground"
+              aria-label={`${t("announcements.unread")}: ${unreadCount}`}
+            >
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          ) : null}
+          onClick={closeSidebar}
+        >
           {isSuperOwner ? t("dashboard.navAnnouncementAdmin") : t("dashboard.navAnnouncements")}
         </SidebarLink>
         <SidebarLink href="/settings" icon={Settings} onClick={closeSidebar}>
@@ -242,5 +262,13 @@ export function DashboardShell({
         billingEnabled={billingEnabled}
       />
     </div>
+  );
+}
+
+export function DashboardShell(props: React.ComponentProps<typeof DashboardShellContent>) {
+  return (
+    <AnnouncementProvider>
+      <DashboardShellContent {...props} />
+    </AnnouncementProvider>
   );
 }


### PR DESCRIPTION
## 概要

お知らせメニューの右端に、現在の未読件数を示すラベルを追加しました。

Closes #278

## 変更内容

- 未読のお知らせがある場合のみ、サイドバーのお知らせメニューに件数ラベルを表示
- 100件以上の場合はレイアウトを崩さないよう `99+` と表示
- お知らせ一覧の取得・既読状態を `AnnouncementProvider` に集約
- お知らせ一覧および重要通知バナーで既読・確認済みにした直後、メニューの件数にも反映
- 既読 API が失敗した場合はサーバーの状態を再取得
- 件数ラベルにスクリーンリーダー向けの未読ラベルを付与

## 対応理由

従来はメニューから未読のお知らせが存在するか判断できず、お知らせページを開くまで確認できませんでした。また、バナーとお知らせ一覧が個別にデータを取得していたため、未読件数を追加する際に状態がずれる可能性がありました。

お知らせ状態をダッシュボード内で共有することで、どの導線から既読操作をしても件数が一貫して更新されるようにしています。

## 確認内容

- `pnpm build` 成功
- 変更対象ファイルの ESLint 成功
- `pnpm exec tsc --noEmit` 成功
- `pnpm lint` は既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx:88` の `react-hooks/set-state-in-effect` エラーにより失敗（今回の変更箇所にエラーなし）
