### PR TITLE
fix: Splitテンプレートの画像表示と選択ラベルを修正

### DIFF
--- a/src/app/(board)/[boardId]/page.tsx
+++ b/src/app/(board)/[boardId]/page.tsx
@@ -12,6 +12,7 @@ import { applyMediaPlanRestrictions } from "@/lib/media-plan";
 import { isCloudFrontSignedDeliveryMode } from "@/lib/cloudfront-signed-url";
 import { deliveryUrlForMediaItem } from "@/lib/media-storage";
 import { isInOwnerScope } from "@/lib/ownership";
+import { resolveSplitViewMediaReferences } from "@/lib/split-view";
 import { getTemplate } from "@/lib/templates";
 import { normalizeConfig } from "@/lib/utils";
 import LiveBoard from "@/components/board/LiveBoard";
@@ -56,18 +57,17 @@ export default async function BoardPage({
 
   await recordBoardViewed(board);
 
-  const normalizedBoard = normalizeConfig(board);
-
-  const template = getTemplate(normalizedBoard.templateId);
-  if (!template) {
-    notFound();
-  }
-
   const media = await db
     .select()
     .from(mediaItems)
     .where(eq(mediaItems.boardId, boardId))
     .orderBy(asc(mediaItems.displayOrder));
+  const normalizedBoard = resolveSplitViewMediaReferences(normalizeConfig(board), media);
+
+  const template = getTemplate(normalizedBoard.templateId);
+  if (!template) {
+    notFound();
+  }
 
   const now = new Date().toISOString();
   const activeMessages = await db

--- a/src/app/api/boards/[id]/route.ts
+++ b/src/app/api/boards/[id]/route.ts
@@ -15,6 +15,7 @@ import {
 import { updateBoardSchema } from "@/lib/validators";
 import { emitSSE } from "@/lib/sse";
 import { findOwnedBoard, resolveOwnerUserId } from "@/lib/ownership";
+import { resolveSplitViewMediaReferences } from "@/lib/split-view";
 import { normalizeConfig } from "@/lib/utils";
 
 export async function GET(
@@ -45,8 +46,10 @@ export async function GET(
     .where(eq(messages.boardId, id));
   const effectivePlan = await getEffectivePlanForOwner(board.ownerUserId);
 
+  const normalizedBoard = resolveSplitViewMediaReferences(normalizeConfig(board), media);
+
   return NextResponse.json({
-    ...normalizeConfig(board),
+    ...normalizedBoard,
     boardPlan: {
       watermark: effectivePlan.plan.limits.watermark,
       scheduling: effectivePlan.plan.limits.scheduling,

--- a/src/app/api/public/boards/[id]/route.ts
+++ b/src/app/api/public/boards/[id]/route.ts
@@ -12,6 +12,7 @@ import { isCloudFrontSignedDeliveryMode } from "@/lib/cloudfront-signed-url";
 import { applyMediaPlanRestrictions } from "@/lib/media-plan";
 import { deliveryUrlForMediaItem } from "@/lib/media-storage";
 import { isInOwnerScope } from "@/lib/ownership";
+import { resolveSplitViewMediaReferences } from "@/lib/split-view";
 import { normalizeConfig } from "@/lib/utils";
 
 export async function GET(
@@ -59,9 +60,10 @@ export async function GET(
           filePath: deliveryUrlForMediaItem(item),
         }))
       : planRestrictedMedia;
+  const normalizedBoard = resolveSplitViewMediaReferences(normalizeConfig(board), media);
 
   return NextResponse.json({
-    ...normalizeConfig(board),
+    ...normalizedBoard,
     boardPlan: {
       watermark: effectivePlan.plan.limits.watermark,
       scheduling: effectivePlan.plan.limits.scheduling,

--- a/src/components/board/templates/SplitViewBoard.tsx
+++ b/src/components/board/templates/SplitViewBoard.tsx
@@ -86,7 +86,9 @@ function findPaneMedia(
 ) {
   if (!pane.mediaPath) return null;
   return mediaItems.find(
-    (item) => item.filePath === pane.mediaPath && item.type === pane.type,
+    (item) =>
+      item.type === pane.type
+      && (item.id === pane.mediaPath || item.filePath === pane.mediaPath),
   ) ?? null;
 }
 

--- a/src/components/dashboard/BoardEditClient.tsx
+++ b/src/components/dashboard/BoardEditClient.tsx
@@ -614,6 +614,7 @@ export default function BoardEditClient({ boardId }: { boardId: string }) {
                 boardId={boardId}
                 mediaItems={board.mediaItems}
                 onUpdate={fetchBoard}
+                showPlaybackControls={board.templateId !== "split-view"}
                 scheduleConfig={supportsScheduleTemplate ? config : undefined}
                 scheduling={boardPlan.scheduling}
                 onScheduleConfigChange={supportsScheduleTemplate ? setConfig : undefined}

--- a/src/components/dashboard/MediaUploadZone.tsx
+++ b/src/components/dashboard/MediaUploadZone.tsx
@@ -35,6 +35,7 @@ interface MediaUploadZoneProps {
   boardId: string;
   mediaItems: MediaItem[];
   onUpdate: () => Promise<void>;
+  showPlaybackControls?: boolean;
   scheduleConfig?: Record<string, unknown>;
   scheduling?: ScheduleCapability;
   onScheduleConfigChange?: (config: Record<string, unknown>) => void;
@@ -206,6 +207,7 @@ export default function MediaUploadZone({
   boardId,
   mediaItems,
   onUpdate,
+  showPlaybackControls = true,
   scheduleConfig,
   scheduling = "none",
   onScheduleConfigChange,
@@ -691,35 +693,37 @@ export default function MediaUploadZone({
               </div>
 
               {/* Duration */}
-              <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
-                <Label className="text-xs text-muted-foreground">{t("media.durationSeconds")}</Label>
-                <NumberInput
-                  min={1}
-                  max={MAX_MEDIA_DURATION_SECONDS}
-                  value={item.duration}
-                  onValueChange={(value) => handleDurationChange(item.id, value)}
-                  className="h-7 w-16 text-xs"
-                />
-                {item.type === "video" && (
-                  <Select
-                    value={item.playbackMode ?? "duration"}
-                    onValueChange={(value) =>
-                      handlePlaybackModeChange(item.id, value as MediaPlaybackMode)}
-                  >
-                    <SelectTrigger className="h-7 w-36 text-xs">
-                      <SelectValue>
-                        {(item.playbackMode ?? "duration") === "until-ended"
-                          ? t("configEditor.videoAdvance.untilEnded")
-                          : t("configEditor.videoAdvance.duration")}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="duration">{t("configEditor.videoAdvance.duration")}</SelectItem>
-                      <SelectItem value="until-ended">{t("configEditor.videoAdvance.untilEnded")}</SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
+              {showPlaybackControls && (
+                <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+                  <Label className="text-xs text-muted-foreground">{t("media.durationSeconds")}</Label>
+                  <NumberInput
+                    min={1}
+                    max={MAX_MEDIA_DURATION_SECONDS}
+                    value={item.duration}
+                    onValueChange={(value) => handleDurationChange(item.id, value)}
+                    className="h-7 w-16 text-xs"
+                  />
+                  {item.type === "video" && (
+                    <Select
+                      value={item.playbackMode ?? "duration"}
+                      onValueChange={(value) =>
+                        handlePlaybackModeChange(item.id, value as MediaPlaybackMode)}
+                    >
+                      <SelectTrigger className="h-7 w-36 text-xs">
+                        <SelectValue>
+                          {(item.playbackMode ?? "duration") === "until-ended"
+                            ? t("configEditor.videoAdvance.untilEnded")
+                            : t("configEditor.videoAdvance.duration")}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="duration">{t("configEditor.videoAdvance.duration")}</SelectItem>
+                        <SelectItem value="until-ended">{t("configEditor.videoAdvance.untilEnded")}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+              )}
 
               {/* Delete */}
               <Button

--- a/src/components/dashboard/config-editors/SplitViewConfigEditor.tsx
+++ b/src/components/dashboard/config-editors/SplitViewConfigEditor.tsx
@@ -153,8 +153,9 @@ export function SplitViewConfigEditor({
       <div className="space-y-4">
         {panes.map((pane, index) => {
           const mediaChoices = pane.type === "video" ? videoMedia : imageMedia;
-          const mediaLabel = pane.mediaPath
-            ? mediaOptionLabel(pane.mediaPath, mediaChoices)
+          const selectedMedia = findMediaByReference(pane.mediaPath, mediaChoices);
+          const mediaLabel = selectedMedia
+            ? mediaOptionLabel(selectedMedia, mediaChoices, t)
             : pane.type === "video"
               ? t("configEditor.split.noneVideo")
               : t("configEditor.itemImageNone");
@@ -236,7 +237,7 @@ export function SplitViewConfigEditor({
                     {pane.type === "video" ? t("common.video") : t("common.image")}
                   </Label>
                   <Select
-                    value={pane.mediaPath || "__none__"}
+                    value={selectedMedia?.id ?? "__none__"}
                     onValueChange={(value) =>
                       updatePane(index, {
                         mediaPath: !value || value === "__none__" ? "" : value,
@@ -251,8 +252,8 @@ export function SplitViewConfigEditor({
                         {pane.type === "video" ? t("configEditor.split.noneVideo") : t("configEditor.itemImageNone")}
                       </SelectItem>
                       {mediaChoices.map((media) => (
-                        <SelectItem key={media.id} value={media.filePath}>
-                          {mediaOptionLabel(media.filePath, mediaChoices)}
+                        <SelectItem key={media.id} value={media.id}>
+                          {mediaOptionLabel(media, mediaChoices, t)}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -281,9 +282,23 @@ function paneTypeLabel(
   return t("configEditor.split.typeText");
 }
 
-function mediaOptionLabel(filePath: string, items: MediaItem[]) {
-  const media = items.find((item) => item.filePath === filePath);
-  return media?.filePath.split("/").pop() ?? filePath.split("/").pop() ?? filePath;
+function findMediaByReference(reference: string, items: MediaItem[]) {
+  if (!reference) return null;
+  return items.find((item) =>
+    item.id === reference || item.filePath === reference
+  ) ?? null;
+}
+
+function mediaOptionLabel(
+  media: MediaItem,
+  items: MediaItem[],
+  t: ReturnType<typeof useLocale>["t"],
+) {
+  const number = items.findIndex((item) => item.id === media.id) + 1;
+  return t(
+    media.type === "video" ? "schedule.videoNumber" : "schedule.imageNumber",
+    { number },
+  );
 }
 
 function ColorInput({

--- a/src/lib/split-view.ts
+++ b/src/lib/split-view.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+import type { MediaItem } from "@/types";
+
+type SplitViewBoard = {
+  templateId: string;
+  config: Record<string, unknown>;
+};
+
+export function resolveSplitViewMediaReferences<T extends SplitViewBoard>(
+  board: T,
+  mediaItems: Pick<MediaItem, "id" | "filePath">[],
+): T {
+  if (board.templateId !== "split-view" || !Array.isArray(board.config.panes)) {
+    return board;
+  }
+
+  let changed = false;
+  const panes = board.config.panes.map((pane) => {
+    if (!pane || typeof pane !== "object") return pane;
+
+    const rawPane = pane as Record<string, unknown>;
+    const reference = rawPane.mediaPath;
+    if (typeof reference !== "string" || !reference) return pane;
+
+    const media = mediaItems.find(
+      (item) => item.id === reference || item.filePath === reference,
+    );
+    if (!media || media.id === reference) return pane;
+
+    changed = true;
+    return { ...rawPane, mediaPath: media.id };
+  });
+
+  if (!changed) return board;
+  return {
+    ...board,
+    config: {
+      ...board.config,
+      panes,
+    },
+  };
+}


### PR DESCRIPTION
## 概要

Splitテンプレートで選択した画像・動画が表示されず、選択ラベルがメディアID相当の文字列になる問題を修正しました。

Closes #289

## 原因

Splitテンプレートは設定にメディアのファイルパスを保存していました。一方、S3/RustFSや公開配信では表示時にファイルパスが配信用URLへ変換されるため、設定値との完全一致に失敗し、対象メディアを見つけられない状態でした。

また、選択肢の表示名にもファイルパス末尾を使っていたため、UUIDがそのまま表示されていました。

## 変更内容

- Splitテンプレートの新規選択値を安定したメディアIDで保存
- 既存のファイルパス設定を、配信用URLへ変換する前にメディアIDへ正規化
- 初回ボード表示、SSE再取得、管理画面取得の各経路で旧設定を互換処理
- 選択肢を「画像1」「動画1」の連番ラベルへ変更
- Splitテンプレートのメディア一覧では不要な秒数・動画切替方法の操作を非表示
- 他テンプレートでは従来どおり再生時間の操作を表示

## 動作確認

- ローカルDBの実際のSplitボードで、設定内の旧ファイルパスとメディアIDが異なる状態を確認
- 旧ファイルパスが対応するメディアIDへ解決されることを実行確認
- Split以外のテンプレート設定を正規化処理が変更しないことを確認
- `pnpm exec tsc --noEmit`
- 変更対象ファイルのESLint
- `pnpm build`
- `git diff --check`

## 補足

`pnpm lint`全体実行は、既存の`src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx:88`にある`react-hooks/set-state-in-effect`エラーで失敗します。今回の変更対象に対するESLintはエラーなしです。
