### PR TITLE
監査ログの保持期間cleanupを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,7 @@ WEBAUTHN_ORIGIN=http://localhost:3000
 # Optional audit logs for security, billing, and admin operations.
 AUDIT_LOG_ENABLED=true
 AUDIT_LOG_IP_HASH_SECRET=
+# Delete audit logs older than this many days. Unset or 0 disables cleanup.
 AUDIT_LOG_RETENTION_DAYS=365
 
 # Optional Super Owner bootstrap.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ UPLOAD_MAX_BYTES=0
 - S3 / CloudFront: `S3_*` と `STORAGE_*` を設定します。
 - Stripe Billing: `BILLING_MODE=stripe`、`PLAN_ENFORCEMENT_MODE=billing`、`STRIPE_*` を設定します。
 - Super Owner: `SUPER_OWNER_*` を設定します。
-- 監査ログ: `AUDIT_LOG_*` を設定します。
+- 監査ログ: `AUDIT_LOG_*` を設定します。`AUDIT_LOG_RETENTION_DAYS` が正の整数の場合、コンテナ起動時に指定日数より古いログを削除します。手動・定期実行では `pnpm audit:cleanup` を使用できます。
 
 詳細な設定例と注意点は [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) を参照してください。
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=prod-deps /app/node_modules ./node_modules
 # Copy drizzle migrations + migration runner
 COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/docker/migrate.cjs ./migrate.cjs
+COPY --from=builder /app/docker/cleanup-audit-logs.cjs ./cleanup-audit-logs.cjs
 COPY --from=builder /app/docker/entrypoint.sh ./entrypoint.sh
 
 # Create writable directory for runtime uploads

--- a/docker/cleanup-audit-logs.cjs
+++ b/docker/cleanup-audit-logs.cjs
@@ -1,0 +1,140 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * Deletes audit logs older than AUDIT_LOG_RETENTION_DAYS.
+ *
+ * This script is safe to run repeatedly and can be invoked at container
+ * startup or by an external scheduler.
+ */
+const { Client } = require("pg");
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_DATABASE_URL =
+  "postgresql://postgres:postgres@127.0.0.1:5432/keinage";
+const CLEANUP_LOCK_KEY = "keinage:audit-log-cleanup";
+
+function readEnvValueFromDotEnv(name) {
+  const envPath = path.resolve(process.cwd(), ".env");
+  if (!fs.existsSync(envPath)) return null;
+
+  const lines = fs.readFileSync(envPath, "utf-8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (!trimmed.startsWith(`${name}=`)) continue;
+
+    const value = trimmed.slice(name.length + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      return value.slice(1, -1);
+    }
+    return value;
+  }
+
+  return null;
+}
+
+function parseRetentionDays(rawValue) {
+  const value = rawValue?.trim() ?? "";
+  if (!value || value === "0") {
+    return { enabled: false, days: null };
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new Error("AUDIT_LOG_RETENTION_DAYS must be 0 or a positive integer.");
+  }
+
+  const days = Number(value);
+  if (!Number.isSafeInteger(days) || days <= 0) {
+    throw new Error("AUDIT_LOG_RETENTION_DAYS must be 0 or a positive integer.");
+  }
+
+  return { enabled: true, days };
+}
+
+function retentionCutoff(days, now = new Date()) {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+async function deleteExpiredAuditLogs(client, cutoff) {
+  const lockResult = await client.query(
+    "SELECT pg_try_advisory_lock(hashtext($1)) AS acquired",
+    [CLEANUP_LOCK_KEY],
+  );
+  if (!lockResult.rows[0]?.acquired) {
+    return { acquired: false, deletedCount: 0 };
+  }
+
+  try {
+    const result = await client.query(
+      "DELETE FROM audit_logs WHERE created_at < $1",
+      [cutoff],
+    );
+    return { acquired: true, deletedCount: result.rowCount ?? 0 };
+  } finally {
+    await client.query(
+      "SELECT pg_advisory_unlock(hashtext($1))",
+      [CLEANUP_LOCK_KEY],
+    );
+  }
+}
+
+async function main() {
+  let retention;
+  try {
+    retention = parseRetentionDays(
+      process.env.AUDIT_LOG_RETENTION_DAYS
+        ?? readEnvValueFromDotEnv("AUDIT_LOG_RETENTION_DAYS"),
+    );
+  } catch (error) {
+    console.error(`[audit-cleanup] Invalid retention setting: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!retention.enabled) {
+    console.log(
+      "[audit-cleanup] Skipped: AUDIT_LOG_RETENTION_DAYS is unset or 0.",
+    );
+    return;
+  }
+
+  const databaseUrl =
+    process.env.DATABASE_URL
+    || readEnvValueFromDotEnv("DATABASE_URL")
+    || DEFAULT_DATABASE_URL;
+  const cutoff = retentionCutoff(retention.days);
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    const result = await deleteExpiredAuditLogs(client, cutoff);
+    if (!result.acquired) {
+      console.log("[audit-cleanup] Skipped: another cleanup is running.");
+      return;
+    }
+
+    console.log(
+      `[audit-cleanup] Deleted ${result.deletedCount} audit log(s) older than `
+      + `${retention.days} day(s). cutoff=${cutoff}`,
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+module.exports = {
+  deleteExpiredAuditLogs,
+  parseRetentionDays,
+  retentionCutoff,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("[audit-cleanup] Failed:", error);
+    process.exitCode = 1;
+  });
+}

--- a/docker/cleanup-audit-logs.test.cjs
+++ b/docker/cleanup-audit-logs.test.cjs
@@ -1,0 +1,103 @@
+// Copyright 2026 Hiroshi Araki (https://hiroshi.araki.tech)
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable @typescript-eslint/no-require-imports */
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  deleteExpiredAuditLogs,
+  parseRetentionDays,
+  retentionCutoff,
+} = require("./cleanup-audit-logs.cjs");
+
+test("retention is disabled when unset or zero", () => {
+  assert.deepEqual(parseRetentionDays(undefined), {
+    enabled: false,
+    days: null,
+  });
+  assert.deepEqual(parseRetentionDays("0"), {
+    enabled: false,
+    days: null,
+  });
+});
+
+test("retention accepts a positive integer", () => {
+  assert.deepEqual(parseRetentionDays("365"), {
+    enabled: true,
+    days: 365,
+  });
+});
+
+test("retention rejects invalid values", () => {
+  assert.throws(() => parseRetentionDays("-1"));
+  assert.throws(() => parseRetentionDays("1.5"));
+  assert.throws(() => parseRetentionDays("abc"));
+});
+
+test("cutoff subtracts the configured number of days", () => {
+  assert.equal(
+    retentionCutoff(365, new Date("2026-06-09T00:00:00.000Z")),
+    "2025-06-09T00:00:00.000Z",
+  );
+});
+
+test("cleanup deletes only through the parameterized cutoff", async () => {
+  const queries = [];
+  const client = {
+    async query(sql, params) {
+      queries.push({ sql, params });
+      if (sql.startsWith("SELECT pg_try_advisory_lock")) {
+        return { rows: [{ acquired: true }] };
+      }
+      if (sql.startsWith("DELETE FROM audit_logs")) {
+        return { rowCount: 4, rows: [] };
+      }
+      return { rows: [{ pg_advisory_unlock: true }] };
+    },
+  };
+
+  const result = await deleteExpiredAuditLogs(
+    client,
+    "2025-06-09T00:00:00.000Z",
+  );
+
+  assert.deepEqual(result, { acquired: true, deletedCount: 4 });
+  assert.equal(queries[1].sql, "DELETE FROM audit_logs WHERE created_at < $1");
+  assert.deepEqual(queries[1].params, ["2025-06-09T00:00:00.000Z"]);
+  assert.equal(queries.length, 3);
+  assert.match(queries[2].sql, /pg_advisory_unlock/);
+});
+
+test("cleanup skips when another process holds the advisory lock", async () => {
+  const client = {
+    async query() {
+      return { rows: [{ acquired: false }] };
+    },
+  };
+
+  assert.deepEqual(
+    await deleteExpiredAuditLogs(client, "2025-06-09T00:00:00.000Z"),
+    { acquired: false, deletedCount: 0 },
+  );
+});
+
+test("cleanup releases the advisory lock when deletion fails", async () => {
+  let unlocked = false;
+  const client = {
+    async query(sql) {
+      if (sql.startsWith("SELECT pg_try_advisory_lock")) {
+        return { rows: [{ acquired: true }] };
+      }
+      if (sql.startsWith("DELETE FROM audit_logs")) {
+        throw new Error("delete failed");
+      }
+      unlocked = true;
+      return { rows: [{ pg_advisory_unlock: true }] };
+    },
+  };
+
+  await assert.rejects(
+    deleteExpiredAuditLogs(client, "2025-06-09T00:00:00.000Z"),
+    /delete failed/,
+  );
+  assert.equal(unlocked, true);
+});

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,5 +6,10 @@ set -e
 echo "[entrypoint] Running database migrations..."
 node migrate.cjs
 
+echo "[entrypoint] Cleaning up expired audit logs..."
+if ! node cleanup-audit-logs.cjs; then
+  echo "[entrypoint] Audit log cleanup failed; continuing server startup." >&2
+fi
+
 echo "[entrypoint] Starting server..."
 exec node server.js

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,7 +43,7 @@ Self-hosted では、次の設定だけで基本運用を開始できます。
 | `GOOGLE_OAUTH_*` | 任意 | Google アカウント登録・ログインを使う場合に設定。 |
 | `WEBAUTHN_*` | 任意 | Owner に Passkey 二要素認証を要求する場合に設定。 |
 | `S3_*` / `STORAGE_*` | 任意 | ローカル `uploads/` ではなく S3互換ストレージを使う場合に設定。 |
-| `AUDIT_LOG_*` | 任意 | 認証、課金、退会、Super Owner などの監査ログ設定。 |
+| `AUDIT_LOG_*` | 任意 | 認証、課金、退会、Super Owner などの監査ログ設定と保持期間。 |
 
 ## 4. 公式SaaS mode
 
@@ -89,9 +89,11 @@ PLAN_ENFORCEMENT_MODE=billing
 | Mail | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` / `SMTP_FROM` | 登録、リセット、重要通知メール。 |
 | Contact | `CONTACT_SMTP_*` / `CONTACT_TO_EMAIL` | 問い合わせフォーム用SMTP。未設定時は問い合わせフォームを無効化。 |
 | Super Owner | `SUPER_OWNER_EMAIL` / `SUPER_OWNER_BOOTSTRAP_ENABLED` / `SUPER_OWNER_REQUIRE_GOOGLE` | 運営者用高権限ユーザーの初回bootstrap。 |
-| Audit | `AUDIT_LOG_ENABLED` / `AUDIT_LOG_IP_HASH_SECRET` / `AUDIT_LOG_RETENTION_DAYS` | 監査ログ、IP hash secret、保持期間。 |
+| Audit | `AUDIT_LOG_ENABLED` / `AUDIT_LOG_IP_HASH_SECRET` / `AUDIT_LOG_RETENTION_DAYS` | 監査ログ、IP hash secret、保持期間。保持日数が正の整数の場合、コンテナ起動時に期限切れログを削除します。未設定または `0` は削除無効です。 |
 
 Stripe price ID は必ず env で管理し、コードや公開ドキュメントに実値を書かないでください。price ID の対応は `src/lib/plans.ts` の `getBillingConfig()` で env から読み取ります。
+
+監査ログ cleanup は `pnpm audit:cleanup` でも実行できます。同じスクリプトを cron や scheduled task から定期実行でき、複数プロセスから同時に呼ばれた場合は PostgreSQL advisory lock により1プロセスだけが削除を実行します。`AUDIT_LOG_ENABLED=false` は新規監査ログのDB保存だけを無効化し、既存ログの保持期間 cleanup は無効化しません。cleanup に失敗した場合は削除対象の内容を出さず、失敗をターミナルへ記録します。コンテナ起動時の cleanup 失敗はサーバー起動を妨げません。
 
 ## 5. 課金単位とOwner scope
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -363,6 +363,8 @@ IPアドレスは生値を保存せず、`AUDIT_LOG_IP_HASH_SECRET` が設定さ
 
 `AUDIT_LOG_ENABLED=false` の場合、DB保存は無効化されますが、重要イベントのターミナルログは維持されます。Super Owner は `/api/super-owner/audit-logs` で直近ログを確認できます。
 
+`docker/cleanup-audit-logs.cjs` は `AUDIT_LOG_RETENTION_DAYS` が正の整数の場合に、指定日数より古い `audit_logs.created_at` を削除します。未設定または `0` では cleanup を無効化します。処理はコンテナ起動時に migration 後へ実行するほか、`pnpm audit:cleanup` を cron / scheduled task から呼び出せます。PostgreSQL advisory lock により同時実行を避け、削除件数と失敗だけをターミナルへ出力します。`AUDIT_LOG_ENABLED=false` でも既存ログの cleanup は継続します。
+
 ## 7. ボードとテンプレート設計
 
 テンプレートは registry 方式です。`boards.templateId` と `boards.config` で表示を決め、DB schema を増やさずにテンプレート固有設定を JSON として保持します。

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "node docker/migrate.cjs",
     "db:studio": "drizzle-kit studio",
-    "db:seed": "tsx scripts/seed.ts"
+    "db:seed": "tsx scripts/seed.ts",
+    "audit:cleanup": "node docker/cleanup-audit-logs.cjs",
+    "test:audit-cleanup": "node --test docker/cleanup-audit-logs.test.cjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1036.0",


### PR DESCRIPTION
## 概要

Issue #234 の対応として、`AUDIT_LOG_RETENTION_DAYS` に基づいて期限切れの `audit_logs` を削除する cleanup 処理を追加しました。

Closes #234

## 変更内容

- `docker/cleanup-audit-logs.cjs` を追加
  - 正の整数が設定された場合、指定日数より古い `audit_logs.created_at` を削除
  - 未設定または `0` の場合は cleanup をスキップ
  - 不正値はエラーとして終了
  - 削除件数、cutoff、スキップ理由、失敗をターミナルへ出力
  - PostgreSQL advisory lock で複数プロセスからの同時実行を防止
- Docker コンテナ起動時に migration 後の cleanup を実行
  - cleanup 失敗時もサーバー起動は継続
- `pnpm audit:cleanup` を追加し、cron / scheduled task から同じ処理を実行可能に変更
- Node.js 組み込みテストを追加
- `.env.example`、README、DEPLOYMENT、DESIGN の説明を更新

## 挙動

- `AUDIT_LOG_RETENTION_DAYS=365`: 実行時点から365日より古いログを削除
- `AUDIT_LOG_RETENTION_DAYS=0` または未設定: cleanup 無効
- `AUDIT_LOG_ENABLED=false`: 新規DB保存は無効になるが、既存ログの保持期間 cleanup は継続
- 再実行時は既に削除済みのログへ影響せず、削除件数は0件

ログには削除対象の監査ログ本文、password、token、secret などを出力しません。

## 確認

- `pnpm test:audit-cleanup`
  - 7テスト成功
- `pnpm exec eslint docker/cleanup-audit-logs.cjs docker/cleanup-audit-logs.test.cjs`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `sh -n docker/entrypoint.sh`
- `AUDIT_LOG_RETENTION_DAYS=0 pnpm audit:cleanup`
- ローカルPostgreSQLでトランザクション内に一時ログを作成して確認
  - cutoff より古いログだけ削除
  - cutoff より新しいログは保持
  - 2回目の実行は0件
  - 検証後に rollback 済み

## 既知事項

`pnpm lint` 全体は、既存の `src/components/dashboard/config-editors/StaffBoardConfigEditor.tsx:88` にある `react-hooks/set-state-in-effect` エラーで失敗します。今回追加した cleanup ファイルの ESLint はエラーなしです。
